### PR TITLE
Add hover feature to show keyword description

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@
 .ruff_cache/**
 out/
 .vscode-test/
+src/providers/hover.json

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import { MF6DefinitionProvider } from "./providers/go-to-definition";
+import { MF6HoverProvider } from "./providers/hover";
 import { mf6ify } from "./commands/mf6-ify";
 
 const MF6 = { language: "mf6", scheme: "file" };
@@ -18,6 +19,11 @@ export function activate(context: vscode.ExtensionContext) {
       MF6,
       new MF6DefinitionProvider(),
     ),
+  );
+
+  // Show hover of MF6 keyword
+  context.subscriptions.push(
+    vscode.languages.registerHoverProvider(MF6, new MF6HoverProvider()),
   );
 }
 

--- a/src/providers/hover.json
+++ b/src/providers/hover.json
@@ -1,0 +1,2611 @@
+{
+  "boundnames": {
+    "options": {
+      ".csub": "keyword to indicate that boundary names may be provided with the list of CSUB cells.",
+      ".ctp": "keyword to indicate that boundary names may be provided with the list of constant temperature cells.",
+      ".cdb": "keyword to indicate that boundary names may be provided with the list of critical depth boundary cells.",
+      ".sft": "keyword to indicate that boundary names may be provided with the list of reach cells.",
+      ".evp": "keyword to indicate that boundary names may be provided with the list of evaporation cells.",
+      ".flw": "keyword to indicate that boundary names may be provided with the list of inflow cells.",
+      ".chd": "keyword to indicate that boundary names may be provided with the list of constant-head cells.",
+      ".uze": "keyword to indicate that boundary names may be provided with the list of unsaturated zone flow cells.",
+      ".prp": "keyword to indicate that boundary names may be provided with the list of particle release points.",
+      ".pcp": "keyword to indicate that boundary names may be provided with the list of precipitation cells.",
+      ".api": "keyword to indicate that boundary names may be provided with the list of api boundary cells.",
+      ".drn": "keyword to indicate that boundary names may be provided with the list of drain cells.",
+      ".gwegwe": "keyword to indicate that boundary names may be provided with the list of GWE Exchange cells.",
+      ".wel": "keyword to indicate that boundary names may be provided with the list of well cells.",
+      ".lak": "keyword to indicate that boundary names may be provided with the list of lake cells.",
+      ".esl": "keyword to indicate that boundary names may be provided with the list of energy source loading cells.",
+      ".lkt": "keyword to indicate that boundary names may be provided with the list of lake cells.",
+      ".gwtgwt": "keyword to indicate that boundary names may be provided with the list of GWT Exchange cells.",
+      ".lke": "keyword to indicate that boundary names may be provided with the list of lake cells.",
+      ".src": "keyword to indicate that boundary names may be provided with the list of mass source cells.",
+      ".ghb": "keyword to indicate that boundary names may be provided with the list of general-head boundary cells.",
+      ".zdg": "keyword to indicate that boundary names may be provided with the list of zero-depth-gradient boundary cells.",
+      ".sfe": "keyword to indicate that boundary names may be provided with the list of reach cells.",
+      ".mwt": "keyword to indicate that boundary names may be provided with the list of well cells.",
+      ".sfr": "keyword to indicate that boundary names may be provided with the list of stream reach cells.",
+      ".riv": "keyword to indicate that boundary names may be provided with the list of river cells.",
+      ".uzf": "keyword to indicate that boundary names may be provided with the list of UZF cells.",
+      ".cnc": "keyword to indicate that boundary names may be provided with the list of constant concentration cells.",
+      ".maw": "keyword to indicate that boundary names may be provided with the list of multi-aquifer well cells.",
+      ".rch": "keyword to indicate that boundary names may be provided with the list of recharge cells.",
+      ".evt": "keyword to indicate that boundary names may be provided with the list of evapotranspiration cells.",
+      ".uzt": "keyword to indicate that boundary names may be provided with the list of unsaturated zone flow cells.",
+      ".mwe": "keyword to indicate that boundary names may be provided with the list of well cells."
+    }
+  },
+  "print_input": {
+    "options": {
+      ".csub": "keyword to indicate that the list of CSUB information will be written to the listing file immediately after it is read.",
+      ".spca": "keyword to indicate that the list of spc information will be written to the listing file immediately after it is read.",
+      ".ctp": "keyword to indicate that the list of constant temperature information will be written to the listing file immediately after it is read.",
+      ".hfb": "keyword to indicate that the list of horizontal flow barriers will be written to the listing file immediately after it is read.",
+      ".cdb": "keyword to indicate that the list of critical depth boundary information will be written to the listing file immediately after it is read.",
+      ".sft": "keyword to indicate that the list of reach information will be written to the listing file immediately after it is read.",
+      ".mve": "keyword to indicate that the list of mover information will be written to the listing file immediately after it is read.",
+      ".evp": "keyword to indicate that the list of evaporation information will be written to the listing file immediately after it is read.",
+      ".flw": "keyword to indicate that the list of inflow information will be written to the listing file immediately after it is read.",
+      ".chd": "keyword to indicate that the list of constant-head information will be written to the listing file immediately after it is read.",
+      ".uze": "keyword to indicate that the list of unsaturated zone flow information will be written to the listing file immediately after it is read.",
+      ".nam": "keyword to indicate that the list of all model stress package information will be written to the listing file immediately after it is read.",
+      ".prp": "keyword to indicate that the list of all model stress package information will be written to the listing file immediately after it is read.",
+      ".pcp": "keyword to indicate that the list of precipitation information will be written to the listing file immediately after it is read.",
+      ".api": "keyword to indicate that the list of api boundary information will be written to the listing file immediately after it is read.",
+      ".drn": "keyword to indicate that the list of drain information will be written to the listing file immediately after it is read.",
+      ".gwegwe": "keyword to indicate that the list of exchange entries will be echoed to the listing file immediately after it is read.",
+      ".olfgwf": "keyword to indicate that the list of exchange entries will be echoed to the listing file immediately after it is read.",
+      ".wel": "keyword to indicate that the list of well information will be written to the listing file immediately after it is read.",
+      ".cxs": "keyword to indicate that the list of stream reach information will be written to the listing file immediately after it is read.",
+      ".lak": "keyword to indicate that the list of lake information will be written to the listing file immediately after it is read.",
+      ".esl": "keyword to indicate that the list of energy source loading information will be written to the listing file immediately after it is read.",
+      ".lkt": "keyword to indicate that the list of lake information will be written to the listing file immediately after it is read.",
+      ".gwtgwt": "keyword to indicate that the list of exchange entries will be echoed to the listing file immediately after it is read.",
+      ".lke": "keyword to indicate that the list of lake information will be written to the listing file immediately after it is read.",
+      ".tvk": "keyword to indicate that information for each change to the hydraulic conductivity in a cell will be written to the model listing file.",
+      ".evta": "keyword to indicate that the list of evapotranspiration information will be written to the listing file immediately after it is read.",
+      ".src": "keyword to indicate that the list of mass source information will be written to the listing file immediately after it is read.",
+      ".ghb": "keyword to indicate that the list of general-head boundary information will be written to the listing file immediately after it is read.",
+      ".rcha": "keyword to indicate that the list of recharge information will be written to the listing file immediately after it is read.",
+      ".zdg": "keyword to indicate that the list of zero-depth-gradient boundary information will be written to the listing file immediately after it is read.",
+      ".gwfgwf": "keyword to indicate that the list of exchange entries will be echoed to the listing file immediately after it is read.",
+      ".sfe": "keyword to indicate that the list of reach information will be written to the listing file immediately after it is read.",
+      ".mvt": "keyword to indicate that the list of mover information will be written to the listing file immediately after it is read.",
+      ".mvr": "keyword to indicate that the list of MVR information will be written to the listing file immediately after it is read.",
+      ".mwt": "keyword to indicate that the list of well information will be written to the listing file immediately after it is read.",
+      ".gnc": "keyword to indicate that the list of GNC information will be written to the listing file immediately after it is read.",
+      ".obs": "keyword to indicate that the list of observation information will be written to the listing file immediately after it is read.",
+      ".chfgwf": "keyword to indicate that the list of exchange entries will be echoed to the listing file immediately after it is read.",
+      ".tvs": "keyword to indicate that information for each change to a storage property in a cell will be written to the model listing file.",
+      ".sfr": "keyword to indicate that the list of stream reach information will be written to the listing file immediately after it is read.",
+      ".spc": "keyword to indicate that the list of spc information will be written to the listing file immediately after it is read.",
+      ".riv": "keyword to indicate that the list of river information will be written to the listing file immediately after it is read.",
+      ".uzf": "keyword to indicate that the list of UZF information will be written to the listing file immediately after it is read.",
+      ".cnc": "keyword to indicate that the list of constant concentration information will be written to the listing file immediately after it is read.",
+      ".maw": "keyword to indicate that the list of multi-aquifer well information will be written to the listing file immediately after it is read.",
+      ".rch": "keyword to indicate that the list of recharge information will be written to the listing file immediately after it is read.",
+      ".evt": "keyword to indicate that the list of evapotranspiration information will be written to the listing file immediately after it is read.",
+      ".uzt": "keyword to indicate that the list of unsaturated zone flow information will be written to the listing file immediately after it is read.",
+      ".mwe": "keyword to indicate that the list of well information will be written to the listing file immediately after it is read."
+    }
+  },
+  "save_flows": {
+    "options": {
+      ".csub": "keyword to indicate that cell-by-cell flow terms will be written to the file specified with ``BUDGET SAVE FILE'' in Output Control.",
+      ".sto": "keyword to indicate that cell-by-cell flow terms will be written to the file specified with ``BUDGET SAVE FILE'' in Output Control.",
+      ".ctp": "keyword to indicate that constant temperature flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".cdb": "keyword to indicate that critical depth boundary flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".sft": "keyword to indicate that reach flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".mve": "keyword to indicate that lake flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".evp": "keyword to indicate that evaporation flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".fmi": "keyword to indicate that FMI flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".npf": "keyword to indicate that budget flow terms will be written to the file specified with ``BUDGET SAVE FILE'' in Output Control.",
+      ".flw": "keyword to indicate that inflow flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".chd": "keyword to indicate that constant-head flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".uze": "keyword to indicate that unsaturated zone flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".nam": "keyword to indicate that all model package flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".pcp": "keyword to indicate that precipitation flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".api": "keyword to indicate that api boundary flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".drn": "keyword to indicate that drain flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".gwegwe": "keyword to indicate that cell-by-cell flow terms will be written to the budget file for each model provided that the Output Control for the models are set up with the ``BUDGET SAVE FILE'' option.",
+      ".wel": "keyword to indicate that well flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".lak": "keyword to indicate that lake flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".esl": "keyword to indicate that energy source loading flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".lkt": "keyword to indicate that lake flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".gwtgwt": "keyword to indicate that cell-by-cell flow terms will be written to the budget file for each model provided that the Output Control for the models are set up with the ``BUDGET SAVE FILE'' option.",
+      ".lke": "keyword to indicate that lake flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".evta": "keyword to indicate that evapotranspiration flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".src": "keyword to indicate that mass source flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".ghb": "keyword to indicate that general-head boundary flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".rcha": "keyword to indicate that recharge flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".zdg": "keyword to indicate that zero-depth-gradient boundary flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".mst": "keyword to indicate that MST flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".gwfgwf": "keyword to indicate that cell-by-cell flow terms will be written to the budget file for each model provided that the Output Control for the models are set up with the ``BUDGET SAVE FILE'' option.",
+      ".sfe": "keyword to indicate that reach flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".mvt": "keyword to indicate that lake flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".est": "keyword to indicate that EST flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".dfw": "keyword to indicate that budget flow terms will be written to the file specified with ``BUDGET SAVE FILE'' in Output Control.",
+      ".mwt": "keyword to indicate that well flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".sfr": "keyword to indicate that stream reach flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".riv": "keyword to indicate that river flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".uzf": "keyword to indicate that UZF flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".cnc": "keyword to indicate that constant concentration flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".ist": "keyword to indicate that IST flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".maw": "keyword to indicate that multi-aquifer well flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".ssm": "keyword to indicate that SSM flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".rch": "keyword to indicate that recharge flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".evt": "keyword to indicate that evapotranspiration flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".uzt": "keyword to indicate that unsaturated zone flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".mwe": "keyword to indicate that well flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control."
+    }
+  },
+  "beta": {
+    "options": {
+      ".csub": "compressibility of water. Typical values of BETA are 4.6512e-10 1/Pa or 2.2270e-8 lb/square foot in SI and English units, respectively. By default, BETA is 4.6512e-10 1/Pa."
+    }
+  },
+  "head_based": {
+    "options": {
+      ".csub": "keyword to indicate the head-based formulation will be used to simulate coarse-grained aquifer materials and no-delay and delay interbeds. Specifying HEAD\\_BASED also specifies the INITIAL\\_PRECONSOLIDATION\\_HEAD option."
+    }
+  },
+  "initial_preconsolidation_head": {
+    "options": {
+      ".csub": "keyword to indicate that preconsolidation heads will be specified for no-delay and delay interbeds in the PACKAGEDATA block. If the SPECIFIED\\_INITIAL\\_INTERBED\\_STATE option is specified in the OPTIONS block, user-specified preconsolidation heads in the PACKAGEDATA block are absolute values. Otherwise, user-specified preconsolidation heads in the PACKAGEDATA block are relative to steady-state or initial heads."
+    }
+  },
+  "ndelaycells": {
+    "options": {
+      ".csub": "number of nodes used to discretize delay interbeds. If not specified, then a default value of 19 is assigned."
+    }
+  },
+  "compression_indices": {
+    "options": {
+      ".csub": "keyword to indicate that the recompression (CR) and compression (CC) indices are specified instead of the elastic specific storage (SSE) and inelastic specific storage (SSV) coefficients. If not specified, then elastic specific storage (SSE) and inelastic specific storage (SSV) coefficients must be specified."
+    }
+  },
+  "update_material_properties": {
+    "options": {
+      ".csub": "keyword to indicate that the thickness and void ratio of coarse-grained and interbed sediments (delay and no-delay) will vary during the simulation. If not specified, the thickness and void ratio of coarse-grained and interbed sediments will not vary during the simulation."
+    }
+  },
+  "cell_fraction": {
+    "options": {
+      ".csub": "keyword to indicate that the thickness of interbeds will be specified in terms of the fraction of cell thickness. If not specified, interbed thicknness must be specified."
+    }
+  },
+  "specified_initial_interbed_state": {
+    "options": {
+      ".csub": "keyword to indicate that absolute preconsolidation stresses (heads) and delay bed heads will be specified for interbeds defined in the PACKAGEDATA block. The SPECIFIED\\_INITIAL\\_INTERBED\\_STATE option is equivalent to specifying the SPECIFIED\\_INITIAL\\_PRECONSOLITATION\\_STRESS and SPECIFIED\\_INITIAL\\_DELAY\\_HEAD. If SPECIFIED\\_INITIAL\\_INTERBED\\_STATE is not specified then preconsolidation stress (head) and delay bed head values specified in the PACKAGEDATA block are relative to simulated values of the first stress period if steady-state or initial stresses and GWF heads if the first stress period is transient."
+    }
+  },
+  "specified_initial_preconsolidation_stress": {
+    "options": {
+      ".csub": "keyword to indicate that absolute preconsolidation stresses (heads) will be specified for interbeds defined in the PACKAGEDATA block. If SPECIFIED\\_INITIAL\\_PRECONSOLITATION\\_STRESS and SPECIFIED\\_INITIAL\\_INTERBED\\_STATE are not specified then preconsolidation stress (head) values specified in the PACKAGEDATA block are relative to simulated values if the first stress period is steady-state or initial stresses (heads) if the first stress period is transient."
+    }
+  },
+  "specified_initial_delay_head": {
+    "options": {
+      ".csub": "keyword to indicate that absolute initial delay bed head will be specified for interbeds defined in the PACKAGEDATA block. If SPECIFIED\\_INITIAL\\_DELAY\\_HEAD and SPECIFIED\\_INITIAL\\_INTERBED\\_STATE are not specified then delay bed head values specified in the PACKAGEDATA block are relative to simulated values if the first stress period is steady-state or initial GWF heads if the first stress period is transient."
+    }
+  },
+  "effective_stress_lag": {
+    "options": {
+      ".csub": "keyword to indicate the effective stress from the previous time step will be used to calculate specific storage values. This option can 1) help with convergence in models with thin cells and water table elevations close to land surface; 2) is identical to the approach used in the SUBWT package for MODFLOW-2005; and 3) is only used if the effective-stress formulation is being used. By default, current effective stress values are used to calculate specific storage values."
+    }
+  },
+  "strain_csv_interbed": {
+    "options": {
+      ".csub": "keyword to specify the record that corresponds to final interbed strain output."
+    }
+  },
+  "fileout": {
+    "options": {
+      ".csub": "keyword to specify that an output filename is expected next.",
+      ".oc": "keyword to specify that an output filename is expected next.",
+      ".sft": "keyword to specify that an output filename is expected next.",
+      ".mve": "keyword to specify that an output filename is expected next.",
+      ".vsc": "keyword to specify that an output filename is expected next.",
+      ".uze": "keyword to specify that an output filename is expected next.",
+      ".prp": "keyword to specify that an output filename is expected next.",
+      ".ims": "keyword to specify that an output filename is expected next.",
+      ".wel": "keyword to specify that an output filename is expected next.",
+      ".lak": "keyword to specify that an output filename is expected next.",
+      ".lkt": "keyword to specify that an output filename is expected next.",
+      ".lke": "keyword to specify that an output filename is expected next.",
+      ".mst": "keyword to specify that an output filename is expected next.",
+      ".buy": "keyword to specify that an output filename is expected next.",
+      ".sfe": "keyword to specify that an output filename is expected next.",
+      ".mvt": "keyword to specify that an output filename is expected next.",
+      ".mvr": "keyword to specify that an output filename is expected next.",
+      ".mwt": "keyword to specify that an output filename is expected next.",
+      ".pts": "keyword to specify that an output filename is expected next.",
+      ".sfr": "keyword to specify that an output filename is expected next.",
+      ".uzf": "keyword to specify that an output filename is expected next.",
+      ".ist": "keyword to specify that an output filename is expected next.",
+      ".nam": "keyword to specify that an output filename is expected next.",
+      ".maw": "keyword to specify that an output filename is expected next.",
+      ".uzt": "keyword to specify that an output filename is expected next.",
+      ".mwe": "keyword to specify that an output filename is expected next."
+    },
+    "continuous": {
+      ".obs": "keyword to specify that an output filename is expected next."
+    }
+  },
+  "strain_csv_coarse": {
+    "options": {
+      ".csub": "keyword to specify the record that corresponds to final coarse-grained material strain output."
+    }
+  },
+  "compaction": {
+    "options": {
+      ".csub": "keyword to specify that record corresponds to the compaction."
+    }
+  },
+  "compaction_elastic": {
+    "options": {
+      ".csub": "keyword to specify that record corresponds to the elastic interbed compaction binary file."
+    }
+  },
+  "compaction_inelastic": {
+    "options": {
+      ".csub": "keyword to specify that record corresponds to the inelastic interbed compaction binary file."
+    }
+  },
+  "compaction_interbed": {
+    "options": {
+      ".csub": "keyword to specify that record corresponds to the interbed compaction binary file."
+    }
+  },
+  "compaction_coarse": {
+    "options": {
+      ".csub": "keyword to specify that record corresponds to the elastic coarse-grained material compaction binary file."
+    }
+  },
+  "zdisplacement": {
+    "options": {
+      ".csub": "keyword to specify that record corresponds to the z-displacement binary file."
+    }
+  },
+  "package_convergence": {
+    "options": {
+      ".csub": "keyword to specify that record corresponds to the package convergence comma spaced values file. Package convergence data is for delay interbeds. A warning message will be issued if package convergence data is requested but delay interbeds are not included in the package.",
+      ".lak": "keyword to specify that record corresponds to the package convergence comma spaced values file.",
+      ".sfr": "keyword to specify that record corresponds to the package convergence comma spaced values file.",
+      ".uzf": "keyword to specify that record corresponds to the package convergence comma spaced values file."
+    }
+  },
+  "ts6": {
+    "options": {
+      ".csub": "keyword to specify that record corresponds to a time-series file.",
+      ".ctp": "keyword to specify that record corresponds to a time-series file.",
+      ".sft": "keyword to specify that record corresponds to a time-series file.",
+      ".evp": "keyword to specify that record corresponds to a time-series file.",
+      ".flw": "keyword to specify that record corresponds to a time-series file.",
+      ".chd": "keyword to specify that record corresponds to a time-series file.",
+      ".uze": "keyword to specify that record corresponds to a time-series file.",
+      ".pcp": "keyword to specify that record corresponds to a time-series file.",
+      ".drn": "keyword to specify that record corresponds to a time-series file.",
+      ".wel": "keyword to specify that record corresponds to a time-series file.",
+      ".lak": "keyword to specify that record corresponds to a time-series file.",
+      ".esl": "keyword to specify that record corresponds to a time-series file.",
+      ".lkt": "keyword to specify that record corresponds to a time-series file.",
+      ".lke": "keyword to specify that record corresponds to a time-series file.",
+      ".tvk": "keyword to specify that record corresponds to a time-series file.",
+      ".src": "keyword to specify that record corresponds to a time-series file.",
+      ".ghb": "keyword to specify that record corresponds to a time-series file.",
+      ".zdg": "keyword to specify that record corresponds to a time-series file.",
+      ".sfe": "keyword to specify that record corresponds to a time-series file.",
+      ".mwt": "keyword to specify that record corresponds to a time-series file.",
+      ".tvs": "keyword to specify that record corresponds to a time-series file.",
+      ".sfr": "keyword to specify that record corresponds to a time-series file.",
+      ".spc": "keyword to specify that record corresponds to a time-series file.",
+      ".riv": "keyword to specify that record corresponds to a time-series file.",
+      ".uzf": "keyword to specify that record corresponds to a time-series file.",
+      ".cnc": "keyword to specify that record corresponds to a time-series file.",
+      ".maw": "keyword to specify that record corresponds to a time-series file.",
+      ".rch": "keyword to specify that record corresponds to a time-series file.",
+      ".evt": "keyword to specify that record corresponds to a time-series file.",
+      ".uzt": "keyword to specify that record corresponds to a time-series file.",
+      ".mwe": "keyword to specify that record corresponds to a time-series file."
+    }
+  },
+  "filein": {
+    "options": {
+      ".csub": "keyword to specify that an input filename is expected next.",
+      ".spca": "keyword to specify that an input filename is expected next.",
+      ".ctp": "keyword to specify that an input filename is expected next.",
+      ".cdb": "keyword to specify that an input filename is expected next.",
+      ".sft": "keyword to specify that an input filename is expected next.",
+      ".evp": "keyword to specify that an input filename is expected next.",
+      ".npf": "keyword to specify that an input filename is expected next.",
+      ".flw": "keyword to specify that an input filename is expected next.",
+      ".chd": "keyword to specify that an input filename is expected next.",
+      ".uze": "keyword to specify that an input filename is expected next.",
+      ".nam": "keyword to specify that an input filename is expected next.",
+      ".pcp": "keyword to specify that an input filename is expected next.",
+      ".api": "keyword to specify that an input filename is expected next.",
+      ".disv": "keyword to specify that an input filename is expected next.",
+      ".dis": "keyword to specify that an input filename is expected next.",
+      ".sto": "keyword to specify that an input filename is expected next.",
+      ".drn": "keyword to specify that an input filename is expected next.",
+      ".gwegwe": "keyword to specify that an input filename is expected next.",
+      ".olfgwf": "keyword to specify that an input filename is expected next.",
+      ".wel": "keyword to specify that an input filename is expected next.",
+      ".lak": "keyword to specify that an input filename is expected next.",
+      ".esl": "keyword to specify that an input filename is expected next.",
+      ".lkt": "keyword to specify that an input filename is expected next.",
+      ".gwtgwt": "keyword to specify that an input filename is expected next.",
+      ".lke": "keyword to specify that an input filename is expected next.",
+      ".tvk": "keyword to specify that an input filename is expected next.",
+      ".evta": "keyword to specify that an input filename is expected next.",
+      ".src": "keyword to specify that an input filename is expected next.",
+      ".ghb": "keyword to specify that an input filename is expected next.",
+      ".rcha": "keyword to specify that an input filename is expected next.",
+      ".zdg": "keyword to specify that an input filename is expected next.",
+      ".gwfgwf": "keyword to specify that an input filename is expected next.",
+      ".sfe": "keyword to specify that an input filename is expected next.",
+      ".dfw": "keyword to specify that an input filename is expected next.",
+      ".mwt": "keyword to specify that an input filename is expected next.",
+      ".chfgwf": "keyword to specify that an input filename is expected next.",
+      ".tvs": "keyword to specify that an input filename is expected next.",
+      ".sfr": "keyword to specify that an input filename is expected next.",
+      ".spc": "keyword to specify that an input filename is expected next.",
+      ".riv": "keyword to specify that an input filename is expected next.",
+      ".uzf": "keyword to specify that an input filename is expected next.",
+      ".cnc": "keyword to specify that an input filename is expected next.",
+      ".maw": "keyword to specify that an input filename is expected next.",
+      ".rch": "keyword to specify that an input filename is expected next.",
+      ".evt": "keyword to specify that an input filename is expected next.",
+      ".uzt": "keyword to specify that an input filename is expected next.",
+      ".tdis": "keyword to specify that an input filename is expected next.",
+      ".mwe": "keyword to specify that an input filename is expected next."
+    },
+    "packagedata": {
+      ".fmi": "keyword to specify that an input filename is expected next."
+    },
+    "tables": {
+      ".lak": "keyword to specify that an input filename is expected next."
+    },
+    "crosssections": {
+      ".sfr": "keyword to specify that an input filename is expected next."
+    },
+    "period": {
+      ".sfr": "keyword to specify that an input filename is expected next."
+    },
+    "fileinput": {
+      ".ssm": "keyword to specify that an input filename is expected next."
+    }
+  },
+  "obs6": {
+    "options": {
+      ".csub": "keyword to specify that record corresponds to an observations file.",
+      ".ctp": "keyword to specify that record corresponds to an observations file.",
+      ".cdb": "keyword to specify that record corresponds to an observations file.",
+      ".sft": "keyword to specify that record corresponds to an observations file.",
+      ".evp": "keyword to specify that record corresponds to an observations file.",
+      ".flw": "keyword to specify that record corresponds to an observations file.",
+      ".chd": "keyword to specify that record corresponds to an observations file.",
+      ".uze": "keyword to specify that record corresponds to an observations file.",
+      ".pcp": "keyword to specify that record corresponds to an observations file.",
+      ".api": "keyword to specify that record corresponds to an observations file.",
+      ".drn": "keyword to specify that record corresponds to an observations file.",
+      ".gwegwe": "keyword to specify that record corresponds to an observations file.",
+      ".olfgwf": "keyword to specify that record corresponds to an observations file.",
+      ".wel": "keyword to specify that record corresponds to an observations file.",
+      ".lak": "keyword to specify that record corresponds to an observations file.",
+      ".esl": "keyword to specify that record corresponds to an observations file.",
+      ".lkt": "keyword to specify that record corresponds to an observations file.",
+      ".gwtgwt": "keyword to specify that record corresponds to an observations file.",
+      ".lke": "keyword to specify that record corresponds to an observations file.",
+      ".evta": "keyword to specify that record corresponds to an observations file.",
+      ".src": "keyword to specify that record corresponds to an observations file.",
+      ".ghb": "keyword to specify that record corresponds to an observations file.",
+      ".rcha": "keyword to specify that record corresponds to an observations file.",
+      ".zdg": "keyword to specify that record corresponds to an observations file.",
+      ".gwfgwf": "keyword to specify that record corresponds to an observations file.",
+      ".sfe": "keyword to specify that record corresponds to an observations file.",
+      ".dfw": "keyword to specify that record corresponds to an observations file.",
+      ".mwt": "keyword to specify that record corresponds to an observations file.",
+      ".chfgwf": "keyword to specify that record corresponds to an observations file.",
+      ".sfr": "keyword to specify that record corresponds to an observations file.",
+      ".riv": "keyword to specify that record corresponds to an observations file.",
+      ".uzf": "keyword to specify that record corresponds to an observations file.",
+      ".cnc": "keyword to specify that record corresponds to an observations file.",
+      ".maw": "keyword to specify that record corresponds to an observations file.",
+      ".rch": "keyword to specify that record corresponds to an observations file.",
+      ".evt": "keyword to specify that record corresponds to an observations file.",
+      ".uzt": "keyword to specify that record corresponds to an observations file.",
+      ".mwe": "keyword to specify that record corresponds to an observations file."
+    }
+  },
+  "ninterbeds": {
+    "dimensions": {
+      ".csub": "is the number of CSUB interbed systems.  More than 1 CSUB interbed systems can be assigned to a GWF cell; however, only 1 GWF cell can be assigned to a single CSUB interbed system."
+    }
+  },
+  "maxsig0": {
+    "dimensions": {
+      ".csub": "is the maximum number of cells that can have a specified stress offset.  More than 1 stress offset can be assigned to a GWF cell. By default, MAXSIG0 is 0."
+    }
+  },
+  "cg_ske_cr": {
+    "griddata": {
+      ".csub": "is the initial elastic coarse-grained material specific storage or recompression index. The recompression index is specified if COMPRESSION\\_INDICES is specified in the OPTIONS block.  Specified or calculated elastic coarse-grained material specific storage values are not adjusted from initial values if HEAD\\_BASED is specified in the OPTIONS block."
+    }
+  },
+  "cg_theta": {
+    "griddata": {
+      ".csub": "is the initial porosity of coarse-grained materials."
+    }
+  },
+  "sgm": {
+    "griddata": {
+      ".csub": "is the specific gravity of moist or unsaturated sediments.  If not specified, then a default value of 1.7 is assigned."
+    }
+  },
+  "sgs": {
+    "griddata": {
+      ".csub": "is the specific gravity of saturated sediments. If not specified, then a default value of 2.0 is assigned."
+    }
+  },
+  "budget": {
+    "options": {
+      ".oc": "keyword to specify that record corresponds to the budget.",
+      ".sft": "keyword to specify that record corresponds to the budget.",
+      ".mve": "keyword to specify that record corresponds to the budget.",
+      ".uze": "keyword to specify that record corresponds to the budget.",
+      ".lak": "keyword to specify that record corresponds to the budget.",
+      ".lkt": "keyword to specify that record corresponds to the budget.",
+      ".lke": "keyword to specify that record corresponds to the budget.",
+      ".sfe": "keyword to specify that record corresponds to the budget.",
+      ".mvt": "keyword to specify that record corresponds to the budget.",
+      ".mvr": "keyword to specify that record corresponds to the budget.",
+      ".mwt": "keyword to specify that record corresponds to the budget.",
+      ".sfr": "keyword to specify that record corresponds to the budget.",
+      ".uzf": "keyword to specify that record corresponds to the budget.",
+      ".ist": "keyword to specify that record corresponds to the budget.",
+      ".maw": "keyword to specify that record corresponds to the budget.",
+      ".uzt": "keyword to specify that record corresponds to the budget.",
+      ".mwe": "keyword to specify that record corresponds to the budget."
+    }
+  },
+  "budgetcsv": {
+    "options": {
+      ".oc": "keyword to specify that record corresponds to the budget CSV.",
+      ".sft": "keyword to specify that record corresponds to the budget CSV.",
+      ".mve": "keyword to specify that record corresponds to the budget CSV.",
+      ".uze": "keyword to specify that record corresponds to the budget CSV.",
+      ".lak": "keyword to specify that record corresponds to the budget CSV.",
+      ".lkt": "keyword to specify that record corresponds to the budget CSV.",
+      ".lke": "keyword to specify that record corresponds to the budget CSV.",
+      ".sfe": "keyword to specify that record corresponds to the budget CSV.",
+      ".mvt": "keyword to specify that record corresponds to the budget CSV.",
+      ".mvr": "keyword to specify that record corresponds to the budget CSV.",
+      ".mwt": "keyword to specify that record corresponds to the budget CSV.",
+      ".sfr": "keyword to specify that record corresponds to the budget CSV.",
+      ".uzf": "keyword to specify that record corresponds to the budget CSV.",
+      ".ist": "keyword to specify that record corresponds to the budget CSV.",
+      ".maw": "keyword to specify that record corresponds to the budget CSV.",
+      ".uzt": "keyword to specify that record corresponds to the budget CSV.",
+      ".mwe": "keyword to specify that record corresponds to the budget CSV."
+    }
+  },
+  "head": {
+    "options": {
+      ".oc": "keyword to specify that record corresponds to head.",
+      ".maw": "keyword to specify that record corresponds to head."
+    }
+  },
+  "print_format": {
+    "options": {
+      ".oc": "keyword to specify format for printing to the listing file.",
+      ".ist": "keyword to specify format for printing to the listing file."
+    }
+  },
+  "columns": {
+    "options": {
+      ".oc": "number of columns for writing data.",
+      ".ist": "number of columns for writing data."
+    }
+  },
+  "width": {
+    "options": {
+      ".oc": "width for writing each number.",
+      ".ist": "width for writing each number."
+    },
+    "griddata": {
+      ".disv1d": "real value that defines the width for each one-dimensional cell. WIDTH must be greater than zero.  If the Cross Section (CXS) Package is used, then the WIDTH value will be multiplied by the specified cross section x-fraction values."
+    },
+    "period": {
+      ".lak": "real or character value that defines the width of the lake outlet. A specified WIDTH value is only used for active lakes if COUTTYPE for lake outlet OUTLETNO is not SPECIFIED. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+    }
+  },
+  "digits": {
+    "options": {
+      ".oc": "number of digits to use for writing a number.",
+      ".obs": "Keyword and an integer digits specifier used for conversion of simulated values to text on output. If not specified, the default is the maximum number of digits stored in the program (as written with the G0 Fortran specifier). When simulated values are written to a comma-separated value text file specified in a CONTINUOUS block below, the digits specifier controls the number of significant digits with which simulated values are written to the output file. The digits specifier has no effect on the number of significant digits with which the simulation time is written for continuous observations.  If DIGITS is specified as zero, then observations are written with the default setting, which is the maximum number of digits.",
+      ".ist": "number of digits to use for writing a number."
+    }
+  },
+  "save": {
+    "period": {
+      ".oc": "keyword to indicate that information will be saved this stress period."
+    }
+  },
+  "print": {
+    "period": {
+      ".oc": "keyword to indicate that information will be printed this stress period."
+    }
+  },
+  "all": {
+    "period": {
+      ".oc": "keyword to indicate save for all time steps in period.",
+      ".prp": "keyword to indicate release at the start of all time steps in the period."
+    }
+  },
+  "first": {
+    "period": {
+      ".oc": "keyword to indicate save for first step in period. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
+      ".prp": "keyword to indicate release at the start of the first time step in the period. This keyword may be used in conjunction with other RELEASESETTING options."
+    }
+  },
+  "last": {
+    "period": {
+      ".oc": "keyword to indicate save for last step in period. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
+      ".prp": "keyword to indicate release at the start of the last time step in the period. This keyword may be used in conjunction with other RELEASESETTING options."
+    }
+  },
+  "frequency": {
+    "period": {
+      ".oc": "save at the specified time step frequency. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
+      ".prp": "release at the specified time step frequency. This keyword may be used in conjunction with other RELEASESETTING options."
+    }
+  },
+  "steps": {
+    "period": {
+      ".oc": "save for each step specified in STEPS. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
+      ".prp": "release at the start of each step specified in STEPS. This option may be used in conjunction with other RELEASESETTING options."
+    }
+  },
+  "qoutflow": {
+    "options": {
+      ".oc": "keyword to specify that record corresponds to qoutflow."
+    }
+  },
+  "stage": {
+    "options": {
+      ".oc": "keyword to specify that record corresponds to stage.",
+      ".lak": "keyword to specify that record corresponds to stage.",
+      ".sfr": "keyword to specify that record corresponds to stage."
+    },
+    "period": {
+      ".lak": "real or character value that defines the stage for the lake. The specified STAGE is only applied if the lake is a constant stage lake. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      ".sfr": "real or character value that defines the stage for the reach. The specified STAGE is only applied if the reach uses the simple routing option. If STAGE is not specified for reaches that use the simple routing option, the specified stage is set to the top of the reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+    }
+  },
+  "xt3d_off": {
+    "options": {
+      ".cnd": "deactivate the xt3d method and use the faster and less accurate approximation.  This option may provide a fast and accurate solution under some circumstances, such as when flow aligns with the model grid, there is no mechanical dispersion, or when the longitudinal and transverse dispersivities are equal.  This option may also be used to assess the computational demand of the XT3D approach by noting the run time differences with and without this option on.",
+      ".dsp": "deactivate the xt3d method and use the faster and less accurate approximation.  This option may provide a fast and accurate solution under some circumstances, such as when flow aligns with the model grid, there is no mechanical dispersion, or when the longitudinal and transverse dispersivities are equal.  This option may also be used to assess the computational demand of the XT3D approach by noting the run time differences with and without this option on."
+    }
+  },
+  "xt3d_rhs": {
+    "options": {
+      ".cnd": "add xt3d terms to right-hand side, when possible.  This option uses less memory, but may require more iterations.",
+      ".dsp": "add xt3d terms to right-hand side, when possible.  This option uses less memory, but may require more iterations."
+    }
+  },
+  "export_array_ascii": {
+    "options": {
+      ".cnd": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
+      ".sto": "keyword that specifies input grid arrays, which already support the layered keyword, should be written to layered ascii output files.",
+      ".disv1d": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
+      ".ic": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
+      ".npf": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
+      ".mip": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
+      ".dis2d": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
+      ".disv": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
+      ".disv2d": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
+      ".dis": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
+      ".dsp": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
+      ".dfw": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
+      ".disu": "keyword that specifies input griddata arrays should be written to layered ascii output files."
+    }
+  },
+  "export_array_netcdf": {
+    "options": {
+      ".cnd": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
+      ".ic": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
+      ".npf": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
+      ".disv": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
+      ".dis": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
+      ".sto": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
+      ".evta": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
+      ".rcha": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
+      ".dsp": "keyword that specifies input griddata arrays should be written to the model output netcdf file."
+    }
+  },
+  "alh": {
+    "griddata": {
+      ".cnd": "longitudinal dispersivity in horizontal direction.  If flow is strictly horizontal, then this is the longitudinal dispersivity that will be used.  If flow is not strictly horizontal or strictly vertical, then the longitudinal dispersivity is a function of both ALH and ALV.  If mechanical dispersion is represented (by specifying any dispersivity values) then this array is required.",
+      ".dsp": "longitudinal dispersivity in horizontal direction.  If flow is strictly horizontal, then this is the longitudinal dispersivity that will be used.  If flow is not strictly horizontal or strictly vertical, then the longitudinal dispersivity is a function of both ALH and ALV.  If mechanical dispersion is represented (by specifying any dispersivity values) then this array is required."
+    }
+  },
+  "alv": {
+    "griddata": {
+      ".cnd": "longitudinal dispersivity in vertical direction.  If flow is strictly vertical, then this is the longitudinal dispsersivity value that will be used.  If flow is not strictly horizontal or strictly vertical, then the longitudinal dispersivity is a function of both ALH and ALV.  If this value is not specified and mechanical dispersion is represented, then this array is set equal to ALH.",
+      ".dsp": "longitudinal dispersivity in vertical direction.  If flow is strictly vertical, then this is the longitudinal dispsersivity value that will be used.  If flow is not strictly horizontal or strictly vertical, then the longitudinal dispersivity is a function of both ALH and ALV.  If this value is not specified and mechanical dispersion is represented, then this array is set equal to ALH."
+    }
+  },
+  "ath1": {
+    "griddata": {
+      ".cnd": "transverse dispersivity in horizontal direction.  This is the transverse dispersivity value for the second ellipsoid axis.  If flow is strictly horizontal and directed in the x direction (along a row for a regular grid), then this value controls spreading in the y direction.  If mechanical dispersion is represented (by specifying any dispersivity values) then this array is required.",
+      ".dsp": "transverse dispersivity in horizontal direction.  This is the transverse dispersivity value for the second ellipsoid axis.  If flow is strictly horizontal and directed in the x direction (along a row for a regular grid), then this value controls spreading in the y direction.  If mechanical dispersion is represented (by specifying any dispersivity values) then this array is required."
+    }
+  },
+  "ath2": {
+    "griddata": {
+      ".cnd": "transverse dispersivity in horizontal direction.  This is the transverse dispersivity value for the third ellipsoid axis.  If flow is strictly horizontal and directed in the x direction (along a row for a regular grid), then this value controls spreading in the z direction.  If this value is not specified and mechanical dispersion is represented, then this array is set equal to ATH1.",
+      ".dsp": "transverse dispersivity in horizontal direction.  This is the transverse dispersivity value for the third ellipsoid axis.  If flow is strictly horizontal and directed in the x direction (along a row for a regular grid), then this value controls spreading in the z direction.  If this value is not specified and mechanical dispersion is represented, then this array is set equal to ATH1."
+    }
+  },
+  "atv": {
+    "griddata": {
+      ".cnd": "transverse dispersivity when flow is in vertical direction.  If flow is strictly vertical and directed in the z direction, then this value controls spreading in the x and y directions.  If this value is not specified and mechanical dispersion is represented, then this array is set equal to ATH2.",
+      ".dsp": "transverse dispersivity when flow is in vertical direction.  If flow is strictly vertical and directed in the z direction, then this value controls spreading in the x and y directions.  If this value is not specified and mechanical dispersion is represented, then this array is set equal to ATH2."
+    }
+  },
+  "ktw": {
+    "griddata": {
+      ".cnd": "thermal conductivity of the simulated fluid.   Note that the CND Package does not account for the tortuosity of the flow paths when solving for the conductive spread of heat.  If tortuosity plays an important role in the thermal conductivity calculation, its effect should be reflected in the value specified for KTW."
+    }
+  },
+  "kts": {
+    "griddata": {
+      ".cnd": "thermal conductivity of the solid aquifer material"
+    }
+  },
+  "steady-state": {
+    "period": {
+      ".sto": "keyword to indicate that stress period IPER is steady-state. Steady-state conditions will apply until the TRANSIENT keyword is specified in a subsequent BEGIN PERIOD block."
+    }
+  },
+  "transient": {
+    "period": {
+      ".sto": "keyword to indicate that stress period IPER is transient. Transient conditions will apply until the STEADY-STATE keyword is specified in a subsequent BEGIN PERIOD block."
+    }
+  },
+  "readasarrays": {
+    "options": {
+      ".spca": "indicates that array-based input will be used for the SPC Package.  This keyword must be specified to use array-based input.  When READASARRAYS is specified, values must be provided for every cell within a model layer, even those cells that have an IDOMAIN value less than one.  Values assigned to cells with IDOMAIN values less than one are not used and have no effect on simulation results.",
+      ".evta": "indicates that array-based input will be used for the Evapotranspiration Package.  This keyword must be specified to use array-based input.  When READASARRAYS is specified, values must be provided for every cell within a model layer, even those cells that have an IDOMAIN value less than one.  Values assigned to cells with IDOMAIN values less than one are not used and have no effect on simulation results.",
+      ".rcha": "indicates that array-based input will be used for the Recharge Package.  This keyword must be specified to use array-based input.  When READASARRAYS is specified, values must be provided for every cell within a model layer, even those cells that have an IDOMAIN value less than one.  Values assigned to cells with IDOMAIN values less than one are not used and have no effect on simulation results. "
+    }
+  },
+  "tas6": {
+    "options": {
+      ".spca": "keyword to specify that record corresponds to a time-array-series file.",
+      ".evta": "keyword to specify that record corresponds to a time-array-series file.",
+      ".rcha": "keyword to specify that record corresponds to a time-array-series file."
+    }
+  },
+  "concentration": {
+    "period": {
+      ".spca": "is the concentration of the associated Recharge or Evapotranspiration stress package.  The concentration array may be defined by a time-array series (see the \"Using Time-Array Series in a Package\" section).",
+      ".sft": "real or character value that defines the concentration for the reach. The specified CONCENTRATION is only applied if the reach is a constant concentration reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      ".lkt": "real or character value that defines the concentration for the lake. The specified CONCENTRATION is only applied if the lake is a constant concentration lake. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      ".mwt": "real or character value that defines the concentration for the well. The specified CONCENTRATION is only applied if the well is a constant concentration well. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      ".spc": "is the boundary concentration. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, the CONCENTRATION for each boundary feature is zero.",
+      ".uzt": "real or character value that defines the concentration for the unsaturated zone flow cell. The specified CONCENTRATION is only applied if the unsaturated zone flow cell is a constant concentration cell. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+    },
+    "options": {
+      ".sft": "keyword to specify that record corresponds to concentration.",
+      ".lkt": "keyword to specify that record corresponds to concentration.",
+      ".mwt": "keyword to specify that record corresponds to concentration.",
+      ".oc": "keyword to specify that record corresponds to concentration.",
+      ".uzt": "keyword to specify that record corresponds to concentration."
+    }
+  },
+  "temperature": {
+    "period": {
+      ".spca": "is the temperature of the associated Recharge or Evapotranspiration stress package.  The temperature array may be defined by a time-array series (see the \"Using Time-Array Series in a Package\" section).",
+      ".uze": "real or character value that defines the temperature for the unsaturated zone flow cell. The specified TEMPERATURE is only applied if the unsaturated zone flow cell is a constant temperature cell. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      ".lke": "real or character value that defines the temperature for the lake. The specified TEMPERATURE is only applied if the lake is a constant temperature lake. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      ".sfe": "real or character value that defines the temperature for the reach. The specified TEMPERATURE is only applied if the reach is a constant temperature reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      ".spc": "is the user-supplied boundary temperature. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, the TEMPERATURE for each boundary feature is zero.",
+      ".mwe": "real or character value that defines the temperature for the well. The specified TEMPERATURE is only applied if the well is a constant temperature well. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+    },
+    "options": {
+      ".uze": "keyword to specify that record corresponds to temperature.",
+      ".lke": "keyword to specify that record corresponds to temperature.",
+      ".sfe": "keyword to specify that record corresponds to temperature.",
+      ".oc": "keyword to specify that record corresponds to temperature.",
+      ".mwe": "keyword to specify that record corresponds to temperature."
+    }
+  },
+  "auxiliary": {
+    "options": {
+      ".ctp": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".cdb": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".sft": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".evp": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".flw": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".chd": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".uze": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".pcp": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".drn": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".gwegwe": "an array of auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided. Most auxiliary variables will not be used by the GWE-GWE Exchange, but they will be available for use by other parts of the program.  If an auxiliary variable with the name ``ANGLDEGX'' is found, then this information will be used as the angle (provided in degrees) between the connection face normal and the x axis, where a value of zero indicates that a normal vector points directly along the positive x axis.  The connection face normal is a normal vector on the cell face shared between the cell in model 1 and the cell in model 2 pointing away from the model 1 cell.  Additional information on ``ANGLDEGX'' is provided in the description of the DISU Package.  If an auxiliary variable with the name ``CDIST'' is found, then this information will be used as the straight-line connection distance, including the vertical component, between the two cell centers.  Both ANGLDEGX and CDIST are required if specific discharge is calculated for either of the groundwater models.",
+      ".wel": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".lak": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".esl": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".lkt": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".gwtgwt": "an array of auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided. Most auxiliary variables will not be used by the GWT-GWT Exchange, but they will be available for use by other parts of the program.  If an auxiliary variable with the name ``ANGLDEGX'' is found, then this information will be used as the angle (provided in degrees) between the connection face normal and the x axis, where a value of zero indicates that a normal vector points directly along the positive x axis.  The connection face normal is a normal vector on the cell face shared between the cell in model 1 and the cell in model 2 pointing away from the model 1 cell.  Additional information on ``ANGLDEGX'' is provided in the description of the DISU Package.  ANGLDEGX must be specified if dispersion is simulated in the connected GWT models.",
+      ".lke": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".evta": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".src": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".ghb": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".rcha": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".zdg": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".gwfgwf": "an array of auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided. Most auxiliary variables will not be used by the GWF-GWF Exchange, but they will be available for use by other parts of the program.  If an auxiliary variable with the name ``ANGLDEGX'' is found, then this information will be used as the angle (provided in degrees) between the connection face normal and the x axis, where a value of zero indicates that a normal vector points directly along the positive x axis.  The connection face normal is a normal vector on the cell face shared between the cell in model 1 and the cell in model 2 pointing away from the model 1 cell.  Additional information on ``ANGLDEGX'' and when it is required is provided in the description of the DISU Package.  If an auxiliary variable with the name ``CDIST'' is found, then this information will be used in the calculation of specific discharge within model cells connected by the exchange.  For a horizontal connection, CDIST should be specified as the horizontal distance between the cell centers, and should not include the vertical component.  For vertical connections, CDIST should be specified as the difference in elevation between the two cell centers.  Both ANGLDEGX and CDIST are required if specific discharge is calculated for either of the groundwater models.",
+      ".sfe": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".mwt": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".sfr": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".riv": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".uzf": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".cnc": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".maw": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".rch": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".evt": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".uzt": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".mwe": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block."
+    },
+    "period": {
+      ".sft": "keyword for specifying auxiliary variable.",
+      ".uze": "keyword for specifying auxiliary variable.",
+      ".lak": "keyword for specifying auxiliary variable.",
+      ".lkt": "keyword for specifying auxiliary variable.",
+      ".lke": "keyword for specifying auxiliary variable.",
+      ".sfe": "keyword for specifying auxiliary variable.",
+      ".mwt": "keyword for specifying auxiliary variable.",
+      ".sfr": "keyword for specifying auxiliary variable.",
+      ".maw": "keyword for specifying auxiliary variable.",
+      ".uzt": "keyword for specifying auxiliary variable.",
+      ".mwe": "keyword for specifying auxiliary variable."
+    }
+  },
+  "auxmultname": {
+    "options": {
+      ".ctp": "name of auxiliary variable to be used as multiplier of temperature value.",
+      ".evp": "name of auxiliary variable to be used as multiplier of evaporation.",
+      ".flw": "name of auxiliary variable to be used as multiplier of flow rate.",
+      ".chd": "name of auxiliary variable to be used as multiplier of CHD head value.",
+      ".pcp": "name of auxiliary variable to be used as multiplier of precipitation.",
+      ".drn": "name of auxiliary variable to be used as multiplier of drain conductance.",
+      ".wel": "name of auxiliary variable to be used as multiplier of well flow rate.",
+      ".esl": "name of auxiliary variable to be used as multiplier of energy loading rate.",
+      ".evta": "name of auxiliary variable to be used as multiplier of evapotranspiration rate.",
+      ".src": "name of auxiliary variable to be used as multiplier of mass loading rate.",
+      ".ghb": "name of auxiliary variable to be used as multiplier of general-head boundary conductance.",
+      ".rcha": "name of auxiliary variable to be used as multiplier of recharge.",
+      ".riv": "name of auxiliary variable to be used as multiplier of riverbed conductance.",
+      ".uzf": "name of auxiliary variable to be used as multiplier of GWF cell area used by UZF cell.",
+      ".cnc": "name of auxiliary variable to be used as multiplier of concentration value.",
+      ".rch": "name of auxiliary variable to be used as multiplier of recharge.",
+      ".evt": "name of auxiliary variable to be used as multiplier of evapotranspiration rate."
+    }
+  },
+  "print_flows": {
+    "options": {
+      ".ctp": "keyword to indicate that the list of constant temperature flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".cdb": "keyword to indicate that the list of critical depth boundary flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".sft": "keyword to indicate that the list of reach flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".mve": "keyword to indicate that the list of lake flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".evp": "keyword to indicate that the list of evaporation flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".npf": "keyword to indicate that calculated flows between cells will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control. If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.  This option can produce extremely large list files because all cell-by-cell flows are printed.  It should only be used with the NPF Package for models that have a small number of cells.",
+      ".flw": "keyword to indicate that the list of inflow flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".chd": "keyword to indicate that the list of constant-head flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".uze": "keyword to indicate that the list of unsaturated zone flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".nam": "keyword to indicate that the list of all model package flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".pcp": "keyword to indicate that the list of precipitation flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".api": "keyword to indicate that the list of api boundary flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".drn": "keyword to indicate that the list of drain flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".gwegwe": "keyword to indicate that the list of exchange flow rates will be printed to the listing file for every stress period in which ``SAVE BUDGET'' is specified in Output Control.",
+      ".olfgwf": "keyword to indicate that the list of exchange flow rates will be printed to the listing file for every stress period in which ``SAVE BUDGET'' is specified in Output Control.",
+      ".wel": "keyword to indicate that the list of well flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".lak": "keyword to indicate that the list of lake flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".esl": "keyword to indicate that the list of energy source loading flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".lkt": "keyword to indicate that the list of lake flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".gwtgwt": "keyword to indicate that the list of exchange flow rates will be printed to the listing file for every stress period in which ``SAVE BUDGET'' is specified in Output Control.",
+      ".lke": "keyword to indicate that the list of lake flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".evta": "keyword to indicate that the list of evapotranspiration flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".src": "keyword to indicate that the list of mass source flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".ghb": "keyword to indicate that the list of general-head boundary flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".rcha": "keyword to indicate that the list of recharge flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".zdg": "keyword to indicate that the list of zero-depth-gradient boundary flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".gwfgwf": "keyword to indicate that the list of exchange flow rates will be printed to the listing file for every stress period in which ``SAVE BUDGET'' is specified in Output Control.",
+      ".sfe": "keyword to indicate that the list of reach flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".mvt": "keyword to indicate that the list of lake flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".mvr": "keyword to indicate that the list of MVR flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".dfw": "keyword to indicate that calculated flows between cells will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control. If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.  This option can produce extremely large list files because all cell-by-cell flows are printed.  It should only be used with the DFW Package for models that have a small number of cells.",
+      ".mwt": "keyword to indicate that the list of well flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".gnc": "keyword to indicate that the list of GNC flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".chfgwf": "keyword to indicate that the list of exchange flow rates will be printed to the listing file for every stress period in which ``SAVE BUDGET'' is specified in Output Control.",
+      ".sfr": "keyword to indicate that the list of stream reach flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".riv": "keyword to indicate that the list of river flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".uzf": "keyword to indicate that the list of UZF flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".cnc": "keyword to indicate that the list of constant concentration flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".maw": "keyword to indicate that the list of multi-aquifer well flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".ssm": "keyword to indicate that the list of SSM flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".rch": "keyword to indicate that the list of recharge flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".evt": "keyword to indicate that the list of evapotranspiration flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".uzt": "keyword to indicate that the list of unsaturated zone flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".mwe": "keyword to indicate that the list of well flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period."
+    }
+  },
+  "maxbound": {
+    "dimensions": {
+      ".ctp": "integer value specifying the maximum number of constant temperature cells that will be specified for use during any stress period.",
+      ".cdb": "integer value specifying the maximum number of critical depth boundary cells that will be specified for use during any stress period.",
+      ".evp": "integer value specifying the maximum number of evaporation cells cells that will be specified for use during any stress period.",
+      ".flw": "integer value specifying the maximum number of inflow cells that will be specified for use during any stress period.",
+      ".chd": "integer value specifying the maximum number of constant-head cells that will be specified for use during any stress period.",
+      ".pcp": "integer value specifying the maximum number of precipitation cells cells that will be specified for use during any stress period.",
+      ".api": "integer value specifying the maximum number of api boundary cells that will be specified for use during any stress period.",
+      ".drn": "integer value specifying the maximum number of drains cells that will be specified for use during any stress period.",
+      ".wel": "integer value specifying the maximum number of wells cells that will be specified for use during any stress period.",
+      ".esl": "integer value specifying the maximum number of source cells that will be specified for use during any stress period.",
+      ".src": "integer value specifying the maximum number of sources cells that will be specified for use during any stress period.",
+      ".ghb": "integer value specifying the maximum number of general-head boundary cells that will be specified for use during any stress period.",
+      ".zdg": "integer value specifying the maximum number of zero-depth-gradient boundary cells that will be specified for use during any stress period.",
+      ".spc": "integer value specifying the maximum number of spc cells that will be specified for use during any stress period.",
+      ".riv": "integer value specifying the maximum number of rivers cells that will be specified for use during any stress period.",
+      ".cnc": "integer value specifying the maximum number of constant concentrations cells that will be specified for use during any stress period.",
+      ".rch": "integer value specifying the maximum number of recharge cells cells that will be specified for use during any stress period.",
+      ".evt": "integer value specifying the maximum number of evapotranspiration cells cells that will be specified for use during any stress period."
+    }
+  },
+  "print_table": {
+    "options": {
+      ".hpc": "keyword to indicate that the partition table will be printed to the listing file."
+    }
+  },
+  "dev_log_mpi": {
+    "options": {
+      ".hpc": "keyword to enable (extremely verbose) logging of mpi traffic to file."
+    }
+  },
+  "partitions": {
+    "partitions": {
+      ".hpc": "is the list of zero-based partition numbers."
+    }
+  },
+  "maxhfb": {
+    "dimensions": {
+      ".hfb": "integer value specifying the maximum number of horizontal flow barriers that will be entered in this input file.  The value of MAXHFB is used to allocate memory for the horizontal flow barriers."
+    }
+  },
+  "length_units": {
+    "options": {
+      ".disv1d": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.",
+      ".dis2d": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.",
+      ".disv": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.",
+      ".disv2d": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.",
+      ".dis": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.",
+      ".disu": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''."
+    }
+  },
+  "nogrb": {
+    "options": {
+      ".disv1d": "keyword to deactivate writing of the binary grid file.",
+      ".dis2d": "keyword to deactivate writing of the binary grid file.",
+      ".disv": "keyword to deactivate writing of the binary grid file.",
+      ".disv2d": "keyword to deactivate writing of the binary grid file.",
+      ".dis": "keyword to deactivate writing of the binary grid file.",
+      ".disu": "keyword to deactivate writing of the binary grid file."
+    }
+  },
+  "xorigin": {
+    "options": {
+      ".disv1d": "x-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      ".dis2d": "x-position of the lower-left corner of the model grid.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      ".disv": "x-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      ".disv2d": "x-position of the lower-left corner of the model grid.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      ".dis": "x-position of the lower-left corner of the model grid.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      ".disu": "x-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space."
+    }
+  },
+  "yorigin": {
+    "options": {
+      ".disv1d": "y-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      ".dis2d": "y-position of the lower-left corner of the model grid.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      ".disv": "y-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      ".disv2d": "y-position of the lower-left corner of the model grid.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      ".dis": "y-position of the lower-left corner of the model grid.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      ".disu": "y-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space."
+    }
+  },
+  "angrot": {
+    "options": {
+      ".disv1d": "counter-clockwise rotation angle (in degrees) of the model grid coordinate system relative to a real-world coordinate system.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      ".dis2d": "counter-clockwise rotation angle (in degrees) of the lower-left corner of the model grid.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      ".disv": "counter-clockwise rotation angle (in degrees) of the model grid coordinate system relative to a real-world coordinate system.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      ".disv2d": "counter-clockwise rotation angle (in degrees) of the lower-left corner of the model grid.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      ".dis": "counter-clockwise rotation angle (in degrees) of the lower-left corner of the model grid.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      ".disu": "counter-clockwise rotation angle (in degrees) of the model grid coordinate system relative to a real-world coordinate system.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space."
+    }
+  },
+  "nodes": {
+    "dimensions": {
+      ".disv1d": "is the number of linear cells.",
+      ".disv2d": "is the number of cells per layer.  This is a constant value for the grid and it applies to all layers.",
+      ".disu": "is the number of cells in the model grid."
+    }
+  },
+  "nvert": {
+    "dimensions": {
+      ".disv1d": "is the total number of (x, y, z) vertex pairs used to characterize the model grid.",
+      ".disv": "is the total number of (x, y) vertex pairs used to characterize the horizontal configuration of the model grid.",
+      ".disv2d": "is the total number of (x, y) vertex pairs used to characterize the horizontal configuration of the model grid.",
+      ".disu": "is the total number of (x, y) vertex pairs used to define the plan-view shape of each cell in the model grid.  If NVERT is not specified or is specified as zero, then the VERTICES and CELL2D blocks below are not read.  NVERT and the accompanying VERTICES and CELL2D blocks should be specified for most simulations.  If the XT3D or SAVE\\_SPECIFIC\\_DISCHARGE options are specified in the NPF Package, then this information is required."
+    }
+  },
+  "bottom": {
+    "griddata": {
+      ".disv1d": "bottom elevation for the one-dimensional cell.",
+      ".dis2d": "is the bottom elevation for each cell.",
+      ".disv2d": "is the bottom elevation for each cell."
+    }
+  },
+  "idomain": {
+    "griddata": {
+      ".disv1d": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1, the cell exists in the simulation.",
+      ".dis2d": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1, the cell exists in the simulation.  If the IDOMAIN value for a cell is -1, the cell does not exist in the simulation.  Furthermore, the first existing cell above will be connected to the first existing cell below.  This type of cell is referred to as a ``vertical pass through'' cell.",
+      ".disv": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1 or greater, the cell exists in the simulation.  If the IDOMAIN value for a cell is -1, the cell does not exist in the simulation.  Furthermore, the first existing cell above will be connected to the first existing cell below.  This type of cell is referred to as a ``vertical pass through'' cell.",
+      ".disv2d": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1 or greater, the cell exists in the simulation.  If the IDOMAIN value for a cell is -1, the cell does not exist in the simulation.  Furthermore, the first existing cell above will be connected to the first existing cell below.  This type of cell is referred to as a ``vertical pass through'' cell.",
+      ".dis": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1, the cell exists in the simulation.  If the IDOMAIN value for a cell is -1, the cell does not exist in the simulation.  Furthermore, the first existing cell above will be connected to the first existing cell below.  This type of cell is referred to as a ``vertical pass through'' cell.",
+      ".disu": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1 or greater, the cell exists in the simulation.  IDOMAIN values of -1 cannot be specified for the DISU Package."
+    }
+  },
+  "strt": {
+    "griddata": {
+      ".ic": "is the initial (starting) concentration---that is, concentration at the beginning of the GWT Model simulation.  STRT must be specified for all GWT Model simulations. One value is read for every model cell."
+    }
+  },
+  "flow_package_name": {
+    "options": {
+      ".sft": "keyword to specify the name of the corresponding flow package.  If not specified, then the corresponding flow package must have the same name as this advanced transport package (the name associated with this package in the GWT name file).",
+      ".uze": "keyword to specify the name of the corresponding flow package.  If not specified, then the corresponding flow package must have the same name as this advanced transport package (the name associated with this package in the GWE name file).",
+      ".lkt": "keyword to specify the name of the corresponding flow package.  If not specified, then the corresponding flow package must have the same name as this advanced transport package (the name associated with this package in the GWT name file).",
+      ".lke": "keyword to specify the name of the corresponding flow package.  If not specified, then the corresponding flow package must have the same name as this advanced transport package (the name associated with this package in the GWE name file).",
+      ".sfe": "keyword to specify the name of the corresponding flow package.  If not specified, then the corresponding flow package must have the same name as this advanced transport package (the name associated with this package in the GWE name file).",
+      ".mwt": "keyword to specify the name of the corresponding flow package.  If not specified, then the corresponding flow package must have the same name as this advanced transport package (the name associated with this package in the GWT name file).",
+      ".uzt": "keyword to specify the name of the corresponding flow package.  If not specified, then the corresponding flow package must have the same name as this advanced transport package (the name associated with this package in the GWT name file).",
+      ".mwe": "keyword to specify the name of the corresponding flow package.  If not specified, then the corresponding flow package must have the same name as this advanced transport package (the name associated with this package in the GWE name file)."
+    }
+  },
+  "flow_package_auxiliary_name": {
+    "options": {
+      ".sft": "keyword to specify the name of an auxiliary variable in the corresponding flow package.  If specified, then the simulated concentrations from this advanced transport package will be copied into the auxiliary variable specified with this name.  Note that the flow package must have an auxiliary variable with this name or the program will terminate with an error.  If the flows for this advanced transport package are read from a file, then this option will have no effect.",
+      ".uze": "keyword to specify the name of an auxiliary variable in the corresponding flow package.  If specified, then the simulated temperatures from this advanced transport package will be copied into the auxiliary variable specified with this name.  Note that the flow package must have an auxiliary variable with this name or the program will terminate with an error.  If the flows for this advanced transport package are read from a file, then this option will have no effect.",
+      ".lkt": "keyword to specify the name of an auxiliary variable in the corresponding flow package.  If specified, then the simulated concentrations from this advanced transport package will be copied into the auxiliary variable specified with this name.  Note that the flow package must have an auxiliary variable with this name or the program will terminate with an error.  If the flows for this advanced transport package are read from a file, then this option will have no effect.",
+      ".lke": "keyword to specify the name of an auxiliary variable in the corresponding flow package.  If specified, then the simulated temperatures from this advanced transport package will be copied into the auxiliary variable specified with this name.  Note that the flow package must have an auxiliary variable with this name or the program will terminate with an error.  If the flows for this advanced transport package are read from a file, then this option will have no effect.",
+      ".sfe": "keyword to specify the name of an auxiliary variable provided in the corresponding flow package (i.e., FLOW\\_PACKAGE\\_NAME).  If specified, then the simulated temperatures from this advanced energy transport package will be copied into the auxiliary variable specified with this name.  Note that the flow package must have an auxiliary variable with this name or the program will terminate with an error.  If the flows for this advanced energy transport package are read from a file, then this option will have no effect.",
+      ".mwt": "keyword to specify the name of an auxiliary variable in the corresponding flow package.  If specified, then the simulated concentrations from this advanced transport package will be copied into the auxiliary variable specified with this name.  Note that the flow package must have an auxiliary variable with this name or the program will terminate with an error.  If the flows for this advanced transport package are read from a file, then this option will have no effect.",
+      ".uzt": "keyword to specify the name of an auxiliary variable in the corresponding flow package.  If specified, then the simulated concentrations from this advanced transport package will be copied into the auxiliary variable specified with this name.  Note that the flow package must have an auxiliary variable with this name or the program will terminate with an error.  If the flows for this advanced transport package are read from a file, then this option will have no effect.",
+      ".mwe": "keyword to specify the name of an auxiliary variable in the corresponding flow package.  If specified, then the simulated temperatures from this advanced transport package will be copied into the auxiliary variable specified with this name.  Note that the flow package must have an auxiliary variable with this name or the program will terminate with an error.  If the flows for this advanced transport package are read from a file, then this option will have no effect."
+    }
+  },
+  "print_concentration": {
+    "options": {
+      ".sft": "keyword to indicate that the list of reach concentration will be printed to the listing file for every stress period in which ``CONCENTRATION PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_CONCENTRATION is specified, then concentration are printed for the last time step of each stress period.",
+      ".lkt": "keyword to indicate that the list of lake concentration will be printed to the listing file for every stress period in which ``CONCENTRATION PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_CONCENTRATION is specified, then concentration are printed for the last time step of each stress period.",
+      ".mwt": "keyword to indicate that the list of well concentration will be printed to the listing file for every stress period in which ``CONCENTRATION PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_CONCENTRATION is specified, then concentration are printed for the last time step of each stress period.",
+      ".uzt": "keyword to indicate that the list of UZF cell concentration will be printed to the listing file for every stress period in which ``CONCENTRATION PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_CONCENTRATION is specified, then concentration are printed for the last time step of each stress period."
+    }
+  },
+  "status": {
+    "period": {
+      ".sft": "keyword option to define reach status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that concentration will be calculated for the reach.  If a reach is inactive, then there will be no solute mass fluxes into or out of the reach and the inactive value will be written for the reach concentration.  If a reach is constant, then the concentration for the reach will be fixed at the user specified value.",
+      ".uze": "keyword option to define UZF cell status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that temperature will be calculated for the UZF cell.  If a UZF cell is inactive, then there will be no energy fluxes into or out of the UZF cell and the inactive value will be written for the UZF cell temperature.  If a UZF cell is constant, then the temperature for the UZF cell will be fixed at the user specified value.",
+      ".lak": "keyword option to define lake status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE.",
+      ".lkt": "keyword option to define lake status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that concentration will be calculated for the lake.  If a lake is inactive, then there will be no solute mass fluxes into or out of the lake and the inactive value will be written for the lake concentration.  If a lake is constant, then the concentration for the lake will be fixed at the user specified value.",
+      ".lke": "keyword option to define lake status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that temperature will be calculated for the lake.  If a lake is inactive, then there will be no energy fluxes into or out of the lake and the inactive value will be written for the lake temperature.  If a lake is constant, then the temperature for the lake will be fixed at the user specified value.",
+      ".sfe": "keyword option to define reach status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that temperature will be calculated for the reach.  If a reach is inactive, then there will be no energy fluxes into or out of the reach and the inactive value will be written for the reach temperature.  If a reach is constant, then the temperature for the reach will be fixed at the user specified value.",
+      ".mwt": "keyword option to define well status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that concentration will be calculated for the well.  If a well is inactive, then there will be no solute mass fluxes into or out of the well and the inactive value will be written for the well concentration.  If a well is constant, then the concentration for the well will be fixed at the user specified value.",
+      ".sfr": "keyword option to define stream reach status.  STATUS can be ACTIVE, INACTIVE, or SIMPLE. The SIMPLE STATUS option simulates streamflow using a user-specified stage for a reach or a stage set to the top of the reach (depth = 0). In cases where the simulated leakage calculated using the specified stage exceeds the sum of inflows to the reach, the stage is set to the top of the reach and leakage is set equal to the sum of inflows. Upstream fractions should be changed using the UPSTREAM\\_FRACTION SFRSETTING if the status for one or more reaches is changed to ACTIVE or INACTIVE. For example, if one of two downstream connections for a reach is inactivated, the upstream fraction for the active and inactive downstream reach should be changed to 1.0 and 0.0, respectively, to ensure that the active reach receives all of the downstream outflow from the upstream reach. By default, STATUS is ACTIVE.",
+      ".maw": "keyword option to define well status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE.",
+      ".uzt": "keyword option to define UZF cell status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that concentration will be calculated for the UZF cell.  If a UZF cell is inactive, then there will be no solute mass fluxes into or out of the UZF cell and the inactive value will be written for the UZF cell concentration.  If a UZF cell is constant, then the concentration for the UZF cell will be fixed at the user specified value.",
+      ".mwe": "keyword option to define well status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that temperature will be calculated for the well.  If a well is inactive, then there will be no solute mass fluxes into or out of the well and the inactive value will be written for the well temperature.  If a well is constant, then the temperature for the well will be fixed at the user specified value."
+    }
+  },
+  "rainfall": {
+    "period": {
+      ".sft": "real or character value that defines the rainfall solute concentration $(ML^{-3})$ for the reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      ".lak": "real or character value that defines the rainfall rate $(LT^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      ".lkt": "real or character value that defines the rainfall solute concentration $(ML^{-3})$ for the lake. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      ".lke": "real or character value that defines the rainfall temperature for the lake. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      ".sfe": "real or character value that defines the rainfall temperature $(e.g.,\\:^{\\circ}C\\:or\\:^{\\circ}F)$ for the reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      ".sfr": "real or character value that defines the  volumetric rate per unit area of water added by precipitation directly on the streamflow routing reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, rainfall  rates are zero for each reach."
+    }
+  },
+  "evaporation": {
+    "period": {
+      ".sft": "real or character value that defines the concentration of evaporated water $(ML^{-3})$ for the reach. If this concentration value is larger than the simulated concentration in the reach, then the evaporated water will be removed at the same concentration as the reach.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      ".lak": "real or character value that defines the maximum evaporation rate $(LT^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      ".lkt": "real or character value that defines the concentration of evaporated water $(ML^{-3})$ for the lake. If this concentration value is larger than the simulated concentration in the lake, then the evaporated water will be removed at the same concentration as the lake.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      ".lke": "use of the EVAPORATION keyword is allowed in the LKE package; however, the specified value is not currently used in LKE calculations.  Instead, the latent heat of evaporation is multiplied by the simulated evaporation rate for determining the thermal energy lost from a stream reach.",
+      ".sfe": "use of the EVAPORATION keyword is allowed in the SFE package; however, the specified value is not currently used in SFE calculations.  Instead, the latent heat of evaporation is multiplied by the simulated evaporation rate for determining the thermal energy lost from a stream reach.",
+      ".sfr": "real or character value that defines the volumetric rate per unit area of water subtracted by evaporation from the streamflow routing reach. A positive evaporation rate should be provided. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. If the volumetric evaporation rate for a reach exceeds the sources of water to the reach (upstream and specified inflows, rainfall, and runoff but excluding groundwater leakage into the reach) the volumetric evaporation rate is limited to the sources of water to the reach. By default, evaporation rates are zero for each reach."
+    }
+  },
+  "runoff": {
+    "period": {
+      ".sft": "real or character value that defines the concentration of runoff $(ML^{-3})$ for the reach. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      ".lak": "real or character value that defines the runoff rate $(L^3 T^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      ".lkt": "real or character value that defines the concentration of runoff $(ML^{-3})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      ".sfe": "real or character value that defines the temperature of runoff $(e.g.,\\:^{\\circ}C\\:or\\:^{\\circ}F)$ for the reach.  Users are free to use whatever temperature scale they want, which might include negative temperatures.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      ".sfr": "real or character value that defines the volumetric rate of diffuse overland runoff that enters the streamflow routing reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. If the volumetric runoff rate for a reach is negative and exceeds inflows to the reach (upstream and specified inflows, and rainfall but excluding groundwater leakage into the reach) the volumetric runoff rate is limited to inflows to the reach and the volumetric evaporation rate for the reach is set to zero. By default, runoff rates are zero for each reach."
+    }
+  },
+  "inflow": {
+    "period": {
+      ".sft": "real or character value that defines the concentration of inflow $(ML^{-3})$ for the reach. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      ".lak": "real or character value that defines the volumetric inflow rate $(L^3 T^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, inflow rates are zero for each lake.",
+      ".sfe": "real or character value that defines the temperature of inflow $(e.g.,\\:^{\\circ}C\\:or\\:^{\\circ}F)$ for the reach. Users are free to use whatever temperature scale they want, which might include negative temperatures.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      ".sfr": "real or character value that defines the volumetric inflow rate for the streamflow routing reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, inflow rates are zero for each reach."
+    }
+  },
+  "viscref": {
+    "options": {
+      ".vsc": "fluid reference viscosity used in the equation of state.  This value is set to 1.0 if not specified as an option."
+    }
+  },
+  "temperature_species_name": {
+    "options": {
+      ".vsc": "string used to identify the auxspeciesname in PACKAGEDATA that corresponds to the temperature species.  There can be only one occurrence of this temperature species name in the PACKAGEDATA block or the program will terminate with an error.  This value has no effect if viscosity does not depend on temperature."
+    }
+  },
+  "thermal_formulation": {
+    "options": {
+      ".vsc": "may be used for specifying which viscosity formulation to use for the temperature species. Can be either LINEAR or NONLINEAR. The LINEAR viscosity formulation is the default."
+    }
+  },
+  "thermal_a2": {
+    "options": {
+      ".vsc": "is an empirical parameter specified by the user for calculating viscosity using a nonlinear formulation.  If A2 is not specified, a default value of 10.0 is assigned (Voss, 1984). "
+    }
+  },
+  "thermal_a3": {
+    "options": {
+      ".vsc": "is an empirical parameter specified by the user for calculating viscosity using a nonlinear formulation.  If A3 is not specified, a default value of 248.37 is assigned (Voss, 1984). "
+    }
+  },
+  "thermal_a4": {
+    "options": {
+      ".vsc": "is an empirical parameter specified by the user for calculating viscosity using a nonlinear formulation.  If A4 is not specified, a default value of 133.15 is assigned (Voss, 1984). "
+    }
+  },
+  "viscosity": {
+    "options": {
+      ".vsc": "keyword to specify that record corresponds to viscosity."
+    }
+  },
+  "nviscspecies": {
+    "dimensions": {
+      ".vsc": "number of species used in the viscosity equation of state.  If either concentrations or temperature (or both) are used to update viscosity then then nrhospecies needs to be at least one."
+    }
+  },
+  "flow_imbalance_correction": {
+    "options": {
+      ".fmi": "correct for an imbalance in flows by assuming that any residual flow error comes in or leaves at the concentration of the cell.  When this option is activated, the GWT Model budget written to the listing file will contain two additional entries: FLOW-ERROR and FLOW-CORRECTION.  These two entries will be equal but opposite in sign.  The FLOW-CORRECTION term is a mass flow that is added to offset the error caused by an imprecise flow balance.  If these terms are not relatively small, the flow model should be rerun with stricter convergence tolerances."
+    }
+  },
+  "scheme": {
+    "options": {
+      ".adv": "scheme used to solve the advection term.  Can be upstream, central, or TVD.  If not specified, upstream weighting is the default weighting scheme."
+    }
+  },
+  "alternative_cell_averaging": {
+    "options": {
+      ".npf": "is a text keyword to indicate that an alternative method will be used for calculating the conductance for horizontal cell connections.  The text value for ALTERNATIVE\\_CELL\\_AVERAGING can be ``LOGARITHMIC'', ``AMT-LMK'', or ``AMT-HMK''.  ``AMT-LMK'' signifies that the conductance will be calculated using arithmetic-mean thickness and logarithmic-mean hydraulic conductivity.  ``AMT-HMK'' signifies that the conductance will be calculated using arithmetic-mean thickness and harmonic-mean hydraulic conductivity. If the user does not specify a value for ALTERNATIVE\\_CELL\\_AVERAGING, then the harmonic-mean method will be used.  This option cannot be used if the XT3D option is invoked."
+    }
+  },
+  "thickstrt": {
+    "options": {
+      ".npf": "indicates that cells having a negative ICELLTYPE are confined, and their cell thickness for conductance calculations will be computed as STRT-BOT rather than TOP-BOT.  This option should be used with caution as it only affects conductance calculations in the NPF Package."
+    }
+  },
+  "cvoptions": {
+    "options": {
+      ".npf": "none",
+      ".gwfgwf": "none"
+    }
+  },
+  "variablecv": {
+    "options": {
+      ".npf": "keyword to indicate that the vertical conductance will be calculated using the saturated thickness and properties of the overlying cell and the thickness and properties of the underlying cell.  If the DEWATERED keyword is also specified, then the vertical conductance is calculated using only the saturated thickness and properties of the overlying cell if the head in the underlying cell is below its top.  If these keywords are not specified, then the default condition is to calculate the vertical conductance at the start of the simulation using the initial head and the cell properties.  The vertical conductance remains constant for the entire simulation.",
+      ".gwfgwf": "keyword to indicate that the vertical conductance will be calculated using the saturated thickness and properties of the overlying cell and the thickness and properties of the underlying cell.  If the DEWATERED keyword is also specified, then the vertical conductance is calculated using only the saturated thickness and properties of the overlying cell if the head in the underlying cell is below its top.  If these keywords are not specified, then the default condition is to calculate the vertical conductance at the start of the simulation using the initial head and the cell properties.  The vertical conductance remains constant for the entire simulation."
+    }
+  },
+  "dewatered": {
+    "options": {
+      ".npf": "If the DEWATERED keyword is specified, then the vertical conductance is calculated using only the saturated thickness and properties of the overlying cell if the head in the underlying cell is below its top.",
+      ".gwfgwf": "If the DEWATERED keyword is specified, then the vertical conductance is calculated using only the saturated thickness and properties of the overlying cell if the head in the underlying cell is below its top."
+    }
+  },
+  "perched": {
+    "options": {
+      ".npf": "keyword to indicate that when a cell is overlying a dewatered convertible cell, the head difference used in Darcy's Law is equal to the head in the overlying cell minus the bottom elevation of the overlying cell.  If not specified, then the default is to use the head difference between the two cells."
+    }
+  },
+  "rewet": {
+    "options": {
+      ".npf": "activates model rewetting.  Rewetting is off by default."
+    }
+  },
+  "wetfct": {
+    "options": {
+      ".npf": "is a keyword and factor that is included in the calculation of the head that is initially established at a cell when that cell is converted from dry to wet."
+    }
+  },
+  "iwetit": {
+    "options": {
+      ".npf": "is a keyword and iteration interval for attempting to wet cells. Wetting is attempted every IWETIT iteration. This applies to outer iterations and not inner iterations. If IWETIT is specified as zero or less, then the value is changed to 1."
+    }
+  },
+  "ihdwet": {
+    "options": {
+      ".npf": "is a keyword and integer flag that determines which equation is used to define the initial head at cells that become wet.  If IHDWET is 0, h = BOT + WETFCT (hm - BOT). If IHDWET is not 0, h = BOT + WETFCT (THRESH)."
+    }
+  },
+  "xt3doptions": {
+    "options": {
+      ".npf": "none"
+    }
+  },
+  "xt3d": {
+    "options": {
+      ".npf": "keyword indicating that the XT3D formulation will be used.  If the RHS keyword is also included, then the XT3D additional terms will be added to the right-hand side.  If the RHS keyword is excluded, then the XT3D terms will be put into the coefficient matrix.  Use of XT3D will substantially increase the computational effort, but will result in improved accuracy for anisotropic conductivity fields and for unstructured grids in which the CVFD requirement is violated.  XT3D requires additional information about the shapes of grid cells.  If XT3D is active and the DISU Package is used, then the user will need to provide in the DISU Package the angldegx array in the CONNECTIONDATA block and the VERTICES and CELL2D blocks.",
+      ".gwfgwf": "keyword that activates the XT3D formulation between the cells connected with this GWF-GWF Exchange."
+    }
+  },
+  "rhs": {
+    "options": {
+      ".npf": "If the RHS keyword is also included, then the XT3D additional terms will be added to the right-hand side.  If the RHS keyword is excluded, then the XT3D terms will be put into the coefficient matrix."
+    }
+  },
+  "save_specific_discharge": {
+    "options": {
+      ".npf": "keyword to indicate that x, y, and z components of specific discharge will be calculated at cell centers and written to the budget file, which is specified with ``BUDGET SAVE FILE'' in Output Control.  If this option is activated, then additional information may be required in the discretization packages and the GWF Exchange package (if GWF models are coupled).  Specifically, ANGLDEGX must be specified in the CONNECTIONDATA block of the DISU Package; ANGLDEGX must also be specified for the GWF Exchange as an auxiliary variable."
+    }
+  },
+  "save_saturation": {
+    "options": {
+      ".npf": "keyword to indicate that cell saturation will be written to the budget file, which is specified with ``BUDGET SAVE FILE'' in Output Control.  Saturation will be saved to the budget file as an auxiliary variable saved with the DATA-SAT text label.  Saturation is a cell variable that ranges from zero to one and can be used by post processing programs to determine how much of a cell volume is saturated.  If ICELLTYPE is 0, then saturation is always one."
+    }
+  },
+  "k22overk": {
+    "options": {
+      ".npf": "keyword to indicate that specified K22 is a ratio of K22 divided by K.  If this option is specified, then the K22 array entered in the NPF Package will be multiplied by K after being read."
+    }
+  },
+  "k33overk": {
+    "options": {
+      ".npf": "keyword to indicate that specified K33 is a ratio of K33 divided by K.  If this option is specified, then the K33 array entered in the NPF Package will be multiplied by K after being read."
+    }
+  },
+  "tvk6": {
+    "options": {
+      ".npf": "keyword to specify that record corresponds to a time-varying hydraulic conductivity (TVK) file.  The behavior of TVK and a description of the input file is provided separately."
+    }
+  },
+  "dev_no_newton": {
+    "options": {
+      ".npf": "turn off Newton for unconfined cells"
+    }
+  },
+  "dev_omega": {
+    "options": {
+      ".npf": "set saturation omega value"
+    }
+  },
+  "icelltype": {
+    "griddata": {
+      ".npf": "flag for each cell that specifies how saturated thickness is treated.  0 means saturated thickness is held constant;  $>$0 means saturated thickness varies with computed head when head is below the cell top; $<$0 means saturated thickness varies with computed head unless the THICKSTRT option is in effect.  When THICKSTRT is in effect, a negative value for ICELLTYPE indicates that the saturated thickness value used in conductance calculations in the NPF Package will be computed as STRT-BOT and held constant.  If the THICKSTRT option is not in effect, then negative values provided by the user for ICELLTYPE are automatically reassigned by the program to a value of one."
+    }
+  },
+  "k": {
+    "griddata": {
+      ".npf": "is the hydraulic conductivity.  For the common case in which the user would like to specify the horizontal hydraulic conductivity and the vertical hydraulic conductivity, then K should be assigned as the horizontal hydraulic conductivity, K33 should be assigned as the vertical hydraulic conductivity, and K22 and the three rotation angles should not be specified.  When more sophisticated anisotropy is required, then K corresponds to the K11 hydraulic conductivity axis.  All included cells (IDOMAIN $>$ 0) must have a K value greater than zero."
+    },
+    "period": {
+      ".tvk": "is the new value to be assigned as the cell's hydraulic conductivity from the start of the specified stress period, as per K in the NPF package.  If the OPTIONS block includes a TS6 entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+    }
+  },
+  "k22": {
+    "griddata": {
+      ".npf": "is the hydraulic conductivity of the second ellipsoid axis (or the ratio of K22/K if the K22OVERK option is specified); for an unrotated case this is the hydraulic conductivity in the y direction.  If K22 is not included in the GRIDDATA block, then K22 is set equal to K.  For a regular MODFLOW grid (DIS Package is used) in which no rotation angles are specified, K22 is the hydraulic conductivity along columns in the y direction. For an unstructured DISU grid, the user must assign principal x and y axes and provide the angle for each cell face relative to the assigned x direction.  All included cells (IDOMAIN $>$ 0) must have a K22 value greater than zero."
+    },
+    "period": {
+      ".tvk": "is the new value to be assigned as the cell's hydraulic conductivity of the second ellipsoid axis (or the ratio of K22/K if the K22OVERK NPF package option is specified) from the start of the specified stress period, as per K22 in the NPF package.  For an unrotated case this is the hydraulic conductivity in the y direction.  If the OPTIONS block includes a TS6 entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+    }
+  },
+  "k33": {
+    "griddata": {
+      ".npf": "is the hydraulic conductivity of the third ellipsoid axis (or the ratio of K33/K if the K33OVERK option is specified); for an unrotated case, this is the vertical hydraulic conductivity.  When anisotropy is applied, K33 corresponds to the K33 tensor component.  All included cells (IDOMAIN $>$ 0) must have a K33 value greater than zero."
+    },
+    "period": {
+      ".tvk": "is the new value to be assigned as the cell's hydraulic conductivity of the third ellipsoid axis (or the ratio of K33/K if the K33OVERK NPF package option is specified) from the start of the specified stress period, as per K33 in the NPF package.  For an unrotated case, this is the vertical hydraulic conductivity.  If the OPTIONS block includes a TS6 entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+    }
+  },
+  "angle1": {
+    "griddata": {
+      ".npf": "is a rotation angle of the hydraulic conductivity tensor in degrees. The angle represents the first of three sequential rotations of the hydraulic conductivity ellipsoid. With the K11, K22, and K33 axes of the ellipsoid initially aligned with the x, y, and z coordinate axes, respectively, ANGLE1 rotates the ellipsoid about its K33 axis (within the x - y plane). A positive value represents counter-clockwise rotation when viewed from any point on the positive K33 axis, looking toward the center of the ellipsoid. A value of zero indicates that the K11 axis lies within the x - z plane. If ANGLE1 is not specified, default values of zero are assigned to ANGLE1, ANGLE2, and ANGLE3, in which case the K11, K22, and K33 axes are aligned with the x, y, and z axes, respectively."
+    }
+  },
+  "angle2": {
+    "griddata": {
+      ".npf": "is a rotation angle of the hydraulic conductivity tensor in degrees. The angle represents the second of three sequential rotations of the hydraulic conductivity ellipsoid. Following the rotation by ANGLE1 described above, ANGLE2 rotates the ellipsoid about its K22 axis (out of the x - y plane). An array can be specified for ANGLE2 only if ANGLE1 is also specified. A positive value of ANGLE2 represents clockwise rotation when viewed from any point on the positive K22 axis, looking toward the center of the ellipsoid. A value of zero indicates that the K11 axis lies within the x - y plane. If ANGLE2 is not specified, default values of zero are assigned to ANGLE2 and ANGLE3; connections that are not user-designated as vertical are assumed to be strictly horizontal (that is, to have no z component to their orientation); and connection lengths are based on horizontal distances."
+    }
+  },
+  "angle3": {
+    "griddata": {
+      ".npf": "is a rotation angle of the hydraulic conductivity tensor in degrees. The angle represents the third of three sequential rotations of the hydraulic conductivity ellipsoid. Following the rotations by ANGLE1 and ANGLE2 described above, ANGLE3 rotates the ellipsoid about its K11 axis. An array can be specified for ANGLE3 only if ANGLE1 and ANGLE2 are also specified. An array must be specified for ANGLE3 if ANGLE2 is specified. A positive value of ANGLE3 represents clockwise rotation when viewed from any point on the positive K11 axis, looking toward the center of the ellipsoid. A value of zero indicates that the K22 axis lies within the x - y plane."
+    }
+  },
+  "wetdry": {
+    "griddata": {
+      ".npf": "is a combination of the wetting threshold and a flag to indicate which neighboring cells can cause a cell to become wet. If WETDRY $<$ 0, only a cell below a dry cell can cause the cell to become wet. If WETDRY $>$ 0, the cell below a dry cell and horizontally adjacent cells can cause a cell to become wet. If WETDRY is 0, the cell cannot be wetted. The absolute value of WETDRY is the wetting threshold. When the sum of BOT and the absolute value of WETDRY at a dry cell is equaled or exceeded by the head at an adjacent cell, the cell is wetted.  WETDRY must be specified if ``REWET'' is specified in the OPTIONS block.  If ``REWET'' is not specified in the options block, then WETDRY can be entered, and memory will be allocated for it, even though it is not used."
+    }
+  },
+  "porosity": {
+    "griddata": {
+      ".mip": "is the aquifer porosity.",
+      ".mst": "is the mobile domain porosity, defined as the mobile domain pore volume per mobile domain volume.  Additional information on porosity within the context of mobile and immobile domain transport simulations is included in the MODFLOW 6 Supplemental Technical Information document. ",
+      ".est": "is the mobile domain porosity, defined as the mobile domain pore volume per mobile domain volume.  The GWE model does not support the concept of an immobile domain in the context of heat transport. ",
+      ".ist": "porosity of the immobile domain specified as the immobile domain pore volume per immobile domain volume."
+    }
+  },
+  "retfactor": {
+    "griddata": {
+      ".mip": "is a real value by which velocity is divided within a given cell.  RETFACTOR can be used to account for solute retardation, i.e., the apparent effect of linear sorption on the velocity of particles that track solute advection.  RETFACTOR may be assigned any real value.  A RETFACTOR value greater than 1 represents particle retardation (slowing), and a value of 1 represents no retardation.  The effect of specifying a RETFACTOR value for each cell is the same as the effect of directly multiplying the POROSITY in each cell by the proposed RETFACTOR value for each cell.  RETFACTOR allows conceptual isolation of effects such as retardation from the effect of porosity.  The default value is 1."
+    }
+  },
+  "izone": {
+    "griddata": {
+      ".mip": "is an integer zone number assigned to each cell.  IZONE may be positive, negative, or zero.  The current cell's zone number is recorded with each particle track datum.  If a PRP package's ISTOPZONE option is set to any value other than zero, particles released by that PRP Package terminate if they enter a cell whose IZONE value matches ISTOPZONE.  If ISTOPZONE is not specified or is set to zero in a PRP Package, IZONE has no effect on the termination of particles released by that PRP Package.  Each PRP Package may configure a single ISTOPZONE value."
+    }
+  },
+  "print_temperature": {
+    "options": {
+      ".uze": "keyword to indicate that the list of UZF cell temperatures will be printed to the listing file for every stress period in which ``TEMPERATURE PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_TEMPERATURE is specified, then temperatures are printed for the last time step of each stress period.",
+      ".lke": "keyword to indicate that the list of lake temperature will be printed to the listing file for every stress period in which ``TEMPERATURE PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_TEMPERATURE is specified, then temperature are printed for the last time step of each stress period.",
+      ".sfe": "keyword to indicate that the list of reach temperatures will be printed to the listing file for every stress period in which ``TEMPERATURE PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_TEMPERATURE is specified, then temperatures are printed for the last time step of each stress period.",
+      ".mwe": "keyword to indicate that the list of well temperature will be printed to the listing file for every stress period in which ``TEMPERATURE PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_TEMPERATURE is specified, then temperature are printed for the last time step of each stress period."
+    }
+  },
+  "infiltration": {
+    "period": {
+      ".uze": "real or character value that defines the temperature of the infiltration $(e.g.,\\:^{\\circ}C\\:or\\:^{\\circ}F)$ for the UZF cell. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      ".uzt": "real or character value that defines the infiltration solute concentration $(ML^{-3})$ for the UZF cell. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+    }
+  },
+  "uzet": {
+    "period": {
+      ".uze": "real or character value that states what fraction of the simulated unsaturated zone evapotranspiration is associated with evaporation.  The evaporative losses from the unsaturated zone moisture content will have an evaporative cooling effect on the GWE cell from which the evaporation originated. If this value is larger than 1, then it will be reset to 1.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      ".uzt": "real or character value that defines the concentration of unsaturated zone evapotranspiration water $(ML^{-3})$ for the UZF cell. If this concentration value is larger than the simulated concentration in the UZF cell, then the unsaturated zone ET water will be removed at the same concentration as the UZF cell.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+    }
+  },
+  "continue": {
+    "options": {
+      ".nam": "keyword flag to indicate that the simulation should continue even if one or more solutions do not converge."
+    }
+  },
+  "nocheck": {
+    "options": {
+      ".nam": "keyword flag to indicate that the model input check routines should not be called prior to each time step. Checks are performed by default."
+    }
+  },
+  "memory_print_option": {
+    "options": {
+      ".nam": "is a flag that controls printing of detailed memory manager usage to the end of the simulation list file.  NONE means do not print detailed information. SUMMARY means print only the total memory for each simulation component. ALL means print information for each variable stored in the memory manager. NONE is default if MEMORY\\_PRINT\\_OPTION is not specified."
+    }
+  },
+  "profile_option": {
+    "options": {
+      ".nam": "is a flag that controls performance profiling and reporting.  NONE disables profiling. SUMMARY means to measure and print a coarse performance profile. DETAIL means collect and print information with the highest resolution available. NONE is default if PROFILE\\_OPTION is not specified."
+    }
+  },
+  "maxerrors": {
+    "options": {
+      ".nam": "maximum number of errors that will be stored and printed."
+    }
+  },
+  "hpc6": {
+    "options": {
+      ".nam": "keyword to specify that record corresponds to a hpc file."
+    }
+  },
+  "tdis6": {
+    "timing": {
+      ".nam": "is the name of the Temporal Discretization (TDIS) Input File."
+    }
+  },
+  "models": {
+    "models": {
+      ".nam": "is the list of model types, model name files, and model names."
+    }
+  },
+  "exchanges": {
+    "exchanges": {
+      ".nam": "is the list of exchange types, exchange files, and model names."
+    }
+  },
+  "mxiter": {
+    "solutiongroup": {
+      ".nam": "is the maximum number of outer iterations for this solution group.  The default value is 1.  If there is only one solution in the solution group, then MXITER must be 1."
+    }
+  },
+  "solutiongroup": {
+    "solutiongroup": {
+      ".nam": "is the list of solution types and models in the solution."
+    }
+  },
+  "dev_exit_solve_method": {
+    "options": {
+      ".prp": "the method for iterative solution of particle exit location and time in the generalized Pollock's method.  0 default, 1 Brent, 2 Chandrupatla.  The default is Brent's method."
+    }
+  },
+  "exit_solve_tolerance": {
+    "options": {
+      ".prp": "the convergence tolerance for iterative solution of particle exit location and time in the generalized Pollock's method.  A value of 0.00001 works well for many problems, but the value that strikes the best balance between accuracy and runtime is problem-dependent."
+    }
+  },
+  "local_z": {
+    "options": {
+      ".prp": "indicates that ``zrpt'' defines the local z coordinate of the release point within the cell, with value of 0 at the bottom and 1 at the top of the cell.  If the cell is partially saturated at release time, the top of the cell is considered to be the water table elevation (the head in the cell) rather than the top defined by the user."
+    }
+  },
+  "extend_tracking": {
+    "options": {
+      ".prp": "indicates that particles should be tracked beyond the end of the simulation's final time step (using that time step's flows) until particles terminate or reach a specified stop time.  By default, particles are terminated at the end of the simulation's final time step."
+    }
+  },
+  "track": {
+    "options": {
+      ".prp": "keyword to specify that record corresponds to a binary track output file.  Each PRP Package may have a distinct binary track output file.",
+      ".oc": "keyword to specify that record corresponds to a binary track file.  Each PRT Model's OC Package may have only one binary track output file."
+    }
+  },
+  "trackcsv": {
+    "options": {
+      ".prp": "keyword to specify that record corresponds to a CSV track output file.  Each PRP Package may have a distinct CSV track output file.",
+      ".oc": "keyword to specify that record corresponds to a CSV track file.  Each PRT Model's OC Package may have only one CSV track file."
+    }
+  },
+  "stoptime": {
+    "options": {
+      ".prp": "real value defining the maximum simulation time to which particles in the package can be tracked.  Particles that have not terminated earlier due to another termination condition will terminate when simulation time STOPTIME is reached.  If the last stress period in the simulation consists of more than one time step, particles will not be tracked past the ending time of the last stress period, regardless of STOPTIME.  If the EXTEND\\_TRACKING option is enabled and the last stress period in the simulation is steady-state, the simulation ending time will not limit the time to which particles can be tracked, but STOPTIME and STOPTRAVELTIME will continue to apply.  If STOPTIME and STOPTRAVELTIME are both provided, particles will be stopped if either is reached."
+    }
+  },
+  "stoptraveltime": {
+    "options": {
+      ".prp": "real value defining the maximum travel time over which particles in the model can be tracked.  Particles that have not terminated earlier due to another termination condition will terminate when their travel time reaches STOPTRAVELTIME.  If the last stress period in the simulation consists of more than one time step, particles will not be tracked past the ending time of the last stress period, regardless of STOPTRAVELTIME.  If the EXTEND\\_TRACKING option is enabled and the last stress period in the simulation is steady-state, the simulation ending time will not limit the time to which particles can be tracked, but STOPTIME and STOPTRAVELTIME will continue to apply.  If STOPTIME and STOPTRAVELTIME are both provided, particles will be stopped if either is reached."
+    }
+  },
+  "stop_at_weak_sink": {
+    "options": {
+      ".prp": "is a text keyword to indicate that a particle is to terminate when it enters a cell that is a weak sink.  By default, particles are allowed to pass though cells that are weak sinks."
+    }
+  },
+  "istopzone": {
+    "options": {
+      ".prp": "integer value defining the stop zone number.  If cells have been assigned IZONE values in the GRIDDATA block, a particle terminates if it enters a cell whose IZONE value matches ISTOPZONE.  An ISTOPZONE value of zero indicates that there is no stop zone.  The default value is zero."
+    }
+  },
+  "drape": {
+    "options": {
+      ".prp": "is a text keyword to indicate that if a particle's release point is in a cell that happens to be inactive at release time, the particle is to be moved to the topmost active cell below it, if any. By default, a particle is not released into the simulation if its release point's cell is inactive at release time."
+    }
+  },
+  "dry_tracking_method": {
+    "options": {
+      ".prp": "is a string indicating how particles should behave in dry-but-active cells (as can occur with the Newton formulation).  The value can be ``DROP'', ``STOP'', or ``STAY''.  The default is ``DROP'', which passes particles vertically and instantaneously to the water table. ``STOP'' causes particles to terminate. ``STAY'' causes particles to remain stationary but active."
+    }
+  },
+  "dev_forceternary": {
+    "options": {
+      ".prp": "force use of the ternary tracking method regardless of cell type in DISV grids."
+    }
+  },
+  "release_time_tolerance": {
+    "options": {
+      ".prp": "real number indicating the tolerance within which to consider consecutive release times coincident. Coincident release times will be merged into a single release time. The default is $\\epsilon \\times 10^{11}$, where $\\epsilon$ is machine precision."
+    }
+  },
+  "release_time_frequency": {
+    "options": {
+      ".prp": "real number indicating the time frequency at which to release particles. This option can be used to schedule releases at a regular interval for the duration of the simulation, starting at the simulation start time. The release schedule is the union of this option, the RELEASETIMES block, and PERIOD block RELEASESETTING selections. If none of these are provided, a single release time is configured at the beginning of the first time step of the simulation's first stress period."
+    }
+  },
+  "nreleasepts": {
+    "dimensions": {
+      ".prp": "is the number of particle release points."
+    }
+  },
+  "nreleasetimes": {
+    "dimensions": {
+      ".prp": "is the number of particle release times specified in the RELEASETIMES block. This is not necessarily the total number of release times; release times are the union of RELEASE\\_TIME\\_FREQUENCY, RELEASETIMES block, and PERIOD block RELEASESETTING selections."
+    }
+  },
+  "fraction": {
+    "period": {
+      ".prp": "release particles after the specified fraction of the time step has elapsed. If FRACTION is not set, particles are released at the start of the specified time step(s). FRACTION must be a single value when used with ALL, FIRST, or FREQUENCY. When used with STEPS, FRACTION may be a single value or an array of the same length as STEPS. If a single FRACTION value is provided with STEPS, the fraction applies to all steps. NOTE: The FRACTION option has been removed. For fine control over release timing, specify times explicitly using the RELEASETIMES block."
+    }
+  },
+  "list": {
+    "options": {
+      ".nam": "is name of the listing file to create for this GWE model.  If not specified, then the name of the list file will be the basename of the GWE model name file and the ``.lst'' extension.  For example, if the GWE name file is called ``my.model.nam'' then the list file will be called ``my.model.lst''."
+    }
+  },
+  "name": {
+    "attributes": {
+      ".tas": "xxx"
+    }
+  },
+  "method": {
+    "attributes": {
+      ".tas": "xxx",
+      ".ts": "xxx"
+    }
+  },
+  "sfac": {
+    "attributes": {
+      ".tas": "xxx"
+    }
+  },
+  "mover": {
+    "options": {
+      ".api": "keyword to indicate that this instance of the api boundary Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.",
+      ".drn": "keyword to indicate that this instance of the Drain Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.",
+      ".wel": "keyword to indicate that this instance of the Well Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.",
+      ".lak": "keyword to indicate that this instance of the LAK Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.",
+      ".ghb": "keyword to indicate that this instance of the General-Head Boundary Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.",
+      ".sfr": "keyword to indicate that this instance of the SFR Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.",
+      ".riv": "keyword to indicate that this instance of the River Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.",
+      ".uzf": "keyword to indicate that this instance of the UZF Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.",
+      ".maw": "keyword to indicate that this instance of the MAW Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water."
+    }
+  },
+  "nrow": {
+    "dimensions": {
+      ".dis2d": "is the number of rows in the model grid.",
+      ".laktab": "integer value specifying the number of rows in the lake table. There must be NROW rows of data in the TABLE block.",
+      ".dis": "is the number of rows in the model grid.",
+      ".sfrtab": "integer value specifying the number of rows in the reach cross-section table. There must be NROW rows of data in the TABLE block."
+    }
+  },
+  "ncol": {
+    "dimensions": {
+      ".dis2d": "is the number of columns in the model grid.",
+      ".laktab": "integer value specifying the number of columns in the lake table. There must be NCOL columns of data in the TABLE block. For lakes with HORIZONTAL and/or VERTICAL CTYPE connections, NCOL must be equal to 3. For lakes with EMBEDDEDH or EMBEDDEDV CTYPE connections, NCOL must be equal to 4.",
+      ".dis": "is the number of columns in the model grid.",
+      ".sfrtab": "integer value specifying the number of columns in the reach cross-section table. There must be NCOL columns of data in the TABLE block. NCOL must be equal to 2 if MANFRACTION is not specified or 3 otherwise."
+    }
+  },
+  "delr": {
+    "griddata": {
+      ".dis2d": "is the column spacing in the row direction.",
+      ".dis": "is the column spacing in the row direction."
+    }
+  },
+  "delc": {
+    "griddata": {
+      ".dis2d": "is the row spacing in the column direction.",
+      ".dis": "is the row spacing in the column direction."
+    }
+  },
+  "ncf6": {
+    "options": {
+      ".disv": "keyword to specify that record corresponds to a netcdf configuration (NCF) file.",
+      ".dis": "keyword to specify that record corresponds to a netcdf configuration (NCF) file."
+    }
+  },
+  "nlay": {
+    "dimensions": {
+      ".disv": "is the number of layers in the model grid.",
+      ".dis": "is the number of layers in the model grid."
+    }
+  },
+  "ncpl": {
+    "dimensions": {
+      ".disv": "is the number of cells per layer.  This is a constant value for the grid and it applies to all layers.",
+      ".ncf": "is the number of cells in a projected plane layer."
+    }
+  },
+  "top": {
+    "griddata": {
+      ".disv": "is the top elevation for each cell in the top model layer.",
+      ".dis": "is the top elevation for each cell in the top model layer.",
+      ".disu": "is the top elevation for each cell in the model grid."
+    }
+  },
+  "botm": {
+    "griddata": {
+      ".disv": "is the bottom elevation for each cell.",
+      ".dis": "is the bottom elevation for each cell."
+    }
+  },
+  "newtonoptions": {
+    "options": {
+      ".nam": "none"
+    }
+  },
+  "newton": {
+    "options": {
+      ".nam": "keyword that activates the Newton-Raphson formulation for surface water flow between connected reaches and stress packages that support calculation of Newton-Raphson terms. ",
+      ".gwfgwf": "keyword that activates the Newton-Raphson formulation for groundwater flow between connected, convertible groundwater cells. Cells will not dry when this option is used."
+    }
+  },
+  "under_relaxation": {
+    "options": {
+      ".nam": "keyword that indicates whether the surface water stage in a reach will be under-relaxed when water levels fall below the bottom of the model below any given cell. By default, Newton-Raphson UNDER\\_RELAXATION is not applied."
+    },
+    "nonlinear": {
+      ".ims": "is an optional keyword that defines the nonlinear under-relaxation schemes used. Under-relaxation is also known as dampening, and is used to reduce the size of the calculated dependent variable before proceeding to the next outer iteration.  Under-relaxation can be an effective tool for highly nonlinear models when there are large and often counteracting changes in the calculated dependent variable between successive outer iterations.  By default under-relaxation is not used.  NONE - under-relaxation is not used (default). SIMPLE - Simple under-relaxation scheme with a fixed relaxation factor (UNDER\\_RELAXATION\\_GAMMA) is used.  COOLEY - Cooley under-relaxation scheme is used.  DBD - delta-bar-delta under-relaxation is used.  Note that the under-relaxation schemes are often used in conjunction with problems that use the Newton-Raphson formulation, however, experience has indicated that they also work well for non-Newton problems, such as those with the wet/dry options of MODFLOW 6."
+    }
+  },
+  "print_option": {
+    "options": {
+      ".ims": "is a flag that controls printing of convergence information from the solver.  NONE means print nothing. SUMMARY means print only the total number of iterations and nonlinear residual reduction summaries. ALL means print linear matrix solver convergence information to the solution listing file and model specific linear matrix solver convergence information to each model listing file in addition to SUMMARY information. NONE is default if PRINT\\_OPTION is not specified.",
+      ".pts": "is a flag that controls printing of convergence information from the solver.  NONE means print nothing. SUMMARY means print only the total number of iterations and nonlinear residual reduction summaries. ALL means print linear matrix solver convergence information to the solution listing file and model specific linear matrix solver convergence information to each model listing file in addition to SUMMARY information. NONE is default if PRINT\\_OPTION is not specified."
+    }
+  },
+  "complexity": {
+    "options": {
+      ".ims": "is an optional keyword that defines default non-linear and linear solver parameters.  SIMPLE - indicates that default solver input values will be defined that work well for nearly linear models. This would be used for models that do not include nonlinear stress packages and models that are either confined or consist of a single unconfined layer that is thick enough to contain the water table within a single layer. MODERATE - indicates that default solver input values will be defined that work well for moderately nonlinear models. This would be used for models that include nonlinear stress packages and models that consist of one or more unconfined layers. The MODERATE option should be used when the SIMPLE option does not result in successful convergence.  COMPLEX - indicates that default solver input values will be defined that work well for highly nonlinear models. This would be used for models that include nonlinear stress packages and models that consist of one or more unconfined layers representing complex geology and surface-water/groundwater interaction. The COMPLEX option should be used when the MODERATE option does not result in successful convergence.  Non-linear and linear solver parameters assigned using a specified complexity can be modified in the NONLINEAR and LINEAR blocks. If the COMPLEXITY option is not specified, NONLINEAR and LINEAR variables will be assigned the simple complexity values.",
+      ".pts": "is an optional keyword that defines default non-linear and linear solver parameters.  SIMPLE - indicates that default solver input values will be defined that work well for nearly linear models. This would be used for models that do not include nonlinear stress packages and models that are either confined or consist of a single unconfined layer that is thick enough to contain the water table within a single layer. MODERATE - indicates that default solver input values will be defined that work well for moderately nonlinear models. This would be used for models that include nonlinear stress packages and models that consist of one or more unconfined layers. The MODERATE option should be used when the SIMPLE option does not result in successful convergence.  COMPLEX - indicates that default solver input values will be defined that work well for highly nonlinear models. This would be used for models that include nonlinear stress packages and models that consist of one or more unconfined layers representing complex geology and surface-water/groundwater interaction. The COMPLEX option should be used when the MODERATE option does not result in successful convergence.  Non-linear and linear solver parameters assigned using a specified complexity can be modified in the NONLINEAR and LINEAR blocks. If the COMPLEXITY option is not specified, NONLINEAR and LINEAR variables will be assigned the simple complexity values."
+    }
+  },
+  "csv_output": {
+    "options": {
+      ".ims": "keyword to specify that the record corresponds to the comma separated values solver convergence output.  The CSV\\_OUTPUT option has been deprecated and split into the CSV_OUTER_OUTPUT and CSV_INNER_OUTPUT options.  Starting with MODFLOW 6 version 6.1.1 if the CSV_OUTPUT option is specified, then it is treated as the CSV_OUTER_OUTPUT option.",
+      ".pts": "keyword to specify that the record corresponds to the comma separated values solver convergence output.  The CSV\\_OUTPUT option has been deprecated and split into the CSV_OUTER_OUTPUT and CSV_INNER_OUTPUT options.  Starting with MODFLOW 6 version 6.1.1 if the CSV_OUTPUT option is specified, then it is treated as the CSV_OUTER_OUTPUT option."
+    }
+  },
+  "csv_outer_output": {
+    "options": {
+      ".ims": "keyword to specify that the record corresponds to the comma separated values outer iteration convergence output.",
+      ".pts": "keyword to specify that the record corresponds to the comma separated values outer iteration convergence output."
+    }
+  },
+  "csv_inner_output": {
+    "options": {
+      ".ims": "keyword to specify that the record corresponds to the comma separated values solver convergence output.",
+      ".pts": "keyword to specify that the record corresponds to the comma separated values solver convergence output."
+    }
+  },
+  "no_ptc": {
+    "options": {
+      ".ims": "is a flag that is used to disable pseudo-transient continuation (PTC). Option only applies to steady-state stress periods for models using the Newton-Raphson formulation. For many problems, PTC can significantly improve convergence behavior for steady-state simulations, and for this reason it is active by default.  In some cases, however, PTC can worsen the convergence behavior, especially when the initial conditions are similar to the solution.  When the initial conditions are similar to, or exactly the same as, the solution and convergence is slow, then the NO\\_PTC FIRST option should be used to deactivate PTC for the first stress period.  The NO\\_PTC ALL option should also be used in order to compare convergence behavior with other MODFLOW versions, as PTC is only available in MODFLOW 6.",
+      ".pts": "is a flag that is used to disable pseudo-transient continuation (PTC). Option only applies to steady-state stress periods for models using the Newton-Raphson formulation. For many problems, PTC can significantly improve convergence behavior for steady-state simulations, and for this reason it is active by default.  In some cases, however, PTC can worsen the convergence behavior, especially when the initial conditions are similar to the solution.  When the initial conditions are similar to, or exactly the same as, the solution and convergence is slow, then the NO\\_PTC FIRST option should be used to deactivate PTC for the first stress period.  The NO\\_PTC ALL option should also be used in order to compare convergence behavior with other MODFLOW versions, as PTC is only available in MODFLOW 6."
+    }
+  },
+  "ats_outer_maximum_fraction": {
+    "options": {
+      ".ims": "real value defining the fraction of the maximum allowable outer iterations used with the Adaptive Time Step (ATS) capability if it is active.  If this value is set to zero by the user, then this solution will have no effect on ATS behavior.  This value must be greater than or equal to zero and less than or equal to 0.5 or the program will terminate with an error.  If it is not specified by the user, then it is assigned a default value of one third.  When the number of outer iterations for this solution is less than the product of this value and the maximum allowable outer iterations, then ATS will increase the time step length by a factor of DTADJ in the ATS input file.  When the number of outer iterations for this solution is greater than the maximum allowable outer iterations minus the product of this value and the maximum allowable outer iterations, then the ATS (if active) will decrease the time step length by a factor of 1 / DTADJ.",
+      ".pts": "real value defining the fraction of the maximum allowable outer iterations used with the Adaptive Time Step (ATS) capability if it is active.  If this value is set to zero by the user, then this solution will have no effect on ATS behavior.  This value must be greater than or equal to zero and less than or equal to 0.5 or the program will terminate with an error.  If it is not specified by the user, then it is assigned a default value of one third.  When the number of outer iterations for this solution is less than the product of this value and the maximum allowable outer iterations, then ATS will increase the time step length by a factor of DTADJ in the ATS input file.  When the number of outer iterations for this solution is greater than the maximum allowable outer iterations minus the product of this value and the maximum allowable outer iterations, then the ATS (if active) will decrease the time step length by a factor of 1 / DTADJ."
+    }
+  },
+  "outer_hclose": {
+    "nonlinear": {
+      ".ims": "real value defining the head change criterion for convergence of the outer (nonlinear) iterations, in units of length. When the maximum absolute value of the head change at all nodes during an iteration is less than or equal to OUTER\\_HCLOSE, iteration stops. Commonly, OUTER\\_HCLOSE equals 0.01.  The OUTER\\_HCLOSE option has been deprecated in favor of the more general OUTER\\_DVCLOSE (for dependent variable), however either one can be specified in order to maintain backward compatibility."
+    }
+  },
+  "outer_dvclose": {
+    "nonlinear": {
+      ".ims": "real value defining the dependent-variable (for example, head) change criterion for convergence of the outer (nonlinear) iterations, in units of the dependent-variable (for example, length for head). When the maximum absolute value of the dependent-variable change at all nodes during an iteration is less than or equal to OUTER\\_DVCLOSE, iteration stops. Commonly, OUTER\\_DVCLOSE equals 0.01. The keyword, OUTER\\_HCLOSE can be still be specified instead of OUTER\\_DVCLOSE for backward compatibility with previous versions of MODFLOW 6 but eventually OUTER\\_HCLOSE will be deprecated and specification of OUTER\\_HCLOSE will cause MODFLOW 6 to terminate with an error."
+    }
+  },
+  "outer_rclosebnd": {
+    "nonlinear": {
+      ".ims": "real value defining the residual tolerance for convergence of model packages that solve a separate equation not solved by the IMS linear solver. This value represents the maximum allowable residual between successive outer iterations at any single model package element. An example of a model package that would use OUTER\\_RCLOSEBND to evaluate convergence is the SFR package which solves a continuity equation for each reach.  The OUTER\\_RCLOSEBND option is deprecated and has no effect on simulation results as of version 6.1.1.  The keyword, OUTER\\_RCLOSEBND can be still be specified for backward compatibility with previous versions of MODFLOW 6 but eventually specification of OUTER\\_RCLOSEBND will cause MODFLOW 6 to terminate with an error."
+    }
+  },
+  "outer_maximum": {
+    "nonlinear": {
+      ".ims": "integer value defining the maximum number of outer (nonlinear) iterations -- that is, calls to the solution routine. For a linear problem OUTER\\_MAXIMUM should be 1."
+    }
+  },
+  "under_relaxation_gamma": {
+    "nonlinear": {
+      ".ims": "real value defining either the relaxation factor for the SIMPLE scheme or the history or memory term factor of the Cooley and delta-bar-delta algorithms. For the SIMPLE scheme, a value of one indicates that there is no under-relaxation and the full head change is applied.  This value can be gradually reduced from one as a way to improve convergence; for well behaved problems, using a value less than one can increase the number of outer iterations required for convergence and needlessly increase run times.  UNDER\\_RELAXATION\\_GAMMA must be greater than zero for the SIMPLE scheme or the program will terminate with an error.  For the Cooley and delta-bar-delta schemes, UNDER\\_RELAXATION\\_GAMMA is a memory term that can range between zero and one. When UNDER\\_RELAXATION\\_GAMMA is zero, only the most recent history (previous iteration value) is maintained. As UNDER\\_RELAXATION\\_GAMMA is increased, past history of iteration changes has greater influence on the memory term. The memory term is maintained as an exponential average of past changes. Retaining some past history can overcome granular behavior in the calculated function surface and therefore helps to overcome cyclic patterns of non-convergence. The value usually ranges from 0.1 to 0.3; a value of 0.2 works well for most problems. UNDER\\_RELAXATION\\_GAMMA only needs to be specified if UNDER\\_RELAXATION is not NONE."
+    }
+  },
+  "under_relaxation_theta": {
+    "nonlinear": {
+      ".ims": "real value defining the reduction factor for the learning rate (under-relaxation term) of the delta-bar-delta algorithm. The value of UNDER\\_RELAXATION\\_THETA is between zero and one. If the change in the dependent-variable (for example, head) is of opposite sign to that of the previous iteration, the under-relaxation term is reduced by a factor of UNDER\\_RELAXATION\\_THETA. The value usually ranges from 0.3 to 0.9; a value of 0.7 works well for most problems. UNDER\\_RELAXATION\\_THETA only needs to be specified if UNDER\\_RELAXATION is DBD."
+    }
+  },
+  "under_relaxation_kappa": {
+    "nonlinear": {
+      ".ims": "real value defining the increment for the learning rate (under-relaxation term) of the delta-bar-delta algorithm. The value of UNDER\\_RELAXATION\\_kappa is between zero and one. If the change in the dependent-variable (for example, head) is of the same sign to that of the previous iteration, the under-relaxation term is increased by an increment of UNDER\\_RELAXATION\\_KAPPA. The value usually ranges from 0.03 to 0.3; a value of 0.1 works well for most problems. UNDER\\_RELAXATION\\_KAPPA only needs to be specified if UNDER\\_RELAXATION is DBD."
+    }
+  },
+  "under_relaxation_momentum": {
+    "nonlinear": {
+      ".ims": "real value defining the fraction of past history changes that is added as a momentum term to the step change for a nonlinear iteration. The value of UNDER\\_RELAXATION\\_MOMENTUM is between zero and one. A large momentum term should only be used when small learning rates are expected. Small amounts of the momentum term help convergence. The value usually ranges from 0.0001 to 0.1; a value of 0.001 works well for most problems. UNDER\\_RELAXATION\\_MOMENTUM only needs to be specified if UNDER\\_RELAXATION is DBD."
+    }
+  },
+  "backtracking_number": {
+    "nonlinear": {
+      ".ims": "integer value defining the maximum number of backtracking iterations allowed for residual reduction computations. If BACKTRACKING\\_NUMBER = 0 then the backtracking iterations are omitted. The value usually ranges from 2 to 20; a value of 10 works well for most problems."
+    }
+  },
+  "backtracking_tolerance": {
+    "nonlinear": {
+      ".ims": "real value defining the tolerance for residual change that is allowed for residual reduction computations. BACKTRACKING\\_TOLERANCE should not be less than one to avoid getting stuck in local minima. A large value serves to check for extreme residual increases, while a low value serves to control step size more severely. The value usually ranges from 1.0 to 10$^6$; a value of 10$^4$ works well for most problems but lower values like 1.1 may be required for harder problems. BACKTRACKING\\_TOLERANCE only needs to be specified if BACKTRACKING\\_NUMBER is greater than zero."
+    }
+  },
+  "backtracking_reduction_factor": {
+    "nonlinear": {
+      ".ims": "real value defining the reduction in step size used for residual reduction computations. The value of BACKTRACKING\\_REDUCTION\\_FACTOR is between zero and one. The value usually ranges from 0.1 to 0.3; a value of 0.2 works well for most problems. BACKTRACKING\\_REDUCTION\\_FACTOR only needs to be specified if BACKTRACKING\\_NUMBER is greater than zero."
+    }
+  },
+  "backtracking_residual_limit": {
+    "nonlinear": {
+      ".ims": "real value defining the limit to which the residual is reduced with backtracking. If the residual is smaller than BACKTRACKING\\_RESIDUAL\\_LIMIT, then further backtracking is not performed. A value of 100 is suitable for large problems and residual reduction to smaller values may only slow down computations. BACKTRACKING\\_RESIDUAL\\_LIMIT only needs to be specified if BACKTRACKING\\_NUMBER is greater than zero."
+    }
+  },
+  "inner_maximum": {
+    "linear": {
+      ".ims": "integer value defining the maximum number of inner (linear) iterations. The number typically depends on the characteristics of the matrix solution scheme being used. For nonlinear problems, INNER\\_MAXIMUM usually ranges from 60 to 600; a value of 100 will be sufficient for most linear problems."
+    }
+  },
+  "inner_hclose": {
+    "linear": {
+      ".ims": "real value defining the head change criterion for convergence of the inner (linear) iterations, in units of length. When the maximum absolute value of the head change at all nodes during an iteration is less than or equal to INNER\\_HCLOSE, the matrix solver assumes convergence. Commonly, INNER\\_HCLOSE is set equal to or an order of magnitude less than the OUTER\\_HCLOSE value specified for the NONLINEAR block.  The INNER\\_HCLOSE keyword has been deprecated in favor of the more general INNER\\_DVCLOSE (for dependent variable), however either one can be specified in order to maintain backward compatibility."
+    }
+  },
+  "inner_dvclose": {
+    "linear": {
+      ".ims": "real value defining the dependent-variable (for example, head) change criterion for convergence of the inner (linear) iterations, in units of the dependent-variable (for example, length for head). When the maximum absolute value of the dependent-variable change at all nodes during an iteration is less than or equal to INNER\\_DVCLOSE, the matrix solver assumes convergence. Commonly, INNER\\_DVCLOSE is set equal to or an order of magnitude less than the OUTER\\_DVCLOSE value specified for the NONLINEAR block. The keyword, INNER\\_HCLOSE can be still be specified instead of INNER\\_DVCLOSE for backward compatibility with previous versions of MODFLOW 6 but eventually INNER\\_HCLOSE will be deprecated and specification of INNER\\_HCLOSE will cause MODFLOW 6 to terminate with an error."
+    }
+  },
+  "inner_rclose": {
+    "linear": {
+      ".ims": "real value that defines the flow residual tolerance for convergence of the IMS linear solver and specific flow residual criteria used. This value represents the maximum allowable residual at any single node.  Value is in units of length cubed per time, and must be consistent with \\mf length and time units. Usually a value of $1.0 \\times 10^{-1}$ is sufficient for the flow-residual criteria when meters and seconds are the defined \\mf length and time."
+    }
+  },
+  "linear_acceleration": {
+    "linear": {
+      ".ims": "a keyword that defines the linear acceleration method used by the default IMS linear solvers.  CG - preconditioned conjugate gradient method.  BICGSTAB - preconditioned bi-conjugate gradient stabilized method."
+    }
+  },
+  "relaxation_factor": {
+    "linear": {
+      ".ims": "optional real value that defines the relaxation factor used by the incomplete LU factorization preconditioners (MILU(0) and MILUT). RELAXATION\\_FACTOR is unitless and should be greater than or equal to 0.0 and less than or equal to 1.0. RELAXATION\\_FACTOR values of about 1.0 are commonly used, and experience suggests that convergence can be optimized in some cases with relax values of 0.97. A RELAXATION\\_FACTOR value of 0.0 will result in either ILU(0) or ILUT preconditioning (depending on the value specified for PRECONDITIONER\\_LEVELS and/or PRECONDITIONER\\_DROP\\_TOLERANCE). By default,  RELAXATION\\_FACTOR is zero."
+    }
+  },
+  "preconditioner_levels": {
+    "linear": {
+      ".ims": "optional integer value defining the level of fill for ILU decomposition used in the ILUT and MILUT preconditioners. Higher levels of fill provide more robustness but also require more memory. For optimal performance, it is suggested that a large level of fill be applied (7 or 8) with use of a drop tolerance. Specification of a PRECONDITIONER\\_LEVELS value greater than zero results in use of the ILUT preconditioner. By default, PRECONDITIONER\\_LEVELS is zero and the zero-fill incomplete LU factorization preconditioners (ILU(0) and MILU(0)) are used."
+    }
+  },
+  "preconditioner_drop_tolerance": {
+    "linear": {
+      ".ims": "optional real value that defines the drop tolerance used to drop preconditioner terms based on the magnitude of matrix entries in the ILUT and MILUT preconditioners. A value of $10^{-4}$ works well for most problems. By default, PRECONDITIONER\\_DROP\\_TOLERANCE is zero and the zero-fill incomplete LU factorization preconditioners (ILU(0) and MILU(0)) are used."
+    }
+  },
+  "number_orthogonalizations": {
+    "linear": {
+      ".ims": "optional integer value defining the interval used to explicitly recalculate the residual of the flow equation using the solver coefficient matrix, the latest dependent-variable (for example, head) estimates, and the right hand side. For problems that benefit from explicit recalculation of the residual, a number between 4 and 10 is appropriate. By default, NUMBER\\_ORTHOGONALIZATIONS is zero."
+    }
+  },
+  "scaling_method": {
+    "linear": {
+      ".ims": "an optional keyword that defines the matrix scaling approach used. By default, matrix scaling is not applied.  NONE - no matrix scaling applied.  DIAGONAL - symmetric matrix scaling using the POLCG preconditioner scaling method in Hill (1992).  L2NORM - symmetric matrix scaling using the L2 norm."
+    }
+  },
+  "reordering_method": {
+    "linear": {
+      ".ims": "an optional keyword that defines the matrix reordering approach used. By default, matrix reordering is not applied.  NONE - original ordering.  RCM - reverse Cuthill McKee ordering.  MD - minimum degree ordering."
+    }
+  },
+  "storagecoefficient": {
+    "options": {
+      ".sto": "keyword to indicate that the SS array is read as storage coefficient rather than specific storage."
+    }
+  },
+  "ss_confined_only": {
+    "options": {
+      ".sto": "keyword to indicate that compressible storage is only calculated for a convertible cell (ICONVERT>0) when the cell is under confined conditions (head greater than or equal to the top of the cell). This option has no effect on cells that are marked as being always confined (ICONVERT=0).  This option is identical to the approach used to calculate storage changes under confined conditions in MODFLOW-2005."
+    }
+  },
+  "tvs6": {
+    "options": {
+      ".sto": "keyword to specify that record corresponds to a time-varying storage (TVS) file.  The behavior of TVS and a description of the input file is provided separately."
+    }
+  },
+  "dev_oldstorageformulation": {
+    "options": {
+      ".sto": "development option flag for old storage formulation"
+    }
+  },
+  "iconvert": {
+    "griddata": {
+      ".sto": "is a flag for each cell that specifies whether or not a cell is convertible for the storage calculation. 0 indicates confined storage is used. $>$0 indicates confined storage is used when head is above cell top and a mixed formulation of unconfined and confined storage is used when head is below cell top."
+    }
+  },
+  "ss": {
+    "griddata": {
+      ".sto": "is specific storage (or the storage coefficient if STORAGECOEFFICIENT is specified as an option). Specific storage values must be greater than or equal to 0. If the CSUB Package is included in the GWF model, specific storage must be zero for every cell."
+    },
+    "period": {
+      ".tvs": "is the new value to be assigned as the cell's specific storage (or storage coefficient if the STORAGECOEFFICIENT STO package option is specified) from the start of the specified stress period, as per SS in the STO package.  Specific storage values must be greater than or equal to 0.  If the OPTIONS block includes a TS6 entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+    }
+  },
+  "sy": {
+    "griddata": {
+      ".sto": "is specific yield. Specific yield values must be greater than or equal to 0. Specific yield does not have to be specified if there are no convertible cells (ICONVERT=0 in every cell)."
+    },
+    "period": {
+      ".tvs": "is the new value to be assigned as the cell's specific yield from the start of the specified stress period, as per SY in the STO package.  Specific yield values must be greater than or equal to 0.  If the OPTIONS block includes a TS6 entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+    }
+  },
+  "auxdepthname": {
+    "options": {
+      ".drn": "name of a variable listed in AUXILIARY that defines the depth at which drainage discharge will be scaled. If a positive value is specified for the AUXDEPTHNAME AUXILIARY variable, then ELEV is the elevation at which the drain starts to discharge and ELEV + DDRN (assuming DDRN is the AUXDEPTHNAME variable) is the elevation when the drain conductance (COND) scaling factor is 1. If a negative drainage depth value is specified for DDRN, then ELEV + DDRN is the elevation at which the drain starts to discharge and ELEV is the elevation when the conductance (COND) scaling factor is 1. A linear- or cubic-scaling is used to scale the drain conductance (COND) when the Standard or Newton-Raphson Formulation is used, respectively.  This discharge scaling option is described in more detail in Chapter 3 of the Supplemental Technical Information."
+    }
+  },
+  "maxats": {
+    "dimensions": {
+      ".ats": "is the number of records in the subsequent perioddata block that will be used for adaptive time stepping."
+    }
+  },
+  "gwfmodelname1": {
+    "options": {
+      ".gwegwe": "keyword to specify name of first corresponding GWF Model.  In the simulation name file, the GWE6-GWE6 entry contains names for GWE Models (exgmnamea and exgmnameb).  The GWE Model with the name exgmnamea must correspond to the GWF Model with the name gwfmodelname1.",
+      ".gwtgwt": "keyword to specify name of first corresponding GWF Model.  In the simulation name file, the GWT6-GWT6 entry contains names for GWT Models (exgmnamea and exgmnameb).  The GWT Model with the name exgmnamea must correspond to the GWF Model with the name gwfmodelname1."
+    }
+  },
+  "gwfmodelname2": {
+    "options": {
+      ".gwegwe": "keyword to specify name of second corresponding GWF Model.  In the simulation name file, the GWE6-GWE6 entry contains names for GWE Models (exgmnamea and exgmnameb).  The GWE Model with the name exgmnameb must correspond to the GWF Model with the name gwfmodelname2.",
+      ".gwtgwt": "keyword to specify name of second corresponding GWF Model.  In the simulation name file, the GWT6-GWT6 entry contains names for GWT Models (exgmnamea and exgmnameb).  The GWT Model with the name exgmnameb must correspond to the GWF Model with the name gwfmodelname2."
+    }
+  },
+  "adv_scheme": {
+    "options": {
+      ".gwegwe": "scheme used to solve the advection term.  Can be upstream, central, or TVD.  If not specified, upstream weighting is the default weighting scheme.",
+      ".gwtgwt": "scheme used to solve the advection term.  Can be upstream, central, or TVD.  If not specified, upstream weighting is the default weighting scheme."
+    }
+  },
+  "cnd_xt3d_off": {
+    "options": {
+      ".gwegwe": "deactivate the xt3d method for the dispersive flux and use the faster and less accurate approximation for this exchange."
+    }
+  },
+  "cnd_xt3d_rhs": {
+    "options": {
+      ".gwegwe": "add xt3d dispersion terms to right-hand side, when possible, for this exchange."
+    }
+  },
+  "mve6": {
+    "options": {
+      ".gwegwe": "keyword to specify that record corresponds to an energy transport mover file."
+    }
+  },
+  "dev_interfacemodel_on": {
+    "options": {
+      ".gwegwe": "activates the interface model mechanism for calculating the coefficients at (and possibly near) the exchange. This keyword should only be used for development purposes.",
+      ".gwtgwt": "activates the interface model mechanism for calculating the coefficients at (and possibly near) the exchange. This keyword should only be used for development purposes.",
+      ".gwfgwf": "activates the interface model mechanism for calculating the coefficients at (and possibly near) the exchange. This keyword should only be used for development purposes."
+    }
+  },
+  "nexg": {
+    "dimensions": {
+      ".gwegwe": "keyword and integer value specifying the number of GWE-GWE exchanges.",
+      ".olfgwf": "keyword and integer value specifying the number of SWF-GWF exchanges.",
+      ".gwtgwt": "keyword and integer value specifying the number of GWT-GWT exchanges.",
+      ".gwfgwf": "keyword and integer value specifying the number of GWF-GWF exchanges.",
+      ".chfgwf": "keyword and integer value specifying the number of SWF-GWF exchanges."
+    }
+  },
+  "fixed_conductance": {
+    "options": {
+      ".olfgwf": "keyword to indicate that the product of the bedleak and cfact input variables in the exchangedata block represents conductance.  This conductance is fixed and does not change as a function of head in the surface water and groundwater models.",
+      ".chfgwf": "keyword to indicate that the product of the bedleak and cfact input variables in the exchangedata block represents conductance.  This conductance is fixed and does not change as a function of head in the surface water and groundwater models."
+    }
+  },
+  "auto_flow_reduce": {
+    "options": {
+      ".wel": "keyword and real value that defines the fraction of the cell thickness used as an interval for smoothly adjusting negative pumping rates to 0 in cells with head values less than or equal to the bottom of the cell. Negative pumping rates are adjusted to 0 or a smaller negative value when the head in the cell is equal to or less than the calculated interval above the cell bottom. AUTO\\_FLOW\\_REDUCE is set to 0.1 if the specified value is less than or equal to zero. By default, negative pumping rates are not reduced during a simulation.  This AUTO\\_FLOW\\_REDUCE option only applies to wells in model cells that are marked as ``convertible'' (ICELLTYPE /= 0) in the Node Property Flow (NPF) input file. Reduction in flow will not occur for wells in cells marked as confined (ICELLTYPE = 0)."
+    }
+  },
+  "auto_flow_reduce_csv": {
+    "options": {
+      ".wel": "keyword to specify that record corresponds to the AUTO\\_FLOW\\_REDUCE output option in which a new record is written for each well and for each time step in which the user-requested extraction rate is reduced by the program."
+    }
+  },
+  "nsections": {
+    "dimensions": {
+      ".cxs": "integer value specifying the number of cross sections that will be defined.  There must be NSECTIONS entries in the PACKAGEDATA block."
+    }
+  },
+  "npoints": {
+    "dimensions": {
+      ".cxs": "integer value specifying the total number of cross-section points defined for all reaches.  There must be NPOINTS entries in the CROSSSECTIONDATA block."
+    }
+  },
+  "print_stage": {
+    "options": {
+      ".lak": "keyword to indicate that the list of lake stages will be printed to the listing file for every stress period in which ``HEAD PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_STAGE is specified, then stages are printed for the last time step of each stress period.",
+      ".sfr": "keyword to indicate that the list of stream reach stages will be printed to the listing file for every stress period in which ``HEAD PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_STAGE is specified, then stages are printed for the last time step of each stress period."
+    }
+  },
+  "surfdep": {
+    "options": {
+      ".lak": "real value that defines the surface depression depth for VERTICAL lake-GWF connections. If specified, SURFDEP must be greater than or equal to zero. If SURFDEP is not specified, a default value of zero is used for all vertical lake-GWF connections."
+    }
+  },
+  "maximum_iterations": {
+    "options": {
+      ".lak": "integer value that defines the maximum number of Newton-Raphson iterations allowed for a lake. By default, MAXIMUM\\_ITERATIONS is equal to 100. MAXIMUM\\_ITERATIONS would only need to be increased from the default value if one or more lakes in a simulation has a large water budget error.",
+      ".sfr": "integer value that defines the maximum number of Streamflow Routing Newton-Raphson iterations allowed for a reach. By default, MAXIMUM\\_ITERATIONS is equal to 100. MAXIMUM\\_ITERATIONS would only need to be increased from the default value if one or more reach in a simulation has a large water budget error."
+    }
+  },
+  "maximum_stage_change": {
+    "options": {
+      ".lak": "real value that defines the lake stage closure tolerance. By default, MAXIMUM\\_STAGE\\_CHANGE is equal to $1 \\times 10^{-5}$. The MAXIMUM\\_STAGE\\_CHANGE would only need to be increased or decreased from the default value if the water budget error for one or more lakes is too small or too large, respectively."
+    }
+  },
+  "time_conversion": {
+    "options": {
+      ".lak": "real value that is used to convert user-specified Manning's roughness coefficients or gravitational acceleration used to calculate outlet flows from seconds to model time units. TIME\\_CONVERSION should be set to 1.0, 60.0, 3,600.0, 86,400.0, and 31,557,600.0 when using time units (TIME\\_UNITS) of seconds, minutes, hours, days, or years in the simulation, respectively. CONVTIME does not need to be specified if no lake outlets are specified or TIME\\_UNITS are seconds.",
+      ".dfw": "real value that is used to convert user-specified Manning's roughness coefficients from seconds to model time units. TIME\\_CONVERSION should be set to 1.0, 60.0, 3,600.0, 86,400.0, and 31,557,600.0 when using time units (TIME\\_UNITS) of seconds, minutes, hours, days, or years in the simulation, respectively. TIME\\_CONVERSION does not need to be specified if TIME\\_UNITS are seconds.",
+      ".sfr": "real value that is used to convert user-specified Manning's roughness coefficients from seconds to model time units. TIME\\_CONVERSION should be set to 1.0, 60.0, 3,600.0, 86,400.0, and 31,557,600.0 when using time units (TIME\\_UNITS) of seconds, minutes, hours, days, or years in the simulation, respectively. TIME\\_CONVERSION does not need to be specified if TIME\\_UNITS are seconds."
+    }
+  },
+  "length_conversion": {
+    "options": {
+      ".lak": "real value that is used to convert outlet user-specified Manning's roughness coefficients or gravitational acceleration used to calculate outlet flows from meters to model length units. LENGTH\\_CONVERSION should be set to 3.28081, 1.0, and 100.0 when using length units (LENGTH\\_UNITS) of feet, meters, or centimeters in the simulation, respectively. LENGTH\\_CONVERSION does not need to be specified if no lake outlets are specified or LENGTH\\_UNITS are meters.",
+      ".dfw": "real value that is used to convert user-specified Manning's roughness coefficients from meters to model length units. LENGTH\\_CONVERSION should be set to 3.28081, 1.0, and 100.0 when using length units (LENGTH\\_UNITS) of feet, meters, or centimeters in the simulation, respectively. LENGTH\\_CONVERSION does not need to be specified if LENGTH\\_UNITS are meters.",
+      ".sfr": "real value that is used to convert user-specified Manning's roughness coefficients from meters to model length units. LENGTH\\_CONVERSION should be set to 3.28081, 1.0, and 100.0 when using length units (LENGTH\\_UNITS) of feet, meters, or centimeters in the simulation, respectively. LENGTH\\_CONVERSION does not need to be specified if LENGTH\\_UNITS are meters."
+    }
+  },
+  "nlakes": {
+    "dimensions": {
+      ".lak": "value specifying the number of lakes that will be simulated for all stress periods."
+    }
+  },
+  "noutlets": {
+    "dimensions": {
+      ".lak": "value specifying the number of outlets that will be simulated for all stress periods. If NOUTLETS is not specified, a default value of zero is used."
+    }
+  },
+  "ntables": {
+    "dimensions": {
+      ".lak": "value specifying the number of lakes tables that will be used to define the lake stage, volume relation, and surface area. If NTABLES is not specified, a default value of zero is used."
+    }
+  },
+  "tab6": {
+    "tables": {
+      ".lak": "keyword to specify that record corresponds to a table file."
+    },
+    "crosssections": {
+      ".sfr": "keyword to specify that record corresponds to a cross-section table file."
+    },
+    "period": {
+      ".sfr": "keyword to specify that record corresponds to a cross-section table file."
+    }
+  },
+  "withdrawal": {
+    "period": {
+      ".lak": "real or character value that defines the maximum withdrawal rate $(L^3 T^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+    }
+  },
+  "rate": {
+    "period": {
+      ".lak": "real or character value that defines the extraction rate for the lake outflow. A positive value indicates inflow and a negative value indicates outflow from the lake. RATE only applies to outlets associated with active lakes (STATUS is ACTIVE). A specified RATE is only applied if COUTTYPE for the OUTLETNO is SPECIFIED. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, the RATE for each SPECIFIED lake outlet is zero.",
+      ".evta": "is the maximum ET flux rate ($LT^{-1}$).",
+      ".mwt": "real or character value that defines the injection solute concentration $(ML^{-3})$ for the well. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      ".maw": "is the volumetric pumping rate for the multi-aquifer well. A positive value indicates recharge and a negative value indicates discharge (pumping). RATE only applies to active (STATUS is ACTIVE) multi-aquifer wells. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, the RATE for each multi-aquifer well is zero.",
+      ".mwe": "real or character value that defines the injection temperature $(e.g.,\\:^{\\circ}C\\:or\\:^{\\circ}F)$ for the well. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+    }
+  },
+  "invert": {
+    "period": {
+      ".lak": "real or character value that defines the invert elevation for the lake outlet. A specified INVERT value is only used for active lakes if COUTTYPE for lake outlet OUTLETNO is not SPECIFIED. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+    }
+  },
+  "rough": {
+    "period": {
+      ".lak": "real value that defines the roughness coefficient for the lake outlet. Any value can be specified if COUTTYPE is not MANNING. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+    }
+  },
+  "slope": {
+    "period": {
+      ".lak": "real or character value that defines the bed slope for the lake outlet. A specified SLOPE value is only used for active lakes if COUTTYPE for lake outlet OUTLETNO is MANNING. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+    }
+  },
+  "ext-inflow": {
+    "period": {
+      ".lkt": "real or character value that defines the concentration of external inflow $(ML^{-3})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      ".lke": "real or character value that defines the temperature of external inflow for the lake.  Users are free to use whatever temperature scale they want, which might include negative temperatures.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+    }
+  },
+  "dsp_xt3d_off": {
+    "options": {
+      ".gwtgwt": "deactivate the xt3d method for the dispersive flux and use the faster and less accurate approximation for this exchange."
+    }
+  },
+  "dsp_xt3d_rhs": {
+    "options": {
+      ".gwtgwt": "add xt3d dispersion terms to right-hand side, when possible, for this exchange."
+    }
+  },
+  "mvt6": {
+    "options": {
+      ".gwtgwt": "keyword to specify that record corresponds to a transport mover file."
+    }
+  },
+  "names": {
+    "attributes": {
+      ".ts": "xxx"
+    }
+  },
+  "methods": {
+    "attributes": {
+      ".ts": "xxx"
+    }
+  },
+  "sfacs": {
+    "attributes": {
+      ".ts": "xxx"
+    }
+  },
+  "timeseries": {
+    "timeseries": {
+      ".ts": "xxx"
+    }
+  },
+  "wkt": {
+    "options": {
+      ".ncf": "is the coordinate reference system (CRS) well-known text (WKT) string."
+    }
+  },
+  "deflate": {
+    "options": {
+      ".ncf": "is the variable deflate level (0=min, 9=max) in the netcdf file. Defining this parameter activates per-variable compression at the level specified."
+    }
+  },
+  "shuffle": {
+    "options": {
+      ".ncf": "is the keyword used to turn on the netcdf variable shuffle filter when the deflate option is also set. The shuffle filter has the effect of storing the first byte of all of a variable's values in a chunk contiguously, followed by all the second bytes, etc. This can be an optimization for compression with certain types of data."
+    }
+  },
+  "chunk_time": {
+    "options": {
+      ".ncf": "is the keyword used to provide a data chunk size for the time dimension in a NETCDF\\_MESH2D or NETCDF\\_STRUCTURED output file. Must be used in combination with the the chunk\\_face parameter (NETCDF\\_MESH2D) or the chunk\\_z, chunk\\_y, and chunk\\_x parameter set (NETCDF\\_STRUCTURED) to have an effect."
+    }
+  },
+  "chunk_face": {
+    "options": {
+      ".ncf": "is the keyword used to provide a data chunk size for the face dimension in a NETCDF\\_MESH2D output file. Must be used in combination with the the chunk\\_time parameter to have an effect."
+    }
+  },
+  "chunk_z": {
+    "options": {
+      ".ncf": "is the keyword used to provide a data chunk size for the z dimension in a NETCDF\\_STRUCTURED output file. Must be used in combination with the the chunk\\_time, chunk\\_x and chunk\\_y parameter set to have an effect."
+    }
+  },
+  "chunk_y": {
+    "options": {
+      ".ncf": "is the keyword used to provide a data chunk size for the y dimension in a NETCDF\\_STRUCTURED output file. Must be used in combination with the the chunk\\_time, chunk\\_x and chunk\\_z parameter set to have an effect."
+    }
+  },
+  "chunk_x": {
+    "options": {
+      ".ncf": "is the keyword used to provide a data chunk size for the x dimension in a NETCDF\\_STRUCTURED output file. Must be used in combination with the the chunk\\_time, chunk\\_y and chunk\\_z parameter set to have an effect."
+    }
+  },
+  "modflow6_attr_off": {
+    "options": {
+      ".ncf": "is the keyword used to turn off internal input tagging in the model netcdf file. Tagging adds internal modflow 6 attribute(s) to variables which facilitate identification. Currently this applies to gridded arrays."
+    }
+  },
+  "latitude": {
+    "griddata": {
+      ".ncf": "cell center latitude."
+    }
+  },
+  "longitude": {
+    "griddata": {
+      ".ncf": "cell center longitude."
+    }
+  },
+  "fixed_cell": {
+    "options": {
+      ".evta": "indicates that evapotranspiration will not be reassigned to a cell underlying the cell specified in the list if the specified cell is inactive.",
+      ".rcha": "indicates that recharge will not be reassigned to a cell underlying the cell specified in the list if the specified cell is inactive.",
+      ".rch": "indicates that recharge will not be reassigned to a cell underlying the cell specified in the list if the specified cell is inactive.",
+      ".evt": "indicates that evapotranspiration will not be reassigned to a cell underlying the cell specified in the list if the specified cell is inactive."
+    }
+  },
+  "ievt": {
+    "period": {
+      ".evta": "IEVT is the layer number that defines the layer in each vertical column where evapotranspiration is applied. If IEVT is omitted, evapotranspiration by default is applied to cells in layer 1.  If IEVT is specified, it must be specified as the first variable in the PERIOD block or MODFLOW will terminate with an error."
+    }
+  },
+  "surface": {
+    "period": {
+      ".evta": "is the elevation of the ET surface ($L$)."
+    }
+  },
+  "depth": {
+    "period": {
+      ".evta": "is the ET extinction depth ($L$)."
+    }
+  },
+  "aux": {
+    "period": {
+      ".evta": "is an array of values for auxiliary variable AUX(IAUX), where iaux is a value from 1 to NAUX, and AUX(IAUX) must be listed as part of the auxiliary variables.  A separate array can be specified for each auxiliary variable.  If an array is not specified for an auxiliary variable, then a value of zero is assigned.  If the value specified here for the auxiliary variable is the same as auxmultname, then the evapotranspiration rate will be multiplied by this array.",
+      ".rcha": "is an array of values for auxiliary variable aux(iaux), where iaux is a value from 1 to naux, and aux(iaux) must be listed as part of the auxiliary variables.  A separate array can be specified for each auxiliary variable.  If an array is not specified for an auxiliary variable, then a value of zero is assigned.  If the value specified here for the auxiliary variable is the same as auxmultname, then the recharge array will be multiplied by this array."
+    }
+  },
+  "track_release": {
+    "options": {
+      ".oc": "keyword to indicate that particle tracking output is to be written when a particle is released"
+    }
+  },
+  "track_exit": {
+    "options": {
+      ".oc": "keyword to indicate that particle tracking output is to be written when a particle exits a feature (a model, cell, or subcell)"
+    }
+  },
+  "track_timestep": {
+    "options": {
+      ".oc": "keyword to indicate that particle tracking output is to be written at the end of each time step"
+    }
+  },
+  "track_terminate": {
+    "options": {
+      ".oc": "keyword to indicate that particle tracking output is to be written when a particle terminates for any reason"
+    }
+  },
+  "track_weaksink": {
+    "options": {
+      ".oc": "keyword to indicate that particle tracking output is to be written when a particle exits a weak sink (a cell which removes some but not all inflow from adjacent cells)"
+    }
+  },
+  "track_usertime": {
+    "options": {
+      ".oc": "keyword to indicate that particle tracking output is to be written at user-specified times, provided as double precision values in the TRACKTIMES block."
+    }
+  },
+  "ntracktimes": {
+    "dimensions": {
+      ".oc": "is the number of user-specified particle tracking times in the TRACKTIMES block."
+    }
+  },
+  "irch": {
+    "period": {
+      ".rcha": "IRCH is the layer number that defines the layer in each vertical column where recharge is applied. If IRCH is omitted, recharge by default is applied to cells in layer 1.  IRCH can only be used if READASARRAYS is specified in the OPTIONS block.  If IRCH is specified, it must be specified as the first variable in the PERIOD block or MODFLOW will terminate with an error."
+    }
+  },
+  "recharge": {
+    "period": {
+      ".rcha": "is the recharge flux rate ($LT^{-1}$).  This rate is multiplied inside the program by the surface area of the cell to calculate the volumetric recharge rate. The recharge array may be defined by a time-array series (see the ``Using Time-Array Series in a Package'' section)."
+    }
+  },
+  "first_order_decay": {
+    "options": {
+      ".mst": "is a text keyword to indicate that first-order decay will occur.  Use of this keyword requires that DECAY and DECAY\\_SORBED (if sorption is active) are specified in the GRIDDATA block.",
+      ".ist": "is a text keyword to indicate that first-order decay will occur.  Use of this keyword requires that DECAY and DECAY\\_SORBED (if sorption is active) are specified in the GRIDDATA block."
+    }
+  },
+  "zero_order_decay": {
+    "options": {
+      ".mst": "is a text keyword to indicate that zero-order decay will occur.  Use of this keyword requires that DECAY and DECAY\\_SORBED (if sorption is active) are specified in the GRIDDATA block.",
+      ".ist": "is a text keyword to indicate that zero-order decay will occur.  Use of this keyword requires that DECAY and DECAY\\_SORBED (if sorption is active) are specified in the GRIDDATA block."
+    }
+  },
+  "sorption": {
+    "options": {
+      ".mst": "is a text keyword to indicate that sorption will be activated.  Valid sorption options include LINEAR, FREUNDLICH, and LANGMUIR.  Use of this keyword requires that BULK\\_DENSITY and DISTCOEF are specified in the GRIDDATA block.  If sorption is specified as FREUNDLICH or LANGMUIR then SP2 is also required in the GRIDDATA block.",
+      ".ist": "is a text keyword to indicate that sorption will be activated.  Valid sorption options include LINEAR, FREUNDLICH, and LANGMUIR.  Use of this keyword requires that BULK\\_DENSITY and DISTCOEF are specified in the GRIDDATA block.  If sorption is specified as FREUNDLICH or LANGMUIR then SP2 is also required in the GRIDDATA block.  The sorption option must be consistent with the sorption option specified in the MST Package or the program will terminate with an error."
+    }
+  },
+  "sorbate": {
+    "options": {
+      ".mst": "keyword to specify that record corresponds to sorbate concentration.",
+      ".ist": "keyword to specify that record corresponds to immobile sorbate concentration."
+    }
+  },
+  "decay": {
+    "griddata": {
+      ".mst": "is the rate coefficient for first or zero-order decay for the aqueous phase of the mobile domain.  A negative value indicates solute production.  The dimensions of decay for first-order decay is one over time.  The dimensions of decay for zero-order decay is mass per length cubed per time.  decay will have no effect on simulation results unless either first- or zero-order decay is specified in the options block.",
+      ".ist": "is the rate coefficient for first or zero-order decay for the aqueous phase of the immobile domain.  A negative value indicates solute production.  The dimensions of decay for first-order decay is one over time.  The dimensions of decay for zero-order decay is mass per length cubed per time.  Decay will have no effect on simulation results unless either first- or zero-order decay is specified in the options block."
+    }
+  },
+  "decay_sorbed": {
+    "griddata": {
+      ".mst": "is the rate coefficient for first or zero-order decay for the sorbed phase of the mobile domain.  A negative value indicates solute production.  The dimensions of decay\\_sorbed for first-order decay is one over time.  The dimensions of decay\\_sorbed for zero-order decay is mass of solute per mass of aquifer per time.  If decay\\_sorbed is not specified and both decay and sorption are active, then the program will terminate with an error.  decay\\_sorbed will have no effect on simulation results unless the SORPTION keyword and either first- or zero-order decay are specified in the options block.",
+      ".ist": "is the rate coefficient for first or zero-order decay for the sorbed phase of the immobile domain.  A negative value indicates solute production.  The dimensions of decay\\_sorbed for first-order decay is one over time.  The dimensions of decay\\_sorbed for zero-order decay is mass of solute per mass of aquifer per time.  If decay\\_sorbed is not specified and both decay and sorption are active, then the program will terminate with an error.  decay\\_sorbed will have no effect on simulation results unless the SORPTION keyword and either first- or zero-order decay are specified in the options block."
+    }
+  },
+  "bulk_density": {
+    "griddata": {
+      ".mst": "is the bulk density of the aquifer in mass per length cubed.  bulk\\_density is not required unless the SORPTION keyword is specified.  Bulk density is defined as the mobile domain solid mass per mobile domain volume.  Additional information on bulk density is included in the MODFLOW 6 Supplemental Technical Information document.",
+      ".ist": "is the bulk density of this immobile domain in mass per length cubed.  Bulk density is defined as the immobile domain solid mass per volume of the immobile domain.  bulk\\_density is not required unless the SORPTION keyword is specified in the options block.  If the SORPTION keyword is not specified in the options block, bulk\\_density will have no effect on simulation results.  "
+    }
+  },
+  "distcoef": {
+    "griddata": {
+      ".mst": "is the distribution coefficient for the equilibrium-controlled linear sorption isotherm in dimensions of length cubed per mass.  If the Freunchlich isotherm is specified, then discoef is the Freundlich constant.  If the Langmuir isotherm is specified, then distcoef is the Langmuir constant.  distcoef is not required unless the SORPTION keyword is specified.",
+      ".ist": "is the distribution coefficient for the equilibrium-controlled linear sorption isotherm in dimensions of length cubed per mass.  distcoef is not required unless the SORPTION keyword is specified in the options block.  If the SORPTION keyword is not specified in the options block, distcoef will have no effect on simulation results. "
+    }
+  },
+  "sp2": {
+    "griddata": {
+      ".mst": "is the exponent for the Freundlich isotherm and the sorption capacity for the Langmuir isotherm.  sp2 is not required unless the SORPTION keyword is specified in the options block.  If the SORPTION keyword is not specified in the options block, sp2 will have no effect on simulation results. ",
+      ".ist": "is the exponent for the Freundlich isotherm and the sorption capacity for the Langmuir isotherm.  sp2 is not required unless the SORPTION keyword is specified in the options block and sorption is specified as FREUNDLICH or LANGMUIR. If the SORPTION keyword is not specified in the options block, or if sorption is specified as LINEAR, sp2 will have no effect on simulation results. "
+    }
+  },
+  "hhformulation_rhs": {
+    "options": {
+      ".buy": "use the variable-density hydraulic head formulation and add off-diagonal terms to the right-hand.  This option will prevent the BUY Package from adding asymmetric terms to the flow matrix."
+    }
+  },
+  "denseref": {
+    "options": {
+      ".buy": "fluid reference density used in the equation of state.  This value is set to 1000. if not specified as an option."
+    }
+  },
+  "density": {
+    "options": {
+      ".buy": "keyword to specify that record corresponds to density."
+    }
+  },
+  "dev_efh_formulation": {
+    "options": {
+      ".buy": "use the variable-density equivalent freshwater head formulation instead of the hydraulic head head formulation.  This dev option has only been implemented for confined aquifer conditions and should generally not be used."
+    }
+  },
+  "nrhospecies": {
+    "dimensions": {
+      ".buy": "number of species used in density equation of state.  This value must be one or greater if the BUY package is activated.  "
+    }
+  },
+  "cell_averaging": {
+    "options": {
+      ".gwfgwf": "is a keyword and text keyword to indicate the method that will be used for calculating the conductance for horizontal cell connections.  The text value for CELL\\_AVERAGING can be ``HARMONIC'', ``LOGARITHMIC'', or ``AMT-LMK'', which means ``arithmetic-mean thickness and logarithmic-mean hydraulic conductivity''. If the user does not specify a value for CELL\\_AVERAGING, then the harmonic-mean method will be used."
+    }
+  },
+  "gnc6": {
+    "options": {
+      ".gwfgwf": "keyword to specify that record corresponds to a ghost-node correction file."
+    }
+  },
+  "mvr6": {
+    "options": {
+      ".gwfgwf": "keyword to specify that record corresponds to a mover file."
+    }
+  },
+  "diffc": {
+    "griddata": {
+      ".dsp": "effective molecular diffusion coefficient."
+    }
+  },
+  "zero_order_decay_water": {
+    "options": {
+      ".est": "is a text keyword to indicate that zero-order decay will occur in the aqueous phase. That is, decay occurs in the water and is a rate per volume of water only, not per volume of aquifer (i.e., grid cell).  Use of this keyword requires that DECAY\\_WATER is specified in the GRIDDATA block."
+    }
+  },
+  "zero_order_decay_solid": {
+    "options": {
+      ".est": "is a text keyword to indicate that zero-order decay will occur in the solid phase. That is, decay occurs in the solid and is a rate per mass (not volume) of solid only.  Use of this keyword requires that DECAY\\_SOLID is specified in the GRIDDATA block."
+    }
+  },
+  "density_water": {
+    "options": {
+      ".est": "density of water used by calculations related to heat storage and conduction.  This value is set to 1,000 kg/m3 if no overriding value is specified.  A user-specified value should be provided for models that use units other than kilograms and meters or if it is necessary to use a value other than the default."
+    }
+  },
+  "heat_capacity_water": {
+    "options": {
+      ".est": "heat capacity of water used by calculations related to heat storage and conduction.  This value is set to 4,184 J/kg/C if no overriding value is specified.  A user-specified value should be provided for models that use units other than kilograms, joules, and degrees Celsius or it is necessary to use a value other than the default."
+    }
+  },
+  "latent_heat_vaporization": {
+    "options": {
+      ".est": "latent heat of vaporization is the amount of energy that is required to convert a given quantity of liquid into a gas and is associated with evaporative cooling.  While the EST package does not simulate evaporation, multiple other packages in a GWE simulation may.  To avoid having to specify the latent heat of vaporization in multiple packages, it is specified in a single location and accessed wherever it is needed.  For example, evaporation may occur from the surface of streams or lakes and the energy consumed by the change in phase would be needed in both the SFE and LKE packages.  This value is set to 2,453,500 J/kg if no overriding value is specified.  A user-specified value should be provided for models that use units other than joules and kilograms or if it is necessary to use a value other than the default."
+    }
+  },
+  "decay_water": {
+    "griddata": {
+      ".est": "is the rate coefficient for zero-order decay for the aqueous phase of the mobile domain.  A negative value indicates heat (energy) production.  The dimensions of zero-order decay in the aqueous phase are energy per length cubed (volume of water) per time.  Zero-order decay in the aqueous phase will have no effect on simulation results unless ZERO\\_ORDER\\_DECAY\\_WATER is specified in the options block."
+    }
+  },
+  "decay_solid": {
+    "griddata": {
+      ".est": "is the rate coefficient for zero-order decay for the solid phase.  A negative value indicates heat (energy) production. The dimensions of zero-order decay in the solid phase are energy per mass of solid per time. Zero-order decay in the solid phase will have no effect on simulation results unless ZERO\\_ORDER\\_DECAY\\_SOLID is specified in the options block."
+    }
+  },
+  "heat_capacity_solid": {
+    "griddata": {
+      ".est": "is the mass-based heat capacity of dry solids (aquifer material). For example, units of J/kg/C may be used (or equivalent)."
+    }
+  },
+  "density_solid": {
+    "griddata": {
+      ".est": "is a user-specified value of the density of aquifer material not considering the voids. Value will remain fixed for the entire simulation.  For example, if working in SI units, values may be entered as kilograms per cubic meter. "
+    }
+  },
+  "length": {
+    "griddata": {
+      ".disv1d": "length for each one-dimensional cell"
+    }
+  },
+  "modelnames": {
+    "options": {
+      ".mvr": "keyword to indicate that all package names will be preceded by the model name for the package.  Model names are required when the Mover Package is used with a GWF-GWF Exchange.  The MODELNAME keyword should not be used for a Mover Package that is for a single GWF Model."
+    }
+  },
+  "maxmvr": {
+    "dimensions": {
+      ".mvr": "integer value specifying the maximum number of water mover entries that will specified for any stress period."
+    }
+  },
+  "maxpackages": {
+    "dimensions": {
+      ".mvr": "integer value specifying the number of unique packages that are included in this water mover input file."
+    }
+  },
+  "central_in_space": {
+    "options": {
+      ".dfw": "keyword to indicate conductance should be calculated using central-in-space weighting instead of the default upstream weighting approach.  This option should be used with caution as it does not work well unless all of the stream reaches are saturated.  With this option, there is no way for water to flow into a dry reach from connected reaches."
+    }
+  },
+  "save_velocity": {
+    "options": {
+      ".dfw": "keyword to indicate that x, y, and z components of velocity will be calculated at cell centers and written to the budget file, which is specified with ``BUDGET SAVE FILE'' in Output Control.  If this option is activated, then additional information may be required in the discretization packages and the GWF Exchange package (if GWF models are coupled).  Specifically, ANGLDEGX must be specified in the CONNECTIONDATA block of the DISU Package; ANGLDEGX must also be specified for the GWF Exchange as an auxiliary variable."
+    }
+  },
+  "dev_swr_conductance": {
+    "options": {
+      ".dfw": "use the conductance formulation in the Surface Water Routing (SWR) Process for MODFLOW-2005."
+    }
+  },
+  "manningsn": {
+    "griddata": {
+      ".dfw": "mannings roughness coefficient"
+    }
+  },
+  "idcxs": {
+    "griddata": {
+      ".dfw": "integer value indication the cross section identifier in the Cross Section Package that applies to the reach.  If not provided then reach will be treated as hydraulically wide."
+    }
+  },
+  "explicit": {
+    "options": {
+      ".gnc": "keyword to indicate that the ghost node correction is applied in an explicit manner on the right-hand side of the matrix.  The explicit approach will likely require additional outer iterations.  If the keyword is not specified, then the correction will be applied in an implicit manner on the left-hand side.  The implicit approach will likely converge better, but may require additional memory.  If the EXPLICIT keyword is not specified, then the BICGSTAB linear acceleration option should be specified within the LINEAR block of the Sparse Matrix Solver."
+    }
+  },
+  "numgnc": {
+    "dimensions": {
+      ".gnc": "is the number of GNC entries."
+    }
+  },
+  "numalphaj": {
+    "dimensions": {
+      ".gnc": "is the number of contributing factors."
+    }
+  },
+  "binary": {
+    "continuous": {
+      ".obs": "an optional keyword used to indicate that the output file should be written in binary (unformatted) form."
+    }
+  },
+  "vertical_offset_tolerance": {
+    "options": {
+      ".disu": "checks are performed to ensure that the top of a cell is not higher than the bottom of an overlying cell.  This option can be used to specify the tolerance that is used for checking.  If top of a cell is above the bottom of an overlying cell by a value less than this tolerance, then the program will not terminate with an error.  The default value is zero.  This option should generally not be used."
+    }
+  },
+  "nja": {
+    "dimensions": {
+      ".disu": "is the sum of the number of connections and NODES.  When calculating the total number of connections, the connection between cell n and cell m is considered to be different from the connection between cell m and cell n.  Thus, NJA is equal to the total number of connections, including n to m and m to n, and the total number of cells."
+    }
+  },
+  "bot": {
+    "griddata": {
+      ".disu": "is the bottom elevation for each cell."
+    }
+  },
+  "area": {
+    "griddata": {
+      ".disu": "is the cell surface area (in plan view)."
+    }
+  },
+  "iac": {
+    "connectiondata": {
+      ".disu": "is the number of connections (plus 1) for each cell.  The sum of all the entries in IAC must be equal to NJA."
+    }
+  },
+  "ja": {
+    "connectiondata": {
+      ".disu": "is a list of cell number (n) followed by its connecting cell numbers (m) for each of the m cells connected to cell n. The number of values to provide for cell n is IAC(n).  This list is sequentially provided for the first to the last cell. The first value in the list must be cell n itself, and the remaining cells must be listed in an increasing order (sorted from lowest number to highest).  Note that the cell and its connections are only supplied for the GWE cells and their connections to the other GWE cells.  Also note that the JA list input may be divided such that every node and its connectivity list can be on a separate line for ease in readability of the file. To further ease readability of the file, the node number of the cell whose connectivity is subsequently listed, may be expressed as a negative number, the sign of which is subsequently converted to positive by the code."
+    }
+  },
+  "ihc": {
+    "connectiondata": {
+      ".disu": "is an index array indicating the direction between node n and all of its m connections.  If IHC = 0 then cell n and cell m are connected in the vertical direction.  Cell n overlies cell m if the cell number for n is less than m; cell m overlies cell n if the cell number for m is less than n.  If IHC = 1 then cell n and cell m are connected in the horizontal direction.  If IHC = 2 then cell n and cell m are connected in the horizontal direction, and the connection is vertically staggered.  A vertically staggered connection is one in which a cell is horizontally connected to more than one cell in a horizontal connection."
+    }
+  },
+  "cl12": {
+    "connectiondata": {
+      ".disu": "is the array containing connection lengths between the center of cell n and the shared face with each adjacent m cell."
+    }
+  },
+  "hwva": {
+    "connectiondata": {
+      ".disu": "is a symmetric array of size NJA.  For horizontal connections, entries in HWVA are the horizontal width perpendicular to flow.  For vertical connections, entries in HWVA are the vertical area for flow.  Thus, values in the HWVA array contain dimensions of both length and area.  Entries in the HWVA array have a one-to-one correspondence with the connections specified in the JA array.  Likewise, there is a one-to-one correspondence between entries in the HWVA array and entries in the IHC array, which specifies the connection type (horizontal or vertical).  Entries in the HWVA array must be symmetric; the program will terminate with an error if the value for HWVA for an n to m connection does not equal the value for HWVA for the corresponding n to m connection."
+    }
+  },
+  "angldegx": {
+    "connectiondata": {
+      ".disu": "is the angle (in degrees) between the horizontal x-axis and the outward normal to the face between a cell and its connecting cells. The angle varies between zero and 360.0 degrees, where zero degrees points in the positive x-axis direction, and 90 degrees points in the positive y-axis direction.  ANGLDEGX is only needed if horizontal anisotropy is specified in the NPF Package, if the XT3D option is used in the NPF Package, or if the SAVE\\_SPECIFIC\\_DISCHARGE option is specified in the NPF Package.  ANGLDEGX does not need to be specified if these conditions are not met.  ANGLDEGX is of size NJA; values specified for vertical connections and for the diagonal position are not used.  Note that ANGLDEGX is read in degrees, which is different from MODFLOW-USG, which reads a similar variable (ANGLEX) in radians."
+    }
+  },
+  "disable_storage_change_integration": {
+    "options": {
+      ".tvs": "keyword that deactivates inclusion of storage derivative terms in the STO package matrix formulation.  In the absence of this keyword (the default), the groundwater storage formulation will be modified to correctly adjust heads based on transient variations in stored water volumes arising from changes to SS and SY properties."
+    }
+  },
+  "storage": {
+    "options": {
+      ".sfr": "keyword that activates storage contributions to the stream-flow routing package continuity equation."
+    }
+  },
+  "maximum_picard_iterations": {
+    "options": {
+      ".sfr": "integer value that defines the maximum number of Streamflow Routing picard iterations allowed when solving for reach stages and flows as part of the GWF formulate step. Picard iterations are used to minimize differences in SFR package results between subsequent GWF picard (non-linear) iterations as a result of non-optimal reach numbering. If reaches are numbered in order, from upstream to downstream, MAXIMUM\\_PICARD\\_ITERATIONS can be set to 1 to reduce model run time. By default, MAXIMUM\\_PICARD\\_ITERATIONS is equal to 100."
+    }
+  },
+  "maximum_depth_change": {
+    "options": {
+      ".sfr": "real value that defines the depth closure tolerance. By default, MAXIMUM\\_DEPTH\\_CHANGE is equal to $1 \\times 10^{-5}$. The MAXIMUM\\_STAGE\\_CHANGE would only need to be increased or decreased from the default value if the water budget error for one or more reach is too small or too large, respectively."
+    }
+  },
+  "unit_conversion": {
+    "options": {
+      ".sfr": "real value that is used to convert user-specified Manning's roughness coefficients from seconds per meters$^{1/3}$ to model length and time units. A constant of 1.486 is used for flow units of cubic feet per second, and a constant of 1.0 is used for units of cubic meters per second. The constant must be multiplied by 86,400 when using time units of days in the simulation."
+    }
+  },
+  "dev_storage_weight": {
+    "options": {
+      ".sfr": "real number value that defines the time weighting factor used to calculate the change in channel storage. STORAGE\\_WEIGHT must have a value between 0.5 and 1. Default STORAGE\\_WEIGHT value is 1."
+    }
+  },
+  "nreaches": {
+    "dimensions": {
+      ".sfr": "integer value specifying the number of stream reaches.  There must be NREACHES entries in the PACKAGEDATA block."
+    }
+  },
+  "bedk": {
+    "period": {
+      ".sfr": "real or character value that defines the hydraulic conductivity of the reach streambed. BEDK can be any positive value if the reach is not connected to an underlying GWF cell. Otherwise, BEDK must be greater than zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+    }
+  },
+  "manning": {
+    "period": {
+      ".sfr": "real or character value that defines the Manning's roughness coefficient for the reach. MANNING must be greater than zero.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+    }
+  },
+  "diversion": {
+    "period": {
+      ".sfr": "keyword to indicate diversion record."
+    }
+  },
+  "upstream_fraction": {
+    "period": {
+      ".sfr": "real value that defines the fraction of upstream flow (USTRF) from each upstream reach that is applied as upstream inflow to the reach. The sum of all USTRF values for all reaches connected to the same upstream reach must be equal to one."
+    }
+  },
+  "cross_section": {
+    "period": {
+      ".sfr": "keyword to specify that record corresponds to a reach cross-section."
+    }
+  },
+  "ats_percel": {
+    "options": {
+      ".adv": "fractional cell distance submitted by the ADV Package to the adaptive time stepping (ATS) package.  If ATS\\_PERCEL is specified and the ATS Package is active, a time step calculation will be made for each cell based on flow through the cell and cell properties.  The largest time step will be calculated such that the advective fractional cell distance (ATS\\_PERCEL) is not exceeded for any active cell in the grid.  This time-step constraint will be submitted to the ATS Package, perhaps with constraints submitted by other packages, in the calculation of the time step.  ATS\\_PERCEL must be greater than zero.  If a value of zero is specified for ATS\\_PERCEL the program will automatically reset it to an internal no data value to indicate that time steps should not be subject to this constraint."
+    }
+  },
+  "water_content": {
+    "options": {
+      ".uzf": "keyword to specify that record corresponds to unsaturated zone water contents."
+    }
+  },
+  "simulate_et": {
+    "options": {
+      ".uzf": "keyword specifying that ET in the unsaturated (UZF) and saturated zones (GWF) will be simulated. ET can be simulated in the UZF cell and not the GWF cell by omitting keywords LINEAR\\_GWET and SQUARE\\_GWET."
+    }
+  },
+  "linear_gwet": {
+    "options": {
+      ".uzf": "keyword specifying that groundwater ET will be simulated using the original ET formulation of MODFLOW-2005."
+    }
+  },
+  "square_gwet": {
+    "options": {
+      ".uzf": "keyword specifying that groundwater ET will be simulated by assuming a constant ET rate for groundwater levels between land surface (TOP) and land surface minus the ET extinction depth (TOP-EXTDP). Groundwater ET is smoothly reduced from the PET rate to zero over a nominal interval at TOP-EXTDP."
+    }
+  },
+  "simulate_gwseep": {
+    "options": {
+      ".uzf": "keyword specifying that groundwater discharge (GWSEEP) to land surface will be simulated. Groundwater discharge is nonzero when groundwater head is greater than land surface.  This option is no longer recommended; a better approach is to use the Drain Package with discharge scaling as a way to handle seepage to land surface.  The Drain Package with discharge scaling is described in Chapter 3 of the Supplemental Technical Information. "
+    }
+  },
+  "unsat_etwc": {
+    "options": {
+      ".uzf": "keyword specifying that ET in the unsaturated zone will be simulated as a function of the specified PET rate while the water content (THETA) is greater than the ET extinction water content (EXTWC)."
+    }
+  },
+  "unsat_etae": {
+    "options": {
+      ".uzf": "keyword specifying that ET in the unsaturated zone will be simulated using a capillary pressure based formulation. Capillary pressure is calculated using the Brooks-Corey retention function."
+    }
+  },
+  "nuzfcells": {
+    "dimensions": {
+      ".uzf": "is the number of UZF cells.  More than one UZF cell can be assigned to a GWF cell; however, only one GWF cell can be assigned to a single UZF cell. If more than one UZF cell is assigned to a GWF cell, then an auxiliary variable should be used to reduce the surface area of the UZF cell with the AUXMULTNAME option."
+    }
+  },
+  "ntrailwaves": {
+    "dimensions": {
+      ".uzf": "is the number of trailing waves.  A recommended value of 7 can be used for NTRAILWAVES.  This value can be increased to lower mass balance error in the unsaturated zone."
+    }
+  },
+  "nwavesets": {
+    "dimensions": {
+      ".uzf": "is the number of wave sets.  A recommended value of 40 can be used for NWAVESETS.  This value can be increased if more waves are required to resolve variations in water content within the unsaturated zone."
+    }
+  },
+  "cim": {
+    "options": {
+      ".ist": "keyword to specify that record corresponds to immobile concentration."
+    },
+    "griddata": {
+      ".ist": "initial concentration of the immobile domain in mass per length cubed.  If CIM is not specified, then it is assumed to be zero."
+    }
+  },
+  "volfrac": {
+    "griddata": {
+      ".ist": "fraction of the cell volume that consists of this immobile domain.  The sum of all immobile domain volume fractions must be less than one."
+    }
+  },
+  "zetaim": {
+    "griddata": {
+      ".ist": "mass transfer rate coefficient between the mobile and immobile domains, in dimensions of per time."
+    }
+  },
+  "netcdf_mesh2d": {
+    "options": {
+      ".nam": "keyword to specify that record corresponds to a layered mesh netcdf file."
+    }
+  },
+  "netcdf_structured": {
+    "options": {
+      ".nam": "keyword to specify that record corresponds to a structured netcdf file."
+    }
+  },
+  "netcdf": {
+    "options": {
+      ".nam": "keyword to specify that record corresponds to a netcdf input file."
+    }
+  },
+  "print_head": {
+    "options": {
+      ".maw": "keyword to indicate that the list of multi-aquifer well heads will be printed to the listing file for every stress period in which ``HEAD PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_HEAD is specified, then heads are printed for the last time step of each stress period."
+    }
+  },
+  "no_well_storage": {
+    "options": {
+      ".maw": "keyword that deactivates inclusion of well storage contributions to the multi-aquifer well package continuity equation."
+    }
+  },
+  "flow_correction": {
+    "options": {
+      ".maw": "keyword that activates flow corrections in cases where the head in a multi-aquifer well is below the bottom of the screen for a connection or the head in a convertible cell connected to a multi-aquifer well is below the cell bottom. When flow corrections are activated, unit head gradients are used to calculate the flow between a multi-aquifer well and a connected GWF cell. By default, flow corrections are not made."
+    }
+  },
+  "flowing_wells": {
+    "options": {
+      ".maw": "keyword that activates the flowing wells option for the multi-aquifer well package."
+    }
+  },
+  "shutdown_theta": {
+    "options": {
+      ".maw": "value that defines the weight applied to discharge rate for wells that limit the water level in a discharging well (defined using the HEAD\\_LIMIT keyword in the stress period data). SHUTDOWN\\_THETA is used to control discharge rate oscillations when the flow rate from the aquifer is less than the specified flow rate from the aquifer to the well. Values range between 0.0 and 1.0, and larger values increase the weight (decrease under-relaxation) applied to the well discharge rate. The HEAD\\_LIMIT option has been included to facilitate backward compatibility with previous versions of MODFLOW but use of the RATE\\_SCALING option instead of the HEAD\\_LIMIT option is recommended. By default, SHUTDOWN\\_THETA is 0.7."
+    }
+  },
+  "shutdown_kappa": {
+    "options": {
+      ".maw": "value that defines the weight applied to discharge rate for wells that limit the water level in a discharging well (defined using the HEAD\\_LIMIT keyword in the stress period data). SHUTDOWN\\_KAPPA is used to control discharge rate oscillations when the flow rate from the aquifer is less than the specified flow rate from the aquifer to the well. Values range between 0.0 and 1.0, and larger values increase the weight applied to the well discharge rate. The HEAD\\_LIMIT option has been included to facilitate backward compatibility with previous versions of MODFLOW but use of the RATE\\_SCALING option instead of the HEAD\\_LIMIT option is recommended. By default, SHUTDOWN\\_KAPPA is 0.0001."
+    }
+  },
+  "maw_flow_reduce_csv": {
+    "options": {
+      ".maw": "keyword to specify that record corresponds to the output option in which a new record is written for each multi-aquifer well and for each time step in which the user-requested extraction or injection rate is reduced by the program."
+    }
+  },
+  "nmawwells": {
+    "dimensions": {
+      ".maw": "integer value specifying the number of multi-aquifer wells that will be simulated for all stress periods."
+    }
+  },
+  "flowing_well": {
+    "period": {
+      ".maw": "keyword to indicate the well is a flowing well.  The FLOWING\\_WELL option can be used to simulate flowing wells when the simulated well head exceeds the specified drainage elevation."
+    }
+  },
+  "well_head": {
+    "period": {
+      ".maw": "is the head in the multi-aquifer well. WELL\\_HEAD is only applied to constant head (STATUS is CONSTANT) and inactive (STATUS is INACTIVE) multi-aquifer wells. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. The program will terminate with an error if WELL\\_HEAD is less than the bottom of the well."
+    }
+  },
+  "head_limit": {
+    "period": {
+      ".maw": "is the limiting water level (head) in the well, which is the minimum of the well RATE or the well inflow rate from the aquifer. HEAD\\_LIMIT can be applied to extraction wells (RATE $<$ 0) or injection wells (RATE $>$ 0). HEAD\\_LIMIT can be deactivated by specifying the text string `OFF'. The HEAD\\_LIMIT option is based on the HEAD\\_LIMIT functionality available in the MNW2~\\citep{konikow2009} package for MODFLOW-2005. The HEAD\\_LIMIT option has been included to facilitate backward compatibility with previous versions of MODFLOW but use of the RATE\\_SCALING option instead of the HEAD\\_LIMIT option is recommended. By default, HEAD\\_LIMIT is `OFF'."
+    }
+  },
+  "shut_off": {
+    "period": {
+      ".maw": "keyword for activating well shut off capability.  Subsequent values define the minimum and maximum pumping rate that a well must exceed to shutoff or reactivate a well, respectively, during a stress period. SHUT\\_OFF is only applied to injection wells (RATE$<0$) and if HEAD\\_LIMIT is specified (not set to `OFF').  If HEAD\\_LIMIT is specified, SHUT\\_OFF can be deactivated by specifying a minimum value equal to zero. The SHUT\\_OFF option is based on the SHUT\\_OFF functionality available in the MNW2~\\citep{konikow2009} package for MODFLOW-2005. The SHUT\\_OFF option has been included to facilitate backward compatibility with previous versions of MODFLOW but use of the RATE\\_SCALING option instead of the SHUT\\_OFF option is recommended. By default, SHUT\\_OFF is not used."
+    }
+  },
+  "rate_scaling": {
+    "period": {
+      ".maw": "activate rate scaling.  If RATE\\_SCALING is specified, both PUMP\\_ELEVATION and SCALING\\_LENGTH must be specified. RATE\\_SCALING cannot be used with HEAD\\_LIMIT.  RATE\\_SCALING can be used for extraction or injection wells.  For extraction wells, the extraction rate will start to decrease once the head in the well lowers to a level equal to the pump elevation plus the scaling length.  If the head in the well drops below the pump elevation, then the extraction rate is calculated to be zero.  For an injection well, the injection rate will begin to decrease once the head in the well rises above the specified pump elevation.  If the head in the well rises above the pump elevation plus the scaling length, then the injection rate will be set to zero."
+    }
+  },
+  "mixed": {
+    "fileinput": {
+      ".ssm": "keyword to specify that these stress package boundaries will have the mixed condition.  The MIXED condition is described in the SOURCES block for AUXMIXED.  The MIXED condition allows for water to be withdrawn at a concentration that is less than the cell concentration.  It is intended primarily for representing evapotranspiration."
+    }
+  },
+  "surf_rate_specified": {
+    "options": {
+      ".evt": "indicates that the proportion of the evapotranspiration rate at the ET surface will be specified as PETM0 in list input."
+    }
+  },
+  "nseg": {
+    "dimensions": {
+      ".evt": "number of ET segments.  Default is one.  When NSEG is greater than 1, the PXDP and PETM arrays must be of size NSEG - 1 and be listed in order from the uppermost segment down. Values for PXDP must be listed first followed by the values for PETM.  PXDP defines the extinction-depth proportion at the bottom of a segment. PETM defines the proportion of the maximum ET flux rate at the bottom of a segment."
+    }
+  },
+  "time_units": {
+    "options": {
+      ".tdis": "is the time units of the simulation.  This is a text string that is used as a label within model output files.  Values for time\\_units may be ``unknown'',  ``seconds'', ``minutes'', ``hours'', ``days'', or ``years''.  The default time unit is ``unknown''."
+    }
+  },
+  "start_date_time": {
+    "options": {
+      ".tdis": "is the starting date and time of the simulation.  This is a text string that is used as a label within the simulation list file.  The value has no effect on the simulation.  The recommended format for the starting date and time is described at https://www.w3.org/TR/NOTE-datetime."
+    }
+  },
+  "ats6": {
+    "options": {
+      ".tdis": "keyword to specify that record corresponds to an adaptive time step (ATS) input file.  The behavior of ATS and a description of the input file is provided separately."
+    }
+  },
+  "nper": {
+    "dimensions": {
+      ".tdis": "is the number of stress periods for the simulation."
+    }
+  }
+}

--- a/src/providers/hover.json
+++ b/src/providers/hover.json
@@ -1,3116 +1,4494 @@
 {
   "adv_scheme": {
     "options": {
-      "exg-gwegwe": "scheme used to solve the advection term.  Can be upstream, central, or TVD.  If not specified, upstream weighting is the default weighting scheme.",
-      "exg-gwtgwt": "scheme used to solve the advection term.  Can be upstream, central, or TVD.  If not specified, upstream weighting is the default weighting scheme."
+      "scheme used to solve the advection term.  Can be upstream, central, or TVD.  If not specified, upstream weighting is the default weighting scheme.": [
+        "exg-gwegwe",
+        "exg-gwtgwt"
+      ]
     }
   },
   "alh": {
     "griddata": {
-      "gwe-cnd": "longitudinal dispersivity in horizontal direction.  If flow is strictly horizontal, then this is the longitudinal dispersivity that will be used.  If flow is not strictly horizontal or strictly vertical, then the longitudinal dispersivity is a function of both ALH and ALV.  If mechanical dispersion is represented (by specifying any dispersivity values) then this array is required.",
-      "gwt-dsp": "longitudinal dispersivity in horizontal direction.  If flow is strictly horizontal, then this is the longitudinal dispersivity that will be used.  If flow is not strictly horizontal or strictly vertical, then the longitudinal dispersivity is a function of both ALH and ALV.  If mechanical dispersion is represented (by specifying any dispersivity values) then this array is required."
+      "longitudinal dispersivity in horizontal direction.  If flow is strictly horizontal, then this is the longitudinal dispersivity that will be used.  If flow is not strictly horizontal or strictly vertical, then the longitudinal dispersivity is a function of both ALH and ALV.  If mechanical dispersion is represented (by specifying any dispersivity values) then this array is required.": [
+        "gwe-cnd",
+        "gwt-dsp"
+      ]
     }
   },
   "all": {
     "period": {
-      "chf-oc": "keyword to indicate save for all time steps in period.",
-      "gwe-oc": "keyword to indicate save for all time steps in period.",
-      "gwf-oc": "keyword to indicate save for all time steps in period.",
-      "gwt-oc": "keyword to indicate save for all time steps in period.",
-      "olf-oc": "keyword to indicate save for all time steps in period.",
-      "prt-oc": "keyword to indicate save for all time steps in period.",
-      "prt-prp": "keyword to indicate release at the start of all time steps in the period.",
-      "swf-oc": "keyword to indicate save for all time steps in period."
+      "keyword to indicate release at the start of all time steps in the period.": [
+        "prt-prp"
+      ],
+      "keyword to indicate save for all time steps in period.": [
+        "chf-oc",
+        "gwe-oc",
+        "gwf-oc",
+        "gwt-oc",
+        "olf-oc",
+        "prt-oc",
+        "swf-oc"
+      ]
     }
   },
   "alternative_cell_averaging": {
     "options": {
-      "gwf-npf": "is a text keyword to indicate that an alternative method will be used for calculating the conductance for horizontal cell connections.  The text value for ALTERNATIVE\\_CELL\\_AVERAGING can be ``LOGARITHMIC'', ``AMT-LMK'', or ``AMT-HMK''.  ``AMT-LMK'' signifies that the conductance will be calculated using arithmetic-mean thickness and logarithmic-mean hydraulic conductivity.  ``AMT-HMK'' signifies that the conductance will be calculated using arithmetic-mean thickness and harmonic-mean hydraulic conductivity. If the user does not specify a value for ALTERNATIVE\\_CELL\\_AVERAGING, then the harmonic-mean method will be used.  This option cannot be used if the XT3D option is invoked."
+      "is a text keyword to indicate that an alternative method will be used for calculating the conductance for horizontal cell connections.  The text value for ALTERNATIVE\\_CELL\\_AVERAGING can be ``LOGARITHMIC'', ``AMT-LMK'', or ``AMT-HMK''.  ``AMT-LMK'' signifies that the conductance will be calculated using arithmetic-mean thickness and logarithmic-mean hydraulic conductivity.  ``AMT-HMK'' signifies that the conductance will be calculated using arithmetic-mean thickness and harmonic-mean hydraulic conductivity. If the user does not specify a value for ALTERNATIVE\\_CELL\\_AVERAGING, then the harmonic-mean method will be used.  This option cannot be used if the XT3D option is invoked.": [
+        "gwf-npf"
+      ]
     }
   },
   "alv": {
     "griddata": {
-      "gwe-cnd": "longitudinal dispersivity in vertical direction.  If flow is strictly vertical, then this is the longitudinal dispsersivity value that will be used.  If flow is not strictly horizontal or strictly vertical, then the longitudinal dispersivity is a function of both ALH and ALV.  If this value is not specified and mechanical dispersion is represented, then this array is set equal to ALH.",
-      "gwt-dsp": "longitudinal dispersivity in vertical direction.  If flow is strictly vertical, then this is the longitudinal dispsersivity value that will be used.  If flow is not strictly horizontal or strictly vertical, then the longitudinal dispersivity is a function of both ALH and ALV.  If this value is not specified and mechanical dispersion is represented, then this array is set equal to ALH."
+      "longitudinal dispersivity in vertical direction.  If flow is strictly vertical, then this is the longitudinal dispsersivity value that will be used.  If flow is not strictly horizontal or strictly vertical, then the longitudinal dispersivity is a function of both ALH and ALV.  If this value is not specified and mechanical dispersion is represented, then this array is set equal to ALH.": [
+        "gwe-cnd",
+        "gwt-dsp"
+      ]
     }
   },
   "angldegx": {
     "connectiondata": {
-      "gwe-disu": "is the angle (in degrees) between the horizontal x-axis and the outward normal to the face between a cell and its connecting cells. The angle varies between zero and 360.0 degrees, where zero degrees points in the positive x-axis direction, and 90 degrees points in the positive y-axis direction.  ANGLDEGX is only needed if horizontal anisotropy is specified in the NPF Package, if the XT3D option is used in the NPF Package, or if the SAVE\\_SPECIFIC\\_DISCHARGE option is specified in the NPF Package.  ANGLDEGX does not need to be specified if these conditions are not met.  ANGLDEGX is of size NJA; values specified for vertical connections and for the diagonal position are not used.  Note that ANGLDEGX is read in degrees, which is different from MODFLOW-USG, which reads a similar variable (ANGLEX) in radians.",
-      "gwf-disu": "is the angle (in degrees) between the horizontal x-axis and the outward normal to the face between a cell and its connecting cells. The angle varies between zero and 360.0 degrees, where zero degrees points in the positive x-axis direction, and 90 degrees points in the positive y-axis direction.  ANGLDEGX is only needed if horizontal anisotropy is specified in the NPF Package, if the XT3D option is used in the NPF Package, or if the SAVE\\_SPECIFIC\\_DISCHARGE option is specified in the NPF Package.  ANGLDEGX does not need to be specified if these conditions are not met.  ANGLDEGX is of size NJA; values specified for vertical connections and for the diagonal position are not used.  Note that ANGLDEGX is read in degrees, which is different from MODFLOW-USG, which reads a similar variable (ANGLEX) in radians.",
-      "gwt-disu": "is the angle (in degrees) between the horizontal x-axis and the outward normal to the face between a cell and its connecting cells. The angle varies between zero and 360.0 degrees, where zero degrees points in the positive x-axis direction, and 90 degrees points in the positive y-axis direction.  ANGLDEGX is only needed if horizontal anisotropy is specified in the NPF Package, if the XT3D option is used in the NPF Package, or if the SAVE\\_SPECIFIC\\_DISCHARGE option is specified in the NPF Package.  ANGLDEGX does not need to be specified if these conditions are not met.  ANGLDEGX is of size NJA; values specified for vertical connections and for the diagonal position are not used.  Note that ANGLDEGX is read in degrees, which is different from MODFLOW-USG, which reads a similar variable (ANGLEX) in radians."
+      "is the angle (in degrees) between the horizontal x-axis and the outward normal to the face between a cell and its connecting cells. The angle varies between zero and 360.0 degrees, where zero degrees points in the positive x-axis direction, and 90 degrees points in the positive y-axis direction.  ANGLDEGX is only needed if horizontal anisotropy is specified in the NPF Package, if the XT3D option is used in the NPF Package, or if the SAVE\\_SPECIFIC\\_DISCHARGE option is specified in the NPF Package.  ANGLDEGX does not need to be specified if these conditions are not met.  ANGLDEGX is of size NJA; values specified for vertical connections and for the diagonal position are not used.  Note that ANGLDEGX is read in degrees, which is different from MODFLOW-USG, which reads a similar variable (ANGLEX) in radians.": [
+        "gwe-disu",
+        "gwf-disu",
+        "gwt-disu"
+      ]
     }
   },
   "angle1": {
     "griddata": {
-      "gwf-npf": "is a rotation angle of the hydraulic conductivity tensor in degrees. The angle represents the first of three sequential rotations of the hydraulic conductivity ellipsoid. With the K11, K22, and K33 axes of the ellipsoid initially aligned with the x, y, and z coordinate axes, respectively, ANGLE1 rotates the ellipsoid about its K33 axis (within the x - y plane). A positive value represents counter-clockwise rotation when viewed from any point on the positive K33 axis, looking toward the center of the ellipsoid. A value of zero indicates that the K11 axis lies within the x - z plane. If ANGLE1 is not specified, default values of zero are assigned to ANGLE1, ANGLE2, and ANGLE3, in which case the K11, K22, and K33 axes are aligned with the x, y, and z axes, respectively."
+      "is a rotation angle of the hydraulic conductivity tensor in degrees. The angle represents the first of three sequential rotations of the hydraulic conductivity ellipsoid. With the K11, K22, and K33 axes of the ellipsoid initially aligned with the x, y, and z coordinate axes, respectively, ANGLE1 rotates the ellipsoid about its K33 axis (within the x - y plane). A positive value represents counter-clockwise rotation when viewed from any point on the positive K33 axis, looking toward the center of the ellipsoid. A value of zero indicates that the K11 axis lies within the x - z plane. If ANGLE1 is not specified, default values of zero are assigned to ANGLE1, ANGLE2, and ANGLE3, in which case the K11, K22, and K33 axes are aligned with the x, y, and z axes, respectively.": [
+        "gwf-npf"
+      ]
     }
   },
   "angle2": {
     "griddata": {
-      "gwf-npf": "is a rotation angle of the hydraulic conductivity tensor in degrees. The angle represents the second of three sequential rotations of the hydraulic conductivity ellipsoid. Following the rotation by ANGLE1 described above, ANGLE2 rotates the ellipsoid about its K22 axis (out of the x - y plane). An array can be specified for ANGLE2 only if ANGLE1 is also specified. A positive value of ANGLE2 represents clockwise rotation when viewed from any point on the positive K22 axis, looking toward the center of the ellipsoid. A value of zero indicates that the K11 axis lies within the x - y plane. If ANGLE2 is not specified, default values of zero are assigned to ANGLE2 and ANGLE3; connections that are not user-designated as vertical are assumed to be strictly horizontal (that is, to have no z component to their orientation); and connection lengths are based on horizontal distances."
+      "is a rotation angle of the hydraulic conductivity tensor in degrees. The angle represents the second of three sequential rotations of the hydraulic conductivity ellipsoid. Following the rotation by ANGLE1 described above, ANGLE2 rotates the ellipsoid about its K22 axis (out of the x - y plane). An array can be specified for ANGLE2 only if ANGLE1 is also specified. A positive value of ANGLE2 represents clockwise rotation when viewed from any point on the positive K22 axis, looking toward the center of the ellipsoid. A value of zero indicates that the K11 axis lies within the x - y plane. If ANGLE2 is not specified, default values of zero are assigned to ANGLE2 and ANGLE3; connections that are not user-designated as vertical are assumed to be strictly horizontal (that is, to have no z component to their orientation); and connection lengths are based on horizontal distances.": [
+        "gwf-npf"
+      ]
     }
   },
   "angle3": {
     "griddata": {
-      "gwf-npf": "is a rotation angle of the hydraulic conductivity tensor in degrees. The angle represents the third of three sequential rotations of the hydraulic conductivity ellipsoid. Following the rotations by ANGLE1 and ANGLE2 described above, ANGLE3 rotates the ellipsoid about its K11 axis. An array can be specified for ANGLE3 only if ANGLE1 and ANGLE2 are also specified. An array must be specified for ANGLE3 if ANGLE2 is specified. A positive value of ANGLE3 represents clockwise rotation when viewed from any point on the positive K11 axis, looking toward the center of the ellipsoid. A value of zero indicates that the K22 axis lies within the x - y plane."
+      "is a rotation angle of the hydraulic conductivity tensor in degrees. The angle represents the third of three sequential rotations of the hydraulic conductivity ellipsoid. Following the rotations by ANGLE1 and ANGLE2 described above, ANGLE3 rotates the ellipsoid about its K11 axis. An array can be specified for ANGLE3 only if ANGLE1 and ANGLE2 are also specified. An array must be specified for ANGLE3 if ANGLE2 is specified. A positive value of ANGLE3 represents clockwise rotation when viewed from any point on the positive K11 axis, looking toward the center of the ellipsoid. A value of zero indicates that the K22 axis lies within the x - y plane.": [
+        "gwf-npf"
+      ]
     }
   },
   "angrot": {
     "options": {
-      "chf-disv1d": "counter-clockwise rotation angle (in degrees) of the model grid coordinate system relative to a real-world coordinate system.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      "gwe-dis": "counter-clockwise rotation angle (in degrees) of the lower-left corner of the model grid.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      "gwe-disu": "counter-clockwise rotation angle (in degrees) of the model grid coordinate system relative to a real-world coordinate system.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      "gwe-disv": "counter-clockwise rotation angle (in degrees) of the model grid coordinate system relative to a real-world coordinate system.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      "gwf-dis": "counter-clockwise rotation angle (in degrees) of the lower-left corner of the model grid.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      "gwf-disu": "counter-clockwise rotation angle (in degrees) of the model grid coordinate system relative to a real-world coordinate system.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      "gwf-disv": "counter-clockwise rotation angle (in degrees) of the model grid coordinate system relative to a real-world coordinate system.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      "gwt-dis": "counter-clockwise rotation angle (in degrees) of the lower-left corner of the model grid.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      "gwt-disu": "counter-clockwise rotation angle (in degrees) of the model grid coordinate system relative to a real-world coordinate system.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      "gwt-disv": "counter-clockwise rotation angle (in degrees) of the model grid coordinate system relative to a real-world coordinate system.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      "olf-dis2d": "counter-clockwise rotation angle (in degrees) of the lower-left corner of the model grid.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      "olf-disv1d": "counter-clockwise rotation angle (in degrees) of the model grid coordinate system relative to a real-world coordinate system.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      "olf-disv2d": "counter-clockwise rotation angle (in degrees) of the lower-left corner of the model grid.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      "prt-dis": "counter-clockwise rotation angle (in degrees) of the lower-left corner of the model grid.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      "prt-disv": "counter-clockwise rotation angle (in degrees) of the model grid coordinate system relative to a real-world coordinate system.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      "swf-dis2d": "counter-clockwise rotation angle (in degrees) of the lower-left corner of the model grid.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      "swf-disv1d": "counter-clockwise rotation angle (in degrees) of the model grid coordinate system relative to a real-world coordinate system.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      "swf-disv2d": "counter-clockwise rotation angle (in degrees) of the lower-left corner of the model grid.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space."
+      "counter-clockwise rotation angle (in degrees) of the lower-left corner of the model grid.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.": [
+        "gwe-dis",
+        "gwf-dis",
+        "gwt-dis",
+        "olf-dis2d",
+        "olf-disv2d",
+        "prt-dis",
+        "swf-dis2d",
+        "swf-disv2d"
+      ],
+      "counter-clockwise rotation angle (in degrees) of the model grid coordinate system relative to a real-world coordinate system.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.": [
+        "chf-disv1d",
+        "gwe-disu",
+        "gwe-disv",
+        "gwf-disu",
+        "gwf-disv",
+        "gwt-disu",
+        "gwt-disv",
+        "olf-disv1d",
+        "prt-disv",
+        "swf-disv1d"
+      ]
     }
   },
   "area": {
     "griddata": {
-      "gwe-disu": "is the cell surface area (in plan view).",
-      "gwf-disu": "is the cell surface area (in plan view).",
-      "gwt-disu": "is the cell surface area (in plan view)."
+      "is the cell surface area (in plan view).": [
+        "gwe-disu",
+        "gwf-disu",
+        "gwt-disu"
+      ]
     }
   },
   "ath1": {
     "griddata": {
-      "gwe-cnd": "transverse dispersivity in horizontal direction.  This is the transverse dispersivity value for the second ellipsoid axis.  If flow is strictly horizontal and directed in the x direction (along a row for a regular grid), then this value controls spreading in the y direction.  If mechanical dispersion is represented (by specifying any dispersivity values) then this array is required.",
-      "gwt-dsp": "transverse dispersivity in horizontal direction.  This is the transverse dispersivity value for the second ellipsoid axis.  If flow is strictly horizontal and directed in the x direction (along a row for a regular grid), then this value controls spreading in the y direction.  If mechanical dispersion is represented (by specifying any dispersivity values) then this array is required."
+      "transverse dispersivity in horizontal direction.  This is the transverse dispersivity value for the second ellipsoid axis.  If flow is strictly horizontal and directed in the x direction (along a row for a regular grid), then this value controls spreading in the y direction.  If mechanical dispersion is represented (by specifying any dispersivity values) then this array is required.": [
+        "gwe-cnd",
+        "gwt-dsp"
+      ]
     }
   },
   "ath2": {
     "griddata": {
-      "gwe-cnd": "transverse dispersivity in horizontal direction.  This is the transverse dispersivity value for the third ellipsoid axis.  If flow is strictly horizontal and directed in the x direction (along a row for a regular grid), then this value controls spreading in the z direction.  If this value is not specified and mechanical dispersion is represented, then this array is set equal to ATH1.",
-      "gwt-dsp": "transverse dispersivity in horizontal direction.  This is the transverse dispersivity value for the third ellipsoid axis.  If flow is strictly horizontal and directed in the x direction (along a row for a regular grid), then this value controls spreading in the z direction.  If this value is not specified and mechanical dispersion is represented, then this array is set equal to ATH1."
+      "transverse dispersivity in horizontal direction.  This is the transverse dispersivity value for the third ellipsoid axis.  If flow is strictly horizontal and directed in the x direction (along a row for a regular grid), then this value controls spreading in the z direction.  If this value is not specified and mechanical dispersion is represented, then this array is set equal to ATH1.": [
+        "gwe-cnd",
+        "gwt-dsp"
+      ]
     }
   },
   "ats6": {
     "options": {
-      "sim-tdis": "keyword to specify that record corresponds to an adaptive time step (ATS) input file.  The behavior of ATS and a description of the input file is provided separately."
+      "keyword to specify that record corresponds to an adaptive time step (ATS) input file.  The behavior of ATS and a description of the input file is provided separately.": [
+        "sim-tdis"
+      ]
     }
   },
   "ats_outer_maximum_fraction": {
     "options": {
-      "sln-ims": "real value defining the fraction of the maximum allowable outer iterations used with the Adaptive Time Step (ATS) capability if it is active.  If this value is set to zero by the user, then this solution will have no effect on ATS behavior.  This value must be greater than or equal to zero and less than or equal to 0.5 or the program will terminate with an error.  If it is not specified by the user, then it is assigned a default value of one third.  When the number of outer iterations for this solution is less than the product of this value and the maximum allowable outer iterations, then ATS will increase the time step length by a factor of DTADJ in the ATS input file.  When the number of outer iterations for this solution is greater than the maximum allowable outer iterations minus the product of this value and the maximum allowable outer iterations, then the ATS (if active) will decrease the time step length by a factor of 1 / DTADJ.",
-      "sln-pts": "real value defining the fraction of the maximum allowable outer iterations used with the Adaptive Time Step (ATS) capability if it is active.  If this value is set to zero by the user, then this solution will have no effect on ATS behavior.  This value must be greater than or equal to zero and less than or equal to 0.5 or the program will terminate with an error.  If it is not specified by the user, then it is assigned a default value of one third.  When the number of outer iterations for this solution is less than the product of this value and the maximum allowable outer iterations, then ATS will increase the time step length by a factor of DTADJ in the ATS input file.  When the number of outer iterations for this solution is greater than the maximum allowable outer iterations minus the product of this value and the maximum allowable outer iterations, then the ATS (if active) will decrease the time step length by a factor of 1 / DTADJ."
+      "real value defining the fraction of the maximum allowable outer iterations used with the Adaptive Time Step (ATS) capability if it is active.  If this value is set to zero by the user, then this solution will have no effect on ATS behavior.  This value must be greater than or equal to zero and less than or equal to 0.5 or the program will terminate with an error.  If it is not specified by the user, then it is assigned a default value of one third.  When the number of outer iterations for this solution is less than the product of this value and the maximum allowable outer iterations, then ATS will increase the time step length by a factor of DTADJ in the ATS input file.  When the number of outer iterations for this solution is greater than the maximum allowable outer iterations minus the product of this value and the maximum allowable outer iterations, then the ATS (if active) will decrease the time step length by a factor of 1 / DTADJ.": [
+        "sln-ims",
+        "sln-pts"
+      ]
     }
   },
   "ats_percel": {
     "options": {
-      "gwt-adv": "fractional cell distance submitted by the ADV Package to the adaptive time stepping (ATS) package.  If ATS\\_PERCEL is specified and the ATS Package is active, a time step calculation will be made for each cell based on flow through the cell and cell properties.  The largest time step will be calculated such that the advective fractional cell distance (ATS\\_PERCEL) is not exceeded for any active cell in the grid.  This time-step constraint will be submitted to the ATS Package, perhaps with constraints submitted by other packages, in the calculation of the time step.  ATS\\_PERCEL must be greater than zero.  If a value of zero is specified for ATS\\_PERCEL the program will automatically reset it to an internal no data value to indicate that time steps should not be subject to this constraint."
+      "fractional cell distance submitted by the ADV Package to the adaptive time stepping (ATS) package.  If ATS\\_PERCEL is specified and the ATS Package is active, a time step calculation will be made for each cell based on flow through the cell and cell properties.  The largest time step will be calculated such that the advective fractional cell distance (ATS\\_PERCEL) is not exceeded for any active cell in the grid.  This time-step constraint will be submitted to the ATS Package, perhaps with constraints submitted by other packages, in the calculation of the time step.  ATS\\_PERCEL must be greater than zero.  If a value of zero is specified for ATS\\_PERCEL the program will automatically reset it to an internal no data value to indicate that time steps should not be subject to this constraint.": [
+        "gwt-adv"
+      ]
     }
   },
   "atv": {
     "griddata": {
-      "gwe-cnd": "transverse dispersivity when flow is in vertical direction.  If flow is strictly vertical and directed in the z direction, then this value controls spreading in the x and y directions.  If this value is not specified and mechanical dispersion is represented, then this array is set equal to ATH2.",
-      "gwt-dsp": "transverse dispersivity when flow is in vertical direction.  If flow is strictly vertical and directed in the z direction, then this value controls spreading in the x and y directions.  If this value is not specified and mechanical dispersion is represented, then this array is set equal to ATH2."
+      "transverse dispersivity when flow is in vertical direction.  If flow is strictly vertical and directed in the z direction, then this value controls spreading in the x and y directions.  If this value is not specified and mechanical dispersion is represented, then this array is set equal to ATH2.": [
+        "gwe-cnd",
+        "gwt-dsp"
+      ]
     }
   },
   "auto_flow_reduce": {
     "options": {
-      "gwf-wel": "keyword and real value that defines the fraction of the cell thickness used as an interval for smoothly adjusting negative pumping rates to 0 in cells with head values less than or equal to the bottom of the cell. Negative pumping rates are adjusted to 0 or a smaller negative value when the head in the cell is equal to or less than the calculated interval above the cell bottom. AUTO\\_FLOW\\_REDUCE is set to 0.1 if the specified value is less than or equal to zero. By default, negative pumping rates are not reduced during a simulation.  This AUTO\\_FLOW\\_REDUCE option only applies to wells in model cells that are marked as ``convertible'' (ICELLTYPE /= 0) in the Node Property Flow (NPF) input file. Reduction in flow will not occur for wells in cells marked as confined (ICELLTYPE = 0)."
+      "keyword and real value that defines the fraction of the cell thickness used as an interval for smoothly adjusting negative pumping rates to 0 in cells with head values less than or equal to the bottom of the cell. Negative pumping rates are adjusted to 0 or a smaller negative value when the head in the cell is equal to or less than the calculated interval above the cell bottom. AUTO\\_FLOW\\_REDUCE is set to 0.1 if the specified value is less than or equal to zero. By default, negative pumping rates are not reduced during a simulation.  This AUTO\\_FLOW\\_REDUCE option only applies to wells in model cells that are marked as ``convertible'' (ICELLTYPE /= 0) in the Node Property Flow (NPF) input file. Reduction in flow will not occur for wells in cells marked as confined (ICELLTYPE = 0).": [
+        "gwf-wel"
+      ]
     }
   },
   "auto_flow_reduce_csv": {
     "options": {
-      "gwf-wel": "keyword to specify that record corresponds to the AUTO\\_FLOW\\_REDUCE output option in which a new record is written for each well and for each time step in which the user-requested extraction rate is reduced by the program."
+      "keyword to specify that record corresponds to the AUTO\\_FLOW\\_REDUCE output option in which a new record is written for each well and for each time step in which the user-requested extraction rate is reduced by the program.": [
+        "gwf-wel"
+      ]
     }
   },
   "aux": {
     "period": {
-      "gwf-evta": "is an array of values for auxiliary variable AUX(IAUX), where iaux is a value from 1 to NAUX, and AUX(IAUX) must be listed as part of the auxiliary variables.  A separate array can be specified for each auxiliary variable.  If an array is not specified for an auxiliary variable, then a value of zero is assigned.  If the value specified here for the auxiliary variable is the same as auxmultname, then the evapotranspiration rate will be multiplied by this array.",
-      "gwf-rcha": "is an array of values for auxiliary variable aux(iaux), where iaux is a value from 1 to naux, and aux(iaux) must be listed as part of the auxiliary variables.  A separate array can be specified for each auxiliary variable.  If an array is not specified for an auxiliary variable, then a value of zero is assigned.  If the value specified here for the auxiliary variable is the same as auxmultname, then the recharge array will be multiplied by this array."
+      "is an array of values for auxiliary variable AUX(IAUX), where iaux is a value from 1 to NAUX, and AUX(IAUX) must be listed as part of the auxiliary variables.  A separate array can be specified for each auxiliary variable.  If an array is not specified for an auxiliary variable, then a value of zero is assigned.  If the value specified here for the auxiliary variable is the same as auxmultname, then the evapotranspiration rate will be multiplied by this array.": [
+        "gwf-evta"
+      ],
+      "is an array of values for auxiliary variable aux(iaux), where iaux is a value from 1 to naux, and aux(iaux) must be listed as part of the auxiliary variables.  A separate array can be specified for each auxiliary variable.  If an array is not specified for an auxiliary variable, then a value of zero is assigned.  If the value specified here for the auxiliary variable is the same as auxmultname, then the recharge array will be multiplied by this array.": [
+        "gwf-rcha"
+      ]
     }
   },
   "auxdepthname": {
     "options": {
-      "gwf-drn": "name of a variable listed in AUXILIARY that defines the depth at which drainage discharge will be scaled. If a positive value is specified for the AUXDEPTHNAME AUXILIARY variable, then ELEV is the elevation at which the drain starts to discharge and ELEV + DDRN (assuming DDRN is the AUXDEPTHNAME variable) is the elevation when the drain conductance (COND) scaling factor is 1. If a negative drainage depth value is specified for DDRN, then ELEV + DDRN is the elevation at which the drain starts to discharge and ELEV is the elevation when the conductance (COND) scaling factor is 1. A linear- or cubic-scaling is used to scale the drain conductance (COND) when the Standard or Newton-Raphson Formulation is used, respectively.  This discharge scaling option is described in more detail in Chapter 3 of the Supplemental Technical Information."
+      "name of a variable listed in AUXILIARY that defines the depth at which drainage discharge will be scaled. If a positive value is specified for the AUXDEPTHNAME AUXILIARY variable, then ELEV is the elevation at which the drain starts to discharge and ELEV + DDRN (assuming DDRN is the AUXDEPTHNAME variable) is the elevation when the drain conductance (COND) scaling factor is 1. If a negative drainage depth value is specified for DDRN, then ELEV + DDRN is the elevation at which the drain starts to discharge and ELEV is the elevation when the conductance (COND) scaling factor is 1. A linear- or cubic-scaling is used to scale the drain conductance (COND) when the Standard or Newton-Raphson Formulation is used, respectively.  This discharge scaling option is described in more detail in Chapter 3 of the Supplemental Technical Information.": [
+        "gwf-drn"
+      ]
     }
   },
   "auxiliary": {
     "options": {
-      "chf-cdb": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      "chf-chd": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      "chf-evp": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      "chf-flw": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      "chf-pcp": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      "chf-zdg": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      "exg-gwegwe": "an array of auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided. Most auxiliary variables will not be used by the GWE-GWE Exchange, but they will be available for use by other parts of the program.  If an auxiliary variable with the name ``ANGLDEGX'' is found, then this information will be used as the angle (provided in degrees) between the connection face normal and the x axis, where a value of zero indicates that a normal vector points directly along the positive x axis.  The connection face normal is a normal vector on the cell face shared between the cell in model 1 and the cell in model 2 pointing away from the model 1 cell.  Additional information on ``ANGLDEGX'' is provided in the description of the DISU Package.  If an auxiliary variable with the name ``CDIST'' is found, then this information will be used as the straight-line connection distance, including the vertical component, between the two cell centers.  Both ANGLDEGX and CDIST are required if specific discharge is calculated for either of the groundwater models.",
-      "exg-gwfgwf": "an array of auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided. Most auxiliary variables will not be used by the GWF-GWF Exchange, but they will be available for use by other parts of the program.  If an auxiliary variable with the name ``ANGLDEGX'' is found, then this information will be used as the angle (provided in degrees) between the connection face normal and the x axis, where a value of zero indicates that a normal vector points directly along the positive x axis.  The connection face normal is a normal vector on the cell face shared between the cell in model 1 and the cell in model 2 pointing away from the model 1 cell.  Additional information on ``ANGLDEGX'' and when it is required is provided in the description of the DISU Package.  If an auxiliary variable with the name ``CDIST'' is found, then this information will be used in the calculation of specific discharge within model cells connected by the exchange.  For a horizontal connection, CDIST should be specified as the horizontal distance between the cell centers, and should not include the vertical component.  For vertical connections, CDIST should be specified as the difference in elevation between the two cell centers.  Both ANGLDEGX and CDIST are required if specific discharge is calculated for either of the groundwater models.",
-      "exg-gwtgwt": "an array of auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided. Most auxiliary variables will not be used by the GWT-GWT Exchange, but they will be available for use by other parts of the program.  If an auxiliary variable with the name ``ANGLDEGX'' is found, then this information will be used as the angle (provided in degrees) between the connection face normal and the x axis, where a value of zero indicates that a normal vector points directly along the positive x axis.  The connection face normal is a normal vector on the cell face shared between the cell in model 1 and the cell in model 2 pointing away from the model 1 cell.  Additional information on ``ANGLDEGX'' is provided in the description of the DISU Package.  ANGLDEGX must be specified if dispersion is simulated in the connected GWT models.",
-      "gwe-ctp": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      "gwe-esl": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      "gwe-lke": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      "gwe-mwe": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      "gwe-sfe": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      "gwe-uze": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      "gwf-chd": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      "gwf-drn": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      "gwf-evt": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      "gwf-evta": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      "gwf-ghb": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      "gwf-lak": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      "gwf-maw": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      "gwf-rch": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      "gwf-rcha": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      "gwf-riv": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      "gwf-sfr": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      "gwf-uzf": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      "gwf-wel": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      "gwt-cnc": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      "gwt-lkt": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      "gwt-mwt": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      "gwt-sft": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      "gwt-src": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      "gwt-uzt": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      "olf-cdb": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      "olf-chd": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      "olf-evp": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      "olf-flw": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      "olf-pcp": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      "olf-zdg": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      "swf-cdb": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      "swf-chd": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      "swf-evp": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      "swf-flw": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      "swf-pcp": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      "swf-zdg": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block."
+      "an array of auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided. Most auxiliary variables will not be used by the GWE-GWE Exchange, but they will be available for use by other parts of the program.  If an auxiliary variable with the name ``ANGLDEGX'' is found, then this information will be used as the angle (provided in degrees) between the connection face normal and the x axis, where a value of zero indicates that a normal vector points directly along the positive x axis.  The connection face normal is a normal vector on the cell face shared between the cell in model 1 and the cell in model 2 pointing away from the model 1 cell.  Additional information on ``ANGLDEGX'' is provided in the description of the DISU Package.  If an auxiliary variable with the name ``CDIST'' is found, then this information will be used as the straight-line connection distance, including the vertical component, between the two cell centers.  Both ANGLDEGX and CDIST are required if specific discharge is calculated for either of the groundwater models.": [
+        "exg-gwegwe"
+      ],
+      "an array of auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided. Most auxiliary variables will not be used by the GWF-GWF Exchange, but they will be available for use by other parts of the program.  If an auxiliary variable with the name ``ANGLDEGX'' is found, then this information will be used as the angle (provided in degrees) between the connection face normal and the x axis, where a value of zero indicates that a normal vector points directly along the positive x axis.  The connection face normal is a normal vector on the cell face shared between the cell in model 1 and the cell in model 2 pointing away from the model 1 cell.  Additional information on ``ANGLDEGX'' and when it is required is provided in the description of the DISU Package.  If an auxiliary variable with the name ``CDIST'' is found, then this information will be used in the calculation of specific discharge within model cells connected by the exchange.  For a horizontal connection, CDIST should be specified as the horizontal distance between the cell centers, and should not include the vertical component.  For vertical connections, CDIST should be specified as the difference in elevation between the two cell centers.  Both ANGLDEGX and CDIST are required if specific discharge is calculated for either of the groundwater models.": [
+        "exg-gwfgwf"
+      ],
+      "an array of auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided. Most auxiliary variables will not be used by the GWT-GWT Exchange, but they will be available for use by other parts of the program.  If an auxiliary variable with the name ``ANGLDEGX'' is found, then this information will be used as the angle (provided in degrees) between the connection face normal and the x axis, where a value of zero indicates that a normal vector points directly along the positive x axis.  The connection face normal is a normal vector on the cell face shared between the cell in model 1 and the cell in model 2 pointing away from the model 1 cell.  Additional information on ``ANGLDEGX'' is provided in the description of the DISU Package.  ANGLDEGX must be specified if dispersion is simulated in the connected GWT models.": [
+        "exg-gwtgwt"
+      ],
+      "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.": [
+        "chf-cdb",
+        "chf-chd",
+        "chf-evp",
+        "chf-flw",
+        "chf-pcp",
+        "chf-zdg",
+        "gwe-ctp",
+        "gwe-esl",
+        "gwe-lke",
+        "gwe-mwe",
+        "gwe-sfe",
+        "gwe-uze",
+        "gwf-chd",
+        "gwf-drn",
+        "gwf-evt",
+        "gwf-evta",
+        "gwf-ghb",
+        "gwf-lak",
+        "gwf-maw",
+        "gwf-rch",
+        "gwf-rcha",
+        "gwf-riv",
+        "gwf-sfr",
+        "gwf-uzf",
+        "gwf-wel",
+        "gwt-cnc",
+        "gwt-lkt",
+        "gwt-mwt",
+        "gwt-sft",
+        "gwt-src",
+        "gwt-uzt",
+        "olf-cdb",
+        "olf-chd",
+        "olf-evp",
+        "olf-flw",
+        "olf-pcp",
+        "olf-zdg",
+        "swf-cdb",
+        "swf-chd",
+        "swf-evp",
+        "swf-flw",
+        "swf-pcp",
+        "swf-zdg"
+      ]
     },
     "period": {
-      "gwe-lke": "keyword for specifying auxiliary variable.",
-      "gwe-mwe": "keyword for specifying auxiliary variable.",
-      "gwe-sfe": "keyword for specifying auxiliary variable.",
-      "gwe-uze": "keyword for specifying auxiliary variable.",
-      "gwf-lak": "keyword for specifying auxiliary variable.",
-      "gwf-maw": "keyword for specifying auxiliary variable.",
-      "gwf-sfr": "keyword for specifying auxiliary variable.",
-      "gwt-lkt": "keyword for specifying auxiliary variable.",
-      "gwt-mwt": "keyword for specifying auxiliary variable.",
-      "gwt-sft": "keyword for specifying auxiliary variable.",
-      "gwt-uzt": "keyword for specifying auxiliary variable."
+      "keyword for specifying auxiliary variable.": [
+        "gwe-lke",
+        "gwe-mwe",
+        "gwe-sfe",
+        "gwe-uze",
+        "gwf-lak",
+        "gwf-maw",
+        "gwf-sfr",
+        "gwt-lkt",
+        "gwt-mwt",
+        "gwt-sft",
+        "gwt-uzt"
+      ]
     }
   },
   "auxmultname": {
     "options": {
-      "chf-chd": "name of auxiliary variable to be used as multiplier of CHD head value.",
-      "chf-evp": "name of auxiliary variable to be used as multiplier of evaporation.",
-      "chf-flw": "name of auxiliary variable to be used as multiplier of flow rate.",
-      "chf-pcp": "name of auxiliary variable to be used as multiplier of precipitation.",
-      "gwe-ctp": "name of auxiliary variable to be used as multiplier of temperature value.",
-      "gwe-esl": "name of auxiliary variable to be used as multiplier of energy loading rate.",
-      "gwf-chd": "name of auxiliary variable to be used as multiplier of CHD head value.",
-      "gwf-drn": "name of auxiliary variable to be used as multiplier of drain conductance.",
-      "gwf-evt": "name of auxiliary variable to be used as multiplier of evapotranspiration rate.",
-      "gwf-evta": "name of auxiliary variable to be used as multiplier of evapotranspiration rate.",
-      "gwf-ghb": "name of auxiliary variable to be used as multiplier of general-head boundary conductance.",
-      "gwf-rch": "name of auxiliary variable to be used as multiplier of recharge.",
-      "gwf-rcha": "name of auxiliary variable to be used as multiplier of recharge.",
-      "gwf-riv": "name of auxiliary variable to be used as multiplier of riverbed conductance.",
-      "gwf-uzf": "name of auxiliary variable to be used as multiplier of GWF cell area used by UZF cell.",
-      "gwf-wel": "name of auxiliary variable to be used as multiplier of well flow rate.",
-      "gwt-cnc": "name of auxiliary variable to be used as multiplier of concentration value.",
-      "gwt-src": "name of auxiliary variable to be used as multiplier of mass loading rate.",
-      "olf-chd": "name of auxiliary variable to be used as multiplier of CHD head value.",
-      "olf-evp": "name of auxiliary variable to be used as multiplier of evaporation.",
-      "olf-flw": "name of auxiliary variable to be used as multiplier of flow rate.",
-      "olf-pcp": "name of auxiliary variable to be used as multiplier of precipitation.",
-      "swf-chd": "name of auxiliary variable to be used as multiplier of CHD head value.",
-      "swf-evp": "name of auxiliary variable to be used as multiplier of evaporation.",
-      "swf-flw": "name of auxiliary variable to be used as multiplier of flow rate.",
-      "swf-pcp": "name of auxiliary variable to be used as multiplier of precipitation."
+      "name of auxiliary variable to be used as multiplier of CHD head value.": [
+        "chf-chd",
+        "gwf-chd",
+        "olf-chd",
+        "swf-chd"
+      ],
+      "name of auxiliary variable to be used as multiplier of GWF cell area used by UZF cell.": [
+        "gwf-uzf"
+      ],
+      "name of auxiliary variable to be used as multiplier of concentration value.": [
+        "gwt-cnc"
+      ],
+      "name of auxiliary variable to be used as multiplier of drain conductance.": [
+        "gwf-drn"
+      ],
+      "name of auxiliary variable to be used as multiplier of energy loading rate.": [
+        "gwe-esl"
+      ],
+      "name of auxiliary variable to be used as multiplier of evaporation.": [
+        "chf-evp",
+        "olf-evp",
+        "swf-evp"
+      ],
+      "name of auxiliary variable to be used as multiplier of evapotranspiration rate.": [
+        "gwf-evt",
+        "gwf-evta"
+      ],
+      "name of auxiliary variable to be used as multiplier of flow rate.": [
+        "chf-flw",
+        "olf-flw",
+        "swf-flw"
+      ],
+      "name of auxiliary variable to be used as multiplier of general-head boundary conductance.": [
+        "gwf-ghb"
+      ],
+      "name of auxiliary variable to be used as multiplier of mass loading rate.": [
+        "gwt-src"
+      ],
+      "name of auxiliary variable to be used as multiplier of precipitation.": [
+        "chf-pcp",
+        "olf-pcp",
+        "swf-pcp"
+      ],
+      "name of auxiliary variable to be used as multiplier of recharge.": [
+        "gwf-rch",
+        "gwf-rcha"
+      ],
+      "name of auxiliary variable to be used as multiplier of riverbed conductance.": [
+        "gwf-riv"
+      ],
+      "name of auxiliary variable to be used as multiplier of temperature value.": [
+        "gwe-ctp"
+      ],
+      "name of auxiliary variable to be used as multiplier of well flow rate.": [
+        "gwf-wel"
+      ]
     }
   },
   "backtracking_number": {
     "nonlinear": {
-      "sln-ims": "integer value defining the maximum number of backtracking iterations allowed for residual reduction computations. If BACKTRACKING\\_NUMBER = 0 then the backtracking iterations are omitted. The value usually ranges from 2 to 20; a value of 10 works well for most problems."
+      "integer value defining the maximum number of backtracking iterations allowed for residual reduction computations. If BACKTRACKING\\_NUMBER = 0 then the backtracking iterations are omitted. The value usually ranges from 2 to 20; a value of 10 works well for most problems.": [
+        "sln-ims"
+      ]
     }
   },
   "backtracking_reduction_factor": {
     "nonlinear": {
-      "sln-ims": "real value defining the reduction in step size used for residual reduction computations. The value of BACKTRACKING\\_REDUCTION\\_FACTOR is between zero and one. The value usually ranges from 0.1 to 0.3; a value of 0.2 works well for most problems. BACKTRACKING\\_REDUCTION\\_FACTOR only needs to be specified if BACKTRACKING\\_NUMBER is greater than zero."
+      "real value defining the reduction in step size used for residual reduction computations. The value of BACKTRACKING\\_REDUCTION\\_FACTOR is between zero and one. The value usually ranges from 0.1 to 0.3; a value of 0.2 works well for most problems. BACKTRACKING\\_REDUCTION\\_FACTOR only needs to be specified if BACKTRACKING\\_NUMBER is greater than zero.": [
+        "sln-ims"
+      ]
     }
   },
   "backtracking_residual_limit": {
     "nonlinear": {
-      "sln-ims": "real value defining the limit to which the residual is reduced with backtracking. If the residual is smaller than BACKTRACKING\\_RESIDUAL\\_LIMIT, then further backtracking is not performed. A value of 100 is suitable for large problems and residual reduction to smaller values may only slow down computations. BACKTRACKING\\_RESIDUAL\\_LIMIT only needs to be specified if BACKTRACKING\\_NUMBER is greater than zero."
+      "real value defining the limit to which the residual is reduced with backtracking. If the residual is smaller than BACKTRACKING\\_RESIDUAL\\_LIMIT, then further backtracking is not performed. A value of 100 is suitable for large problems and residual reduction to smaller values may only slow down computations. BACKTRACKING\\_RESIDUAL\\_LIMIT only needs to be specified if BACKTRACKING\\_NUMBER is greater than zero.": [
+        "sln-ims"
+      ]
     }
   },
   "backtracking_tolerance": {
     "nonlinear": {
-      "sln-ims": "real value defining the tolerance for residual change that is allowed for residual reduction computations. BACKTRACKING\\_TOLERANCE should not be less than one to avoid getting stuck in local minima. A large value serves to check for extreme residual increases, while a low value serves to control step size more severely. The value usually ranges from 1.0 to 10$^6$; a value of 10$^4$ works well for most problems but lower values like 1.1 may be required for harder problems. BACKTRACKING\\_TOLERANCE only needs to be specified if BACKTRACKING\\_NUMBER is greater than zero."
+      "real value defining the tolerance for residual change that is allowed for residual reduction computations. BACKTRACKING\\_TOLERANCE should not be less than one to avoid getting stuck in local minima. A large value serves to check for extreme residual increases, while a low value serves to control step size more severely. The value usually ranges from 1.0 to 10$^6$; a value of 10$^4$ works well for most problems but lower values like 1.1 may be required for harder problems. BACKTRACKING\\_TOLERANCE only needs to be specified if BACKTRACKING\\_NUMBER is greater than zero.": [
+        "sln-ims"
+      ]
     }
   },
   "bedk": {
     "period": {
-      "gwf-sfr": "real or character value that defines the hydraulic conductivity of the reach streambed. BEDK can be any positive value if the reach is not connected to an underlying GWF cell. Otherwise, BEDK must be greater than zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+      "real or character value that defines the hydraulic conductivity of the reach streambed. BEDK can be any positive value if the reach is not connected to an underlying GWF cell. Otherwise, BEDK must be greater than zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+        "gwf-sfr"
+      ]
     }
   },
   "beta": {
     "options": {
-      "gwf-csub": "compressibility of water. Typical values of BETA are 4.6512e-10 1/Pa or 2.2270e-8 lb/square foot in SI and English units, respectively. By default, BETA is 4.6512e-10 1/Pa."
+      "compressibility of water. Typical values of BETA are 4.6512e-10 1/Pa or 2.2270e-8 lb/square foot in SI and English units, respectively. By default, BETA is 4.6512e-10 1/Pa.": [
+        "gwf-csub"
+      ]
     }
   },
   "binary": {
     "continuous": {
-      "utl-obs": "an optional keyword used to indicate that the output file should be written in binary (unformatted) form."
+      "an optional keyword used to indicate that the output file should be written in binary (unformatted) form.": [
+        "utl-obs"
+      ]
     }
   },
   "bot": {
     "griddata": {
-      "gwe-disu": "is the bottom elevation for each cell.",
-      "gwf-disu": "is the bottom elevation for each cell.",
-      "gwt-disu": "is the bottom elevation for each cell."
+      "is the bottom elevation for each cell.": [
+        "gwe-disu",
+        "gwf-disu",
+        "gwt-disu"
+      ]
     }
   },
   "botm": {
     "griddata": {
-      "gwe-dis": "is the bottom elevation for each cell.",
-      "gwe-disv": "is the bottom elevation for each cell.",
-      "gwf-dis": "is the bottom elevation for each cell.",
-      "gwf-disv": "is the bottom elevation for each cell.",
-      "gwt-dis": "is the bottom elevation for each cell.",
-      "gwt-disv": "is the bottom elevation for each cell.",
-      "prt-dis": "is the bottom elevation for each cell.",
-      "prt-disv": "is the bottom elevation for each cell."
+      "is the bottom elevation for each cell.": [
+        "gwe-dis",
+        "gwe-disv",
+        "gwf-dis",
+        "gwf-disv",
+        "gwt-dis",
+        "gwt-disv",
+        "prt-dis",
+        "prt-disv"
+      ]
     }
   },
   "bottom": {
     "griddata": {
-      "chf-disv1d": "bottom elevation for the one-dimensional cell.",
-      "olf-dis2d": "is the bottom elevation for each cell.",
-      "olf-disv1d": "bottom elevation for the one-dimensional cell.",
-      "olf-disv2d": "is the bottom elevation for each cell.",
-      "swf-dis2d": "is the bottom elevation for each cell.",
-      "swf-disv1d": "bottom elevation for the one-dimensional cell.",
-      "swf-disv2d": "is the bottom elevation for each cell."
+      "bottom elevation for the one-dimensional cell.": [
+        "chf-disv1d",
+        "olf-disv1d",
+        "swf-disv1d"
+      ],
+      "is the bottom elevation for each cell.": [
+        "olf-dis2d",
+        "olf-disv2d",
+        "swf-dis2d",
+        "swf-disv2d"
+      ]
     }
   },
   "boundnames": {
     "options": {
-      "chf-cdb": "keyword to indicate that boundary names may be provided with the list of critical depth boundary cells.",
-      "chf-chd": "keyword to indicate that boundary names may be provided with the list of constant-head cells.",
-      "chf-evp": "keyword to indicate that boundary names may be provided with the list of evaporation cells.",
-      "chf-flw": "keyword to indicate that boundary names may be provided with the list of inflow cells.",
-      "chf-pcp": "keyword to indicate that boundary names may be provided with the list of precipitation cells.",
-      "chf-zdg": "keyword to indicate that boundary names may be provided with the list of zero-depth-gradient boundary cells.",
-      "exg-gwegwe": "keyword to indicate that boundary names may be provided with the list of GWE Exchange cells.",
-      "exg-gwtgwt": "keyword to indicate that boundary names may be provided with the list of GWT Exchange cells.",
-      "gwe-ctp": "keyword to indicate that boundary names may be provided with the list of constant temperature cells.",
-      "gwe-esl": "keyword to indicate that boundary names may be provided with the list of energy source loading cells.",
-      "gwe-lke": "keyword to indicate that boundary names may be provided with the list of lake cells.",
-      "gwe-mwe": "keyword to indicate that boundary names may be provided with the list of well cells.",
-      "gwe-sfe": "keyword to indicate that boundary names may be provided with the list of reach cells.",
-      "gwe-uze": "keyword to indicate that boundary names may be provided with the list of unsaturated zone flow cells.",
-      "gwf-api": "keyword to indicate that boundary names may be provided with the list of api boundary cells.",
-      "gwf-chd": "keyword to indicate that boundary names may be provided with the list of constant-head cells.",
-      "gwf-csub": "keyword to indicate that boundary names may be provided with the list of CSUB cells.",
-      "gwf-drn": "keyword to indicate that boundary names may be provided with the list of drain cells.",
-      "gwf-evt": "keyword to indicate that boundary names may be provided with the list of evapotranspiration cells.",
-      "gwf-ghb": "keyword to indicate that boundary names may be provided with the list of general-head boundary cells.",
-      "gwf-lak": "keyword to indicate that boundary names may be provided with the list of lake cells.",
-      "gwf-maw": "keyword to indicate that boundary names may be provided with the list of multi-aquifer well cells.",
-      "gwf-rch": "keyword to indicate that boundary names may be provided with the list of recharge cells.",
-      "gwf-riv": "keyword to indicate that boundary names may be provided with the list of river cells.",
-      "gwf-sfr": "keyword to indicate that boundary names may be provided with the list of stream reach cells.",
-      "gwf-uzf": "keyword to indicate that boundary names may be provided with the list of UZF cells.",
-      "gwf-wel": "keyword to indicate that boundary names may be provided with the list of well cells.",
-      "gwt-api": "keyword to indicate that boundary names may be provided with the list of api boundary cells.",
-      "gwt-cnc": "keyword to indicate that boundary names may be provided with the list of constant concentration cells.",
-      "gwt-lkt": "keyword to indicate that boundary names may be provided with the list of lake cells.",
-      "gwt-mwt": "keyword to indicate that boundary names may be provided with the list of well cells.",
-      "gwt-sft": "keyword to indicate that boundary names may be provided with the list of reach cells.",
-      "gwt-src": "keyword to indicate that boundary names may be provided with the list of mass source cells.",
-      "gwt-uzt": "keyword to indicate that boundary names may be provided with the list of unsaturated zone flow cells.",
-      "olf-cdb": "keyword to indicate that boundary names may be provided with the list of critical depth boundary cells.",
-      "olf-chd": "keyword to indicate that boundary names may be provided with the list of constant-head cells.",
-      "olf-evp": "keyword to indicate that boundary names may be provided with the list of evaporation cells.",
-      "olf-flw": "keyword to indicate that boundary names may be provided with the list of inflow cells.",
-      "olf-pcp": "keyword to indicate that boundary names may be provided with the list of precipitation cells.",
-      "olf-zdg": "keyword to indicate that boundary names may be provided with the list of zero-depth-gradient boundary cells.",
-      "prt-prp": "keyword to indicate that boundary names may be provided with the list of particle release points.",
-      "swf-cdb": "keyword to indicate that boundary names may be provided with the list of critical depth boundary cells.",
-      "swf-chd": "keyword to indicate that boundary names may be provided with the list of constant-head cells.",
-      "swf-evp": "keyword to indicate that boundary names may be provided with the list of evaporation cells.",
-      "swf-flw": "keyword to indicate that boundary names may be provided with the list of inflow cells.",
-      "swf-pcp": "keyword to indicate that boundary names may be provided with the list of precipitation cells.",
-      "swf-zdg": "keyword to indicate that boundary names may be provided with the list of zero-depth-gradient boundary cells."
+      "keyword to indicate that boundary names may be provided with the list of CSUB cells.": [
+        "gwf-csub"
+      ],
+      "keyword to indicate that boundary names may be provided with the list of GWE Exchange cells.": [
+        "exg-gwegwe"
+      ],
+      "keyword to indicate that boundary names may be provided with the list of GWT Exchange cells.": [
+        "exg-gwtgwt"
+      ],
+      "keyword to indicate that boundary names may be provided with the list of UZF cells.": [
+        "gwf-uzf"
+      ],
+      "keyword to indicate that boundary names may be provided with the list of api boundary cells.": [
+        "gwf-api",
+        "gwt-api"
+      ],
+      "keyword to indicate that boundary names may be provided with the list of constant concentration cells.": [
+        "gwt-cnc"
+      ],
+      "keyword to indicate that boundary names may be provided with the list of constant temperature cells.": [
+        "gwe-ctp"
+      ],
+      "keyword to indicate that boundary names may be provided with the list of constant-head cells.": [
+        "chf-chd",
+        "gwf-chd",
+        "olf-chd",
+        "swf-chd"
+      ],
+      "keyword to indicate that boundary names may be provided with the list of critical depth boundary cells.": [
+        "chf-cdb",
+        "olf-cdb",
+        "swf-cdb"
+      ],
+      "keyword to indicate that boundary names may be provided with the list of drain cells.": [
+        "gwf-drn"
+      ],
+      "keyword to indicate that boundary names may be provided with the list of energy source loading cells.": [
+        "gwe-esl"
+      ],
+      "keyword to indicate that boundary names may be provided with the list of evaporation cells.": [
+        "chf-evp",
+        "olf-evp",
+        "swf-evp"
+      ],
+      "keyword to indicate that boundary names may be provided with the list of evapotranspiration cells.": [
+        "gwf-evt"
+      ],
+      "keyword to indicate that boundary names may be provided with the list of general-head boundary cells.": [
+        "gwf-ghb"
+      ],
+      "keyword to indicate that boundary names may be provided with the list of inflow cells.": [
+        "chf-flw",
+        "olf-flw",
+        "swf-flw"
+      ],
+      "keyword to indicate that boundary names may be provided with the list of lake cells.": [
+        "gwe-lke",
+        "gwf-lak",
+        "gwt-lkt"
+      ],
+      "keyword to indicate that boundary names may be provided with the list of mass source cells.": [
+        "gwt-src"
+      ],
+      "keyword to indicate that boundary names may be provided with the list of multi-aquifer well cells.": [
+        "gwf-maw"
+      ],
+      "keyword to indicate that boundary names may be provided with the list of particle release points.": [
+        "prt-prp"
+      ],
+      "keyword to indicate that boundary names may be provided with the list of precipitation cells.": [
+        "chf-pcp",
+        "olf-pcp",
+        "swf-pcp"
+      ],
+      "keyword to indicate that boundary names may be provided with the list of reach cells.": [
+        "gwe-sfe",
+        "gwt-sft"
+      ],
+      "keyword to indicate that boundary names may be provided with the list of recharge cells.": [
+        "gwf-rch"
+      ],
+      "keyword to indicate that boundary names may be provided with the list of river cells.": [
+        "gwf-riv"
+      ],
+      "keyword to indicate that boundary names may be provided with the list of stream reach cells.": [
+        "gwf-sfr"
+      ],
+      "keyword to indicate that boundary names may be provided with the list of unsaturated zone flow cells.": [
+        "gwe-uze",
+        "gwt-uzt"
+      ],
+      "keyword to indicate that boundary names may be provided with the list of well cells.": [
+        "gwe-mwe",
+        "gwf-wel",
+        "gwt-mwt"
+      ],
+      "keyword to indicate that boundary names may be provided with the list of zero-depth-gradient boundary cells.": [
+        "chf-zdg",
+        "olf-zdg",
+        "swf-zdg"
+      ]
     }
   },
   "budget": {
     "options": {
-      "chf-oc": "keyword to specify that record corresponds to the budget.",
-      "gwe-lke": "keyword to specify that record corresponds to the budget.",
-      "gwe-mve": "keyword to specify that record corresponds to the budget.",
-      "gwe-mwe": "keyword to specify that record corresponds to the budget.",
-      "gwe-oc": "keyword to specify that record corresponds to the budget.",
-      "gwe-sfe": "keyword to specify that record corresponds to the budget.",
-      "gwe-uze": "keyword to specify that record corresponds to the budget.",
-      "gwf-lak": "keyword to specify that record corresponds to the budget.",
-      "gwf-maw": "keyword to specify that record corresponds to the budget.",
-      "gwf-mvr": "keyword to specify that record corresponds to the budget.",
-      "gwf-oc": "keyword to specify that record corresponds to the budget.",
-      "gwf-sfr": "keyword to specify that record corresponds to the budget.",
-      "gwf-uzf": "keyword to specify that record corresponds to the budget.",
-      "gwt-ist": "keyword to specify that record corresponds to the budget.",
-      "gwt-lkt": "keyword to specify that record corresponds to the budget.",
-      "gwt-mvt": "keyword to specify that record corresponds to the budget.",
-      "gwt-mwt": "keyword to specify that record corresponds to the budget.",
-      "gwt-oc": "keyword to specify that record corresponds to the budget.",
-      "gwt-sft": "keyword to specify that record corresponds to the budget.",
-      "gwt-uzt": "keyword to specify that record corresponds to the budget.",
-      "olf-oc": "keyword to specify that record corresponds to the budget.",
-      "prt-oc": "keyword to specify that record corresponds to the budget.",
-      "swf-oc": "keyword to specify that record corresponds to the budget."
+      "keyword to specify that record corresponds to the budget.": [
+        "chf-oc",
+        "gwe-lke",
+        "gwe-mve",
+        "gwe-mwe",
+        "gwe-oc",
+        "gwe-sfe",
+        "gwe-uze",
+        "gwf-lak",
+        "gwf-maw",
+        "gwf-mvr",
+        "gwf-oc",
+        "gwf-sfr",
+        "gwf-uzf",
+        "gwt-ist",
+        "gwt-lkt",
+        "gwt-mvt",
+        "gwt-mwt",
+        "gwt-oc",
+        "gwt-sft",
+        "gwt-uzt",
+        "olf-oc",
+        "prt-oc",
+        "swf-oc"
+      ]
     }
   },
   "budgetcsv": {
     "options": {
-      "chf-oc": "keyword to specify that record corresponds to the budget CSV.",
-      "gwe-lke": "keyword to specify that record corresponds to the budget CSV.",
-      "gwe-mve": "keyword to specify that record corresponds to the budget CSV.",
-      "gwe-mwe": "keyword to specify that record corresponds to the budget CSV.",
-      "gwe-oc": "keyword to specify that record corresponds to the budget CSV.",
-      "gwe-sfe": "keyword to specify that record corresponds to the budget CSV.",
-      "gwe-uze": "keyword to specify that record corresponds to the budget CSV.",
-      "gwf-lak": "keyword to specify that record corresponds to the budget CSV.",
-      "gwf-maw": "keyword to specify that record corresponds to the budget CSV.",
-      "gwf-mvr": "keyword to specify that record corresponds to the budget CSV.",
-      "gwf-oc": "keyword to specify that record corresponds to the budget CSV.",
-      "gwf-sfr": "keyword to specify that record corresponds to the budget CSV.",
-      "gwf-uzf": "keyword to specify that record corresponds to the budget CSV.",
-      "gwt-ist": "keyword to specify that record corresponds to the budget CSV.",
-      "gwt-lkt": "keyword to specify that record corresponds to the budget CSV.",
-      "gwt-mvt": "keyword to specify that record corresponds to the budget CSV.",
-      "gwt-mwt": "keyword to specify that record corresponds to the budget CSV.",
-      "gwt-oc": "keyword to specify that record corresponds to the budget CSV.",
-      "gwt-sft": "keyword to specify that record corresponds to the budget CSV.",
-      "gwt-uzt": "keyword to specify that record corresponds to the budget CSV.",
-      "olf-oc": "keyword to specify that record corresponds to the budget CSV.",
-      "prt-oc": "keyword to specify that record corresponds to the budget CSV.",
-      "swf-oc": "keyword to specify that record corresponds to the budget CSV."
+      "keyword to specify that record corresponds to the budget CSV.": [
+        "chf-oc",
+        "gwe-lke",
+        "gwe-mve",
+        "gwe-mwe",
+        "gwe-oc",
+        "gwe-sfe",
+        "gwe-uze",
+        "gwf-lak",
+        "gwf-maw",
+        "gwf-mvr",
+        "gwf-oc",
+        "gwf-sfr",
+        "gwf-uzf",
+        "gwt-ist",
+        "gwt-lkt",
+        "gwt-mvt",
+        "gwt-mwt",
+        "gwt-oc",
+        "gwt-sft",
+        "gwt-uzt",
+        "olf-oc",
+        "prt-oc",
+        "swf-oc"
+      ]
     }
   },
   "bulk_density": {
     "griddata": {
-      "gwt-ist": "is the bulk density of this immobile domain in mass per length cubed.  Bulk density is defined as the immobile domain solid mass per volume of the immobile domain.  bulk\\_density is not required unless the SORPTION keyword is specified in the options block.  If the SORPTION keyword is not specified in the options block, bulk\\_density will have no effect on simulation results.  ",
-      "gwt-mst": "is the bulk density of the aquifer in mass per length cubed.  bulk\\_density is not required unless the SORPTION keyword is specified.  Bulk density is defined as the mobile domain solid mass per mobile domain volume.  Additional information on bulk density is included in the MODFLOW 6 Supplemental Technical Information document."
+      "is the bulk density of the aquifer in mass per length cubed.  bulk\\_density is not required unless the SORPTION keyword is specified.  Bulk density is defined as the mobile domain solid mass per mobile domain volume.  Additional information on bulk density is included in the MODFLOW 6 Supplemental Technical Information document.": [
+        "gwt-mst"
+      ],
+      "is the bulk density of this immobile domain in mass per length cubed.  Bulk density is defined as the immobile domain solid mass per volume of the immobile domain.  bulk\\_density is not required unless the SORPTION keyword is specified in the options block.  If the SORPTION keyword is not specified in the options block, bulk\\_density will have no effect on simulation results.  ": [
+        "gwt-ist"
+      ]
     }
   },
   "cell_averaging": {
     "options": {
-      "exg-gwfgwf": "is a keyword and text keyword to indicate the method that will be used for calculating the conductance for horizontal cell connections.  The text value for CELL\\_AVERAGING can be ``HARMONIC'', ``LOGARITHMIC'', or ``AMT-LMK'', which means ``arithmetic-mean thickness and logarithmic-mean hydraulic conductivity''. If the user does not specify a value for CELL\\_AVERAGING, then the harmonic-mean method will be used."
+      "is a keyword and text keyword to indicate the method that will be used for calculating the conductance for horizontal cell connections.  The text value for CELL\\_AVERAGING can be ``HARMONIC'', ``LOGARITHMIC'', or ``AMT-LMK'', which means ``arithmetic-mean thickness and logarithmic-mean hydraulic conductivity''. If the user does not specify a value for CELL\\_AVERAGING, then the harmonic-mean method will be used.": [
+        "exg-gwfgwf"
+      ]
     }
   },
   "cell_fraction": {
     "options": {
-      "gwf-csub": "keyword to indicate that the thickness of interbeds will be specified in terms of the fraction of cell thickness. If not specified, interbed thicknness must be specified."
+      "keyword to indicate that the thickness of interbeds will be specified in terms of the fraction of cell thickness. If not specified, interbed thicknness must be specified.": [
+        "gwf-csub"
+      ]
     }
   },
   "central_in_space": {
     "options": {
-      "chf-dfw": "keyword to indicate conductance should be calculated using central-in-space weighting instead of the default upstream weighting approach.  This option should be used with caution as it does not work well unless all of the stream reaches are saturated.  With this option, there is no way for water to flow into a dry reach from connected reaches.",
-      "olf-dfw": "keyword to indicate conductance should be calculated using central-in-space weighting instead of the default upstream weighting approach.  This option should be used with caution as it does not work well unless all of the stream reaches are saturated.  With this option, there is no way for water to flow into a dry reach from connected reaches.",
-      "swf-dfw": "keyword to indicate conductance should be calculated using central-in-space weighting instead of the default upstream weighting approach.  This option should be used with caution as it does not work well unless all of the stream reaches are saturated.  With this option, there is no way for water to flow into a dry reach from connected reaches."
+      "keyword to indicate conductance should be calculated using central-in-space weighting instead of the default upstream weighting approach.  This option should be used with caution as it does not work well unless all of the stream reaches are saturated.  With this option, there is no way for water to flow into a dry reach from connected reaches.": [
+        "chf-dfw",
+        "olf-dfw",
+        "swf-dfw"
+      ]
     }
   },
   "cg_ske_cr": {
     "griddata": {
-      "gwf-csub": "is the initial elastic coarse-grained material specific storage or recompression index. The recompression index is specified if COMPRESSION\\_INDICES is specified in the OPTIONS block.  Specified or calculated elastic coarse-grained material specific storage values are not adjusted from initial values if HEAD\\_BASED is specified in the OPTIONS block."
+      "is the initial elastic coarse-grained material specific storage or recompression index. The recompression index is specified if COMPRESSION\\_INDICES is specified in the OPTIONS block.  Specified or calculated elastic coarse-grained material specific storage values are not adjusted from initial values if HEAD\\_BASED is specified in the OPTIONS block.": [
+        "gwf-csub"
+      ]
     }
   },
   "cg_theta": {
     "griddata": {
-      "gwf-csub": "is the initial porosity of coarse-grained materials."
+      "is the initial porosity of coarse-grained materials.": [
+        "gwf-csub"
+      ]
     }
   },
   "chunk_face": {
     "options": {
-      "utl-ncf": "is the keyword used to provide a data chunk size for the face dimension in a NETCDF\\_MESH2D output file. Must be used in combination with the the chunk\\_time parameter to have an effect."
+      "is the keyword used to provide a data chunk size for the face dimension in a NETCDF\\_MESH2D output file. Must be used in combination with the the chunk\\_time parameter to have an effect.": [
+        "utl-ncf"
+      ]
     }
   },
   "chunk_time": {
     "options": {
-      "utl-ncf": "is the keyword used to provide a data chunk size for the time dimension in a NETCDF\\_MESH2D or NETCDF\\_STRUCTURED output file. Must be used in combination with the the chunk\\_face parameter (NETCDF\\_MESH2D) or the chunk\\_z, chunk\\_y, and chunk\\_x parameter set (NETCDF\\_STRUCTURED) to have an effect."
+      "is the keyword used to provide a data chunk size for the time dimension in a NETCDF\\_MESH2D or NETCDF\\_STRUCTURED output file. Must be used in combination with the the chunk\\_face parameter (NETCDF\\_MESH2D) or the chunk\\_z, chunk\\_y, and chunk\\_x parameter set (NETCDF\\_STRUCTURED) to have an effect.": [
+        "utl-ncf"
+      ]
     }
   },
   "chunk_x": {
     "options": {
-      "utl-ncf": "is the keyword used to provide a data chunk size for the x dimension in a NETCDF\\_STRUCTURED output file. Must be used in combination with the the chunk\\_time, chunk\\_y and chunk\\_z parameter set to have an effect."
+      "is the keyword used to provide a data chunk size for the x dimension in a NETCDF\\_STRUCTURED output file. Must be used in combination with the the chunk\\_time, chunk\\_y and chunk\\_z parameter set to have an effect.": [
+        "utl-ncf"
+      ]
     }
   },
   "chunk_y": {
     "options": {
-      "utl-ncf": "is the keyword used to provide a data chunk size for the y dimension in a NETCDF\\_STRUCTURED output file. Must be used in combination with the the chunk\\_time, chunk\\_x and chunk\\_z parameter set to have an effect."
+      "is the keyword used to provide a data chunk size for the y dimension in a NETCDF\\_STRUCTURED output file. Must be used in combination with the the chunk\\_time, chunk\\_x and chunk\\_z parameter set to have an effect.": [
+        "utl-ncf"
+      ]
     }
   },
   "chunk_z": {
     "options": {
-      "utl-ncf": "is the keyword used to provide a data chunk size for the z dimension in a NETCDF\\_STRUCTURED output file. Must be used in combination with the the chunk\\_time, chunk\\_x and chunk\\_y parameter set to have an effect."
+      "is the keyword used to provide a data chunk size for the z dimension in a NETCDF\\_STRUCTURED output file. Must be used in combination with the the chunk\\_time, chunk\\_x and chunk\\_y parameter set to have an effect.": [
+        "utl-ncf"
+      ]
     }
   },
   "cim": {
     "griddata": {
-      "gwt-ist": "initial concentration of the immobile domain in mass per length cubed.  If CIM is not specified, then it is assumed to be zero."
+      "initial concentration of the immobile domain in mass per length cubed.  If CIM is not specified, then it is assumed to be zero.": [
+        "gwt-ist"
+      ]
     },
     "options": {
-      "gwt-ist": "keyword to specify that record corresponds to immobile concentration."
+      "keyword to specify that record corresponds to immobile concentration.": [
+        "gwt-ist"
+      ]
     }
   },
   "cl12": {
     "connectiondata": {
-      "gwe-disu": "is the array containing connection lengths between the center of cell n and the shared face with each adjacent m cell.",
-      "gwf-disu": "is the array containing connection lengths between the center of cell n and the shared face with each adjacent m cell.",
-      "gwt-disu": "is the array containing connection lengths between the center of cell n and the shared face with each adjacent m cell."
+      "is the array containing connection lengths between the center of cell n and the shared face with each adjacent m cell.": [
+        "gwe-disu",
+        "gwf-disu",
+        "gwt-disu"
+      ]
     }
   },
   "cnd_xt3d_off": {
     "options": {
-      "exg-gwegwe": "deactivate the xt3d method for the dispersive flux and use the faster and less accurate approximation for this exchange."
+      "deactivate the xt3d method for the dispersive flux and use the faster and less accurate approximation for this exchange.": [
+        "exg-gwegwe"
+      ]
     }
   },
   "cnd_xt3d_rhs": {
     "options": {
-      "exg-gwegwe": "add xt3d dispersion terms to right-hand side, when possible, for this exchange."
+      "add xt3d dispersion terms to right-hand side, when possible, for this exchange.": [
+        "exg-gwegwe"
+      ]
     }
   },
   "columns": {
     "options": {
-      "chf-oc": "number of columns for writing data.",
-      "gwe-oc": "number of columns for writing data.",
-      "gwf-oc": "number of columns for writing data.",
-      "gwt-ist": "number of columns for writing data.",
-      "gwt-oc": "number of columns for writing data.",
-      "olf-oc": "number of columns for writing data.",
-      "swf-oc": "number of columns for writing data."
+      "number of columns for writing data.": [
+        "chf-oc",
+        "gwe-oc",
+        "gwf-oc",
+        "gwt-ist",
+        "gwt-oc",
+        "olf-oc",
+        "swf-oc"
+      ]
     }
   },
   "compaction": {
     "options": {
-      "gwf-csub": "keyword to specify that record corresponds to the compaction."
+      "keyword to specify that record corresponds to the compaction.": [
+        "gwf-csub"
+      ]
     }
   },
   "compaction_coarse": {
     "options": {
-      "gwf-csub": "keyword to specify that record corresponds to the elastic coarse-grained material compaction binary file."
+      "keyword to specify that record corresponds to the elastic coarse-grained material compaction binary file.": [
+        "gwf-csub"
+      ]
     }
   },
   "compaction_elastic": {
     "options": {
-      "gwf-csub": "keyword to specify that record corresponds to the elastic interbed compaction binary file."
+      "keyword to specify that record corresponds to the elastic interbed compaction binary file.": [
+        "gwf-csub"
+      ]
     }
   },
   "compaction_inelastic": {
     "options": {
-      "gwf-csub": "keyword to specify that record corresponds to the inelastic interbed compaction binary file."
+      "keyword to specify that record corresponds to the inelastic interbed compaction binary file.": [
+        "gwf-csub"
+      ]
     }
   },
   "compaction_interbed": {
     "options": {
-      "gwf-csub": "keyword to specify that record corresponds to the interbed compaction binary file."
+      "keyword to specify that record corresponds to the interbed compaction binary file.": [
+        "gwf-csub"
+      ]
     }
   },
   "complexity": {
     "options": {
-      "sln-ims": "is an optional keyword that defines default non-linear and linear solver parameters.  SIMPLE - indicates that default solver input values will be defined that work well for nearly linear models. This would be used for models that do not include nonlinear stress packages and models that are either confined or consist of a single unconfined layer that is thick enough to contain the water table within a single layer. MODERATE - indicates that default solver input values will be defined that work well for moderately nonlinear models. This would be used for models that include nonlinear stress packages and models that consist of one or more unconfined layers. The MODERATE option should be used when the SIMPLE option does not result in successful convergence.  COMPLEX - indicates that default solver input values will be defined that work well for highly nonlinear models. This would be used for models that include nonlinear stress packages and models that consist of one or more unconfined layers representing complex geology and surface-water/groundwater interaction. The COMPLEX option should be used when the MODERATE option does not result in successful convergence.  Non-linear and linear solver parameters assigned using a specified complexity can be modified in the NONLINEAR and LINEAR blocks. If the COMPLEXITY option is not specified, NONLINEAR and LINEAR variables will be assigned the simple complexity values.",
-      "sln-pts": "is an optional keyword that defines default non-linear and linear solver parameters.  SIMPLE - indicates that default solver input values will be defined that work well for nearly linear models. This would be used for models that do not include nonlinear stress packages and models that are either confined or consist of a single unconfined layer that is thick enough to contain the water table within a single layer. MODERATE - indicates that default solver input values will be defined that work well for moderately nonlinear models. This would be used for models that include nonlinear stress packages and models that consist of one or more unconfined layers. The MODERATE option should be used when the SIMPLE option does not result in successful convergence.  COMPLEX - indicates that default solver input values will be defined that work well for highly nonlinear models. This would be used for models that include nonlinear stress packages and models that consist of one or more unconfined layers representing complex geology and surface-water/groundwater interaction. The COMPLEX option should be used when the MODERATE option does not result in successful convergence.  Non-linear and linear solver parameters assigned using a specified complexity can be modified in the NONLINEAR and LINEAR blocks. If the COMPLEXITY option is not specified, NONLINEAR and LINEAR variables will be assigned the simple complexity values."
+      "is an optional keyword that defines default non-linear and linear solver parameters.  SIMPLE - indicates that default solver input values will be defined that work well for nearly linear models. This would be used for models that do not include nonlinear stress packages and models that are either confined or consist of a single unconfined layer that is thick enough to contain the water table within a single layer. MODERATE - indicates that default solver input values will be defined that work well for moderately nonlinear models. This would be used for models that include nonlinear stress packages and models that consist of one or more unconfined layers. The MODERATE option should be used when the SIMPLE option does not result in successful convergence.  COMPLEX - indicates that default solver input values will be defined that work well for highly nonlinear models. This would be used for models that include nonlinear stress packages and models that consist of one or more unconfined layers representing complex geology and surface-water/groundwater interaction. The COMPLEX option should be used when the MODERATE option does not result in successful convergence.  Non-linear and linear solver parameters assigned using a specified complexity can be modified in the NONLINEAR and LINEAR blocks. If the COMPLEXITY option is not specified, NONLINEAR and LINEAR variables will be assigned the simple complexity values.": [
+        "sln-ims",
+        "sln-pts"
+      ]
     }
   },
   "compression_indices": {
     "options": {
-      "gwf-csub": "keyword to indicate that the recompression (CR) and compression (CC) indices are specified instead of the elastic specific storage (SSE) and inelastic specific storage (SSV) coefficients. If not specified, then elastic specific storage (SSE) and inelastic specific storage (SSV) coefficients must be specified."
+      "keyword to indicate that the recompression (CR) and compression (CC) indices are specified instead of the elastic specific storage (SSE) and inelastic specific storage (SSV) coefficients. If not specified, then elastic specific storage (SSE) and inelastic specific storage (SSV) coefficients must be specified.": [
+        "gwf-csub"
+      ]
     }
   },
   "concentration": {
     "options": {
-      "gwt-lkt": "keyword to specify that record corresponds to concentration.",
-      "gwt-mwt": "keyword to specify that record corresponds to concentration.",
-      "gwt-oc": "keyword to specify that record corresponds to concentration.",
-      "gwt-sft": "keyword to specify that record corresponds to concentration.",
-      "gwt-uzt": "keyword to specify that record corresponds to concentration."
+      "keyword to specify that record corresponds to concentration.": [
+        "gwt-lkt",
+        "gwt-mwt",
+        "gwt-oc",
+        "gwt-sft",
+        "gwt-uzt"
+      ]
     },
     "period": {
-      "gwt-lkt": "real or character value that defines the concentration for the lake. The specified CONCENTRATION is only applied if the lake is a constant concentration lake. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      "gwt-mwt": "real or character value that defines the concentration for the well. The specified CONCENTRATION is only applied if the well is a constant concentration well. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      "gwt-sft": "real or character value that defines the concentration for the reach. The specified CONCENTRATION is only applied if the reach is a constant concentration reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      "gwt-uzt": "real or character value that defines the concentration for the unsaturated zone flow cell. The specified CONCENTRATION is only applied if the unsaturated zone flow cell is a constant concentration cell. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      "utl-spc": "is the boundary concentration. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, the CONCENTRATION for each boundary feature is zero.",
-      "utl-spca": "is the concentration of the associated Recharge or Evapotranspiration stress package.  The concentration array may be defined by a time-array series (see the \"Using Time-Array Series in a Package\" section)."
+      "is the boundary concentration. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, the CONCENTRATION for each boundary feature is zero.": [
+        "utl-spc"
+      ],
+      "is the concentration of the associated Recharge or Evapotranspiration stress package.  The concentration array may be defined by a time-array series (see the \"Using Time-Array Series in a Package\" section).": [
+        "utl-spca"
+      ],
+      "real or character value that defines the concentration for the lake. The specified CONCENTRATION is only applied if the lake is a constant concentration lake. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+        "gwt-lkt"
+      ],
+      "real or character value that defines the concentration for the reach. The specified CONCENTRATION is only applied if the reach is a constant concentration reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+        "gwt-sft"
+      ],
+      "real or character value that defines the concentration for the unsaturated zone flow cell. The specified CONCENTRATION is only applied if the unsaturated zone flow cell is a constant concentration cell. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+        "gwt-uzt"
+      ],
+      "real or character value that defines the concentration for the well. The specified CONCENTRATION is only applied if the well is a constant concentration well. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+        "gwt-mwt"
+      ]
     }
   },
   "continue": {
     "options": {
-      "sim-nam": "keyword flag to indicate that the simulation should continue even if one or more solutions do not converge."
+      "keyword flag to indicate that the simulation should continue even if one or more solutions do not converge.": [
+        "sim-nam"
+      ]
     }
   },
   "cross_section": {
     "period": {
-      "gwf-sfr": "keyword to specify that record corresponds to a reach cross-section."
+      "keyword to specify that record corresponds to a reach cross-section.": [
+        "gwf-sfr"
+      ]
     }
   },
   "csv_inner_output": {
     "options": {
-      "sln-ims": "keyword to specify that the record corresponds to the comma separated values solver convergence output.",
-      "sln-pts": "keyword to specify that the record corresponds to the comma separated values solver convergence output."
+      "keyword to specify that the record corresponds to the comma separated values solver convergence output.": [
+        "sln-ims",
+        "sln-pts"
+      ]
     }
   },
   "csv_outer_output": {
     "options": {
-      "sln-ims": "keyword to specify that the record corresponds to the comma separated values outer iteration convergence output.",
-      "sln-pts": "keyword to specify that the record corresponds to the comma separated values outer iteration convergence output."
+      "keyword to specify that the record corresponds to the comma separated values outer iteration convergence output.": [
+        "sln-ims",
+        "sln-pts"
+      ]
     }
   },
   "csv_output": {
     "options": {
-      "sln-ims": "keyword to specify that the record corresponds to the comma separated values solver convergence output.  The CSV\\_OUTPUT option has been deprecated and split into the CSV_OUTER_OUTPUT and CSV_INNER_OUTPUT options.  Starting with MODFLOW 6 version 6.1.1 if the CSV_OUTPUT option is specified, then it is treated as the CSV_OUTER_OUTPUT option.",
-      "sln-pts": "keyword to specify that the record corresponds to the comma separated values solver convergence output.  The CSV\\_OUTPUT option has been deprecated and split into the CSV_OUTER_OUTPUT and CSV_INNER_OUTPUT options.  Starting with MODFLOW 6 version 6.1.1 if the CSV_OUTPUT option is specified, then it is treated as the CSV_OUTER_OUTPUT option."
+      "keyword to specify that the record corresponds to the comma separated values solver convergence output.  The CSV\\_OUTPUT option has been deprecated and split into the CSV_OUTER_OUTPUT and CSV_INNER_OUTPUT options.  Starting with MODFLOW 6 version 6.1.1 if the CSV_OUTPUT option is specified, then it is treated as the CSV_OUTER_OUTPUT option.": [
+        "sln-ims",
+        "sln-pts"
+      ]
     }
   },
   "cvoptions": {
     "options": {
-      "exg-gwfgwf": "none",
-      "gwf-npf": "none"
+      "none": [
+        "exg-gwfgwf",
+        "gwf-npf"
+      ]
     }
   },
   "decay": {
     "griddata": {
-      "gwt-ist": "is the rate coefficient for first or zero-order decay for the aqueous phase of the immobile domain.  A negative value indicates solute production.  The dimensions of decay for first-order decay is one over time.  The dimensions of decay for zero-order decay is mass per length cubed per time.  Decay will have no effect on simulation results unless either first- or zero-order decay is specified in the options block.",
-      "gwt-mst": "is the rate coefficient for first or zero-order decay for the aqueous phase of the mobile domain.  A negative value indicates solute production.  The dimensions of decay for first-order decay is one over time.  The dimensions of decay for zero-order decay is mass per length cubed per time.  decay will have no effect on simulation results unless either first- or zero-order decay is specified in the options block."
+      "is the rate coefficient for first or zero-order decay for the aqueous phase of the immobile domain.  A negative value indicates solute production.  The dimensions of decay for first-order decay is one over time.  The dimensions of decay for zero-order decay is mass per length cubed per time.  Decay will have no effect on simulation results unless either first- or zero-order decay is specified in the options block.": [
+        "gwt-ist"
+      ],
+      "is the rate coefficient for first or zero-order decay for the aqueous phase of the mobile domain.  A negative value indicates solute production.  The dimensions of decay for first-order decay is one over time.  The dimensions of decay for zero-order decay is mass per length cubed per time.  decay will have no effect on simulation results unless either first- or zero-order decay is specified in the options block.": [
+        "gwt-mst"
+      ]
     }
   },
   "decay_solid": {
     "griddata": {
-      "gwe-est": "is the rate coefficient for zero-order decay for the solid phase.  A negative value indicates heat (energy) production. The dimensions of zero-order decay in the solid phase are energy per mass of solid per time. Zero-order decay in the solid phase will have no effect on simulation results unless ZERO\\_ORDER\\_DECAY\\_SOLID is specified in the options block."
+      "is the rate coefficient for zero-order decay for the solid phase.  A negative value indicates heat (energy) production. The dimensions of zero-order decay in the solid phase are energy per mass of solid per time. Zero-order decay in the solid phase will have no effect on simulation results unless ZERO\\_ORDER\\_DECAY\\_SOLID is specified in the options block.": [
+        "gwe-est"
+      ]
     }
   },
   "decay_sorbed": {
     "griddata": {
-      "gwt-ist": "is the rate coefficient for first or zero-order decay for the sorbed phase of the immobile domain.  A negative value indicates solute production.  The dimensions of decay\\_sorbed for first-order decay is one over time.  The dimensions of decay\\_sorbed for zero-order decay is mass of solute per mass of aquifer per time.  If decay\\_sorbed is not specified and both decay and sorption are active, then the program will terminate with an error.  decay\\_sorbed will have no effect on simulation results unless the SORPTION keyword and either first- or zero-order decay are specified in the options block.",
-      "gwt-mst": "is the rate coefficient for first or zero-order decay for the sorbed phase of the mobile domain.  A negative value indicates solute production.  The dimensions of decay\\_sorbed for first-order decay is one over time.  The dimensions of decay\\_sorbed for zero-order decay is mass of solute per mass of aquifer per time.  If decay\\_sorbed is not specified and both decay and sorption are active, then the program will terminate with an error.  decay\\_sorbed will have no effect on simulation results unless the SORPTION keyword and either first- or zero-order decay are specified in the options block."
+      "is the rate coefficient for first or zero-order decay for the sorbed phase of the immobile domain.  A negative value indicates solute production.  The dimensions of decay\\_sorbed for first-order decay is one over time.  The dimensions of decay\\_sorbed for zero-order decay is mass of solute per mass of aquifer per time.  If decay\\_sorbed is not specified and both decay and sorption are active, then the program will terminate with an error.  decay\\_sorbed will have no effect on simulation results unless the SORPTION keyword and either first- or zero-order decay are specified in the options block.": [
+        "gwt-ist"
+      ],
+      "is the rate coefficient for first or zero-order decay for the sorbed phase of the mobile domain.  A negative value indicates solute production.  The dimensions of decay\\_sorbed for first-order decay is one over time.  The dimensions of decay\\_sorbed for zero-order decay is mass of solute per mass of aquifer per time.  If decay\\_sorbed is not specified and both decay and sorption are active, then the program will terminate with an error.  decay\\_sorbed will have no effect on simulation results unless the SORPTION keyword and either first- or zero-order decay are specified in the options block.": [
+        "gwt-mst"
+      ]
     }
   },
   "decay_water": {
     "griddata": {
-      "gwe-est": "is the rate coefficient for zero-order decay for the aqueous phase of the mobile domain.  A negative value indicates heat (energy) production.  The dimensions of zero-order decay in the aqueous phase are energy per length cubed (volume of water) per time.  Zero-order decay in the aqueous phase will have no effect on simulation results unless ZERO\\_ORDER\\_DECAY\\_WATER is specified in the options block."
+      "is the rate coefficient for zero-order decay for the aqueous phase of the mobile domain.  A negative value indicates heat (energy) production.  The dimensions of zero-order decay in the aqueous phase are energy per length cubed (volume of water) per time.  Zero-order decay in the aqueous phase will have no effect on simulation results unless ZERO\\_ORDER\\_DECAY\\_WATER is specified in the options block.": [
+        "gwe-est"
+      ]
     }
   },
   "deflate": {
     "options": {
-      "utl-ncf": "is the variable deflate level (0=min, 9=max) in the netcdf file. Defining this parameter activates per-variable compression at the level specified."
+      "is the variable deflate level (0=min, 9=max) in the netcdf file. Defining this parameter activates per-variable compression at the level specified.": [
+        "utl-ncf"
+      ]
     }
   },
   "delc": {
     "griddata": {
-      "gwe-dis": "is the row spacing in the column direction.",
-      "gwf-dis": "is the row spacing in the column direction.",
-      "gwt-dis": "is the row spacing in the column direction.",
-      "olf-dis2d": "is the row spacing in the column direction.",
-      "prt-dis": "is the row spacing in the column direction.",
-      "swf-dis2d": "is the row spacing in the column direction."
+      "is the row spacing in the column direction.": [
+        "gwe-dis",
+        "gwf-dis",
+        "gwt-dis",
+        "olf-dis2d",
+        "prt-dis",
+        "swf-dis2d"
+      ]
     }
   },
   "delr": {
     "griddata": {
-      "gwe-dis": "is the column spacing in the row direction.",
-      "gwf-dis": "is the column spacing in the row direction.",
-      "gwt-dis": "is the column spacing in the row direction.",
-      "olf-dis2d": "is the column spacing in the row direction.",
-      "prt-dis": "is the column spacing in the row direction.",
-      "swf-dis2d": "is the column spacing in the row direction."
+      "is the column spacing in the row direction.": [
+        "gwe-dis",
+        "gwf-dis",
+        "gwt-dis",
+        "olf-dis2d",
+        "prt-dis",
+        "swf-dis2d"
+      ]
     }
   },
   "denseref": {
     "options": {
-      "gwf-buy": "fluid reference density used in the equation of state.  This value is set to 1000. if not specified as an option."
+      "fluid reference density used in the equation of state.  This value is set to 1000. if not specified as an option.": [
+        "gwf-buy"
+      ]
     }
   },
   "density": {
     "options": {
-      "gwf-buy": "keyword to specify that record corresponds to density."
+      "keyword to specify that record corresponds to density.": [
+        "gwf-buy"
+      ]
     }
   },
   "density_solid": {
     "griddata": {
-      "gwe-est": "is a user-specified value of the density of aquifer material not considering the voids. Value will remain fixed for the entire simulation.  For example, if working in SI units, values may be entered as kilograms per cubic meter. "
+      "is a user-specified value of the density of aquifer material not considering the voids. Value will remain fixed for the entire simulation.  For example, if working in SI units, values may be entered as kilograms per cubic meter. ": [
+        "gwe-est"
+      ]
     }
   },
   "density_water": {
     "options": {
-      "gwe-est": "density of water used by calculations related to heat storage and conduction.  This value is set to 1,000 kg/m3 if no overriding value is specified.  A user-specified value should be provided for models that use units other than kilograms and meters or if it is necessary to use a value other than the default."
+      "density of water used by calculations related to heat storage and conduction.  This value is set to 1,000 kg/m3 if no overriding value is specified.  A user-specified value should be provided for models that use units other than kilograms and meters or if it is necessary to use a value other than the default.": [
+        "gwe-est"
+      ]
     }
   },
   "depth": {
     "period": {
-      "gwf-evta": "is the ET extinction depth ($L$)."
+      "is the ET extinction depth ($L$).": [
+        "gwf-evta"
+      ]
     }
   },
   "dev_efh_formulation": {
     "options": {
-      "gwf-buy": "use the variable-density equivalent freshwater head formulation instead of the hydraulic head head formulation.  This dev option has only been implemented for confined aquifer conditions and should generally not be used."
+      "use the variable-density equivalent freshwater head formulation instead of the hydraulic head head formulation.  This dev option has only been implemented for confined aquifer conditions and should generally not be used.": [
+        "gwf-buy"
+      ]
     }
   },
   "dev_exit_solve_method": {
     "options": {
-      "prt-prp": "the method for iterative solution of particle exit location and time in the generalized Pollock's method.  0 default, 1 Brent, 2 Chandrupatla.  The default is Brent's method."
+      "the method for iterative solution of particle exit location and time in the generalized Pollock's method.  0 default, 1 Brent, 2 Chandrupatla.  The default is Brent's method.": [
+        "prt-prp"
+      ]
     }
   },
   "dev_forceternary": {
     "options": {
-      "prt-prp": "force use of the ternary tracking method regardless of cell type in DISV grids."
+      "force use of the ternary tracking method regardless of cell type in DISV grids.": [
+        "prt-prp"
+      ]
     }
   },
   "dev_interfacemodel_on": {
     "options": {
-      "exg-gwegwe": "activates the interface model mechanism for calculating the coefficients at (and possibly near) the exchange. This keyword should only be used for development purposes.",
-      "exg-gwfgwf": "activates the interface model mechanism for calculating the coefficients at (and possibly near) the exchange. This keyword should only be used for development purposes.",
-      "exg-gwtgwt": "activates the interface model mechanism for calculating the coefficients at (and possibly near) the exchange. This keyword should only be used for development purposes."
+      "activates the interface model mechanism for calculating the coefficients at (and possibly near) the exchange. This keyword should only be used for development purposes.": [
+        "exg-gwegwe",
+        "exg-gwfgwf",
+        "exg-gwtgwt"
+      ]
     }
   },
   "dev_log_mpi": {
     "options": {
-      "utl-hpc": "keyword to enable (extremely verbose) logging of mpi traffic to file."
+      "keyword to enable (extremely verbose) logging of mpi traffic to file.": [
+        "utl-hpc"
+      ]
     }
   },
   "dev_no_newton": {
     "options": {
-      "gwf-npf": "turn off Newton for unconfined cells"
+      "turn off Newton for unconfined cells": [
+        "gwf-npf"
+      ]
     }
   },
   "dev_oldstorageformulation": {
     "options": {
-      "gwf-sto": "development option flag for old storage formulation"
+      "development option flag for old storage formulation": [
+        "gwf-sto"
+      ]
     }
   },
   "dev_omega": {
     "options": {
-      "gwf-npf": "set saturation omega value"
+      "set saturation omega value": [
+        "gwf-npf"
+      ]
     }
   },
   "dev_storage_weight": {
     "options": {
-      "gwf-sfr": "real number value that defines the time weighting factor used to calculate the change in channel storage. STORAGE\\_WEIGHT must have a value between 0.5 and 1. Default STORAGE\\_WEIGHT value is 1."
+      "real number value that defines the time weighting factor used to calculate the change in channel storage. STORAGE\\_WEIGHT must have a value between 0.5 and 1. Default STORAGE\\_WEIGHT value is 1.": [
+        "gwf-sfr"
+      ]
     }
   },
   "dev_swr_conductance": {
     "options": {
-      "chf-dfw": "use the conductance formulation in the Surface Water Routing (SWR) Process for MODFLOW-2005.",
-      "olf-dfw": "use the conductance formulation in the Surface Water Routing (SWR) Process for MODFLOW-2005.",
-      "swf-dfw": "use the conductance formulation in the Surface Water Routing (SWR) Process for MODFLOW-2005."
+      "use the conductance formulation in the Surface Water Routing (SWR) Process for MODFLOW-2005.": [
+        "chf-dfw",
+        "olf-dfw",
+        "swf-dfw"
+      ]
     }
   },
   "dewatered": {
     "options": {
-      "exg-gwfgwf": "If the DEWATERED keyword is specified, then the vertical conductance is calculated using only the saturated thickness and properties of the overlying cell if the head in the underlying cell is below its top.",
-      "gwf-npf": "If the DEWATERED keyword is specified, then the vertical conductance is calculated using only the saturated thickness and properties of the overlying cell if the head in the underlying cell is below its top."
+      "If the DEWATERED keyword is specified, then the vertical conductance is calculated using only the saturated thickness and properties of the overlying cell if the head in the underlying cell is below its top.": [
+        "exg-gwfgwf",
+        "gwf-npf"
+      ]
     }
   },
   "diffc": {
     "griddata": {
-      "gwt-dsp": "effective molecular diffusion coefficient."
+      "effective molecular diffusion coefficient.": [
+        "gwt-dsp"
+      ]
     }
   },
   "digits": {
     "options": {
-      "chf-oc": "number of digits to use for writing a number.",
-      "gwe-oc": "number of digits to use for writing a number.",
-      "gwf-oc": "number of digits to use for writing a number.",
-      "gwt-ist": "number of digits to use for writing a number.",
-      "gwt-oc": "number of digits to use for writing a number.",
-      "olf-oc": "number of digits to use for writing a number.",
-      "swf-oc": "number of digits to use for writing a number.",
-      "utl-obs": "Keyword and an integer digits specifier used for conversion of simulated values to text on output. If not specified, the default is the maximum number of digits stored in the program (as written with the G0 Fortran specifier). When simulated values are written to a comma-separated value text file specified in a CONTINUOUS block below, the digits specifier controls the number of significant digits with which simulated values are written to the output file. The digits specifier has no effect on the number of significant digits with which the simulation time is written for continuous observations.  If DIGITS is specified as zero, then observations are written with the default setting, which is the maximum number of digits."
+      "Keyword and an integer digits specifier used for conversion of simulated values to text on output. If not specified, the default is the maximum number of digits stored in the program (as written with the G0 Fortran specifier). When simulated values are written to a comma-separated value text file specified in a CONTINUOUS block below, the digits specifier controls the number of significant digits with which simulated values are written to the output file. The digits specifier has no effect on the number of significant digits with which the simulation time is written for continuous observations.  If DIGITS is specified as zero, then observations are written with the default setting, which is the maximum number of digits.": [
+        "utl-obs"
+      ],
+      "number of digits to use for writing a number.": [
+        "chf-oc",
+        "gwe-oc",
+        "gwf-oc",
+        "gwt-ist",
+        "gwt-oc",
+        "olf-oc",
+        "swf-oc"
+      ]
     }
   },
   "disable_storage_change_integration": {
     "options": {
-      "utl-tvs": "keyword that deactivates inclusion of storage derivative terms in the STO package matrix formulation.  In the absence of this keyword (the default), the groundwater storage formulation will be modified to correctly adjust heads based on transient variations in stored water volumes arising from changes to SS and SY properties."
+      "keyword that deactivates inclusion of storage derivative terms in the STO package matrix formulation.  In the absence of this keyword (the default), the groundwater storage formulation will be modified to correctly adjust heads based on transient variations in stored water volumes arising from changes to SS and SY properties.": [
+        "utl-tvs"
+      ]
     }
   },
   "distcoef": {
     "griddata": {
-      "gwt-ist": "is the distribution coefficient for the equilibrium-controlled linear sorption isotherm in dimensions of length cubed per mass.  distcoef is not required unless the SORPTION keyword is specified in the options block.  If the SORPTION keyword is not specified in the options block, distcoef will have no effect on simulation results. ",
-      "gwt-mst": "is the distribution coefficient for the equilibrium-controlled linear sorption isotherm in dimensions of length cubed per mass.  If the Freunchlich isotherm is specified, then discoef is the Freundlich constant.  If the Langmuir isotherm is specified, then distcoef is the Langmuir constant.  distcoef is not required unless the SORPTION keyword is specified."
+      "is the distribution coefficient for the equilibrium-controlled linear sorption isotherm in dimensions of length cubed per mass.  If the Freunchlich isotherm is specified, then discoef is the Freundlich constant.  If the Langmuir isotherm is specified, then distcoef is the Langmuir constant.  distcoef is not required unless the SORPTION keyword is specified.": [
+        "gwt-mst"
+      ],
+      "is the distribution coefficient for the equilibrium-controlled linear sorption isotherm in dimensions of length cubed per mass.  distcoef is not required unless the SORPTION keyword is specified in the options block.  If the SORPTION keyword is not specified in the options block, distcoef will have no effect on simulation results. ": [
+        "gwt-ist"
+      ]
     }
   },
   "diversion": {
     "period": {
-      "gwf-sfr": "keyword to indicate diversion record."
+      "keyword to indicate diversion record.": [
+        "gwf-sfr"
+      ]
     }
   },
   "drape": {
     "options": {
-      "prt-prp": "is a text keyword to indicate that if a particle's release point is in a cell that happens to be inactive at release time, the particle is to be moved to the topmost active cell below it, if any. By default, a particle is not released into the simulation if its release point's cell is inactive at release time."
+      "is a text keyword to indicate that if a particle's release point is in a cell that happens to be inactive at release time, the particle is to be moved to the topmost active cell below it, if any. By default, a particle is not released into the simulation if its release point's cell is inactive at release time.": [
+        "prt-prp"
+      ]
     }
   },
   "dry_tracking_method": {
     "options": {
-      "prt-prp": "is a string indicating how particles should behave in dry-but-active cells (as can occur with the Newton formulation).  The value can be ``DROP'', ``STOP'', or ``STAY''.  The default is ``DROP'', which passes particles vertically and instantaneously to the water table. ``STOP'' causes particles to terminate. ``STAY'' causes particles to remain stationary but active."
+      "is a string indicating how particles should behave in dry-but-active cells (as can occur with the Newton formulation).  The value can be ``DROP'', ``STOP'', or ``STAY''.  The default is ``DROP'', which passes particles vertically and instantaneously to the water table. ``STOP'' causes particles to terminate. ``STAY'' causes particles to remain stationary but active.": [
+        "prt-prp"
+      ]
     }
   },
   "dsp_xt3d_off": {
     "options": {
-      "exg-gwtgwt": "deactivate the xt3d method for the dispersive flux and use the faster and less accurate approximation for this exchange."
+      "deactivate the xt3d method for the dispersive flux and use the faster and less accurate approximation for this exchange.": [
+        "exg-gwtgwt"
+      ]
     }
   },
   "dsp_xt3d_rhs": {
     "options": {
-      "exg-gwtgwt": "add xt3d dispersion terms to right-hand side, when possible, for this exchange."
+      "add xt3d dispersion terms to right-hand side, when possible, for this exchange.": [
+        "exg-gwtgwt"
+      ]
     }
   },
   "effective_stress_lag": {
     "options": {
-      "gwf-csub": "keyword to indicate the effective stress from the previous time step will be used to calculate specific storage values. This option can 1) help with convergence in models with thin cells and water table elevations close to land surface; 2) is identical to the approach used in the SUBWT package for MODFLOW-2005; and 3) is only used if the effective-stress formulation is being used. By default, current effective stress values are used to calculate specific storage values."
+      "keyword to indicate the effective stress from the previous time step will be used to calculate specific storage values. This option can 1) help with convergence in models with thin cells and water table elevations close to land surface; 2) is identical to the approach used in the SUBWT package for MODFLOW-2005; and 3) is only used if the effective-stress formulation is being used. By default, current effective stress values are used to calculate specific storage values.": [
+        "gwf-csub"
+      ]
     }
   },
   "evaporation": {
     "period": {
-      "gwe-lke": "use of the EVAPORATION keyword is allowed in the LKE package; however, the specified value is not currently used in LKE calculations.  Instead, the latent heat of evaporation is multiplied by the simulated evaporation rate for determining the thermal energy lost from a stream reach.",
-      "gwe-sfe": "use of the EVAPORATION keyword is allowed in the SFE package; however, the specified value is not currently used in SFE calculations.  Instead, the latent heat of evaporation is multiplied by the simulated evaporation rate for determining the thermal energy lost from a stream reach.",
-      "gwf-lak": "real or character value that defines the maximum evaporation rate $(LT^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      "gwf-sfr": "real or character value that defines the volumetric rate per unit area of water subtracted by evaporation from the streamflow routing reach. A positive evaporation rate should be provided. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. If the volumetric evaporation rate for a reach exceeds the sources of water to the reach (upstream and specified inflows, rainfall, and runoff but excluding groundwater leakage into the reach) the volumetric evaporation rate is limited to the sources of water to the reach. By default, evaporation rates are zero for each reach.",
-      "gwt-lkt": "real or character value that defines the concentration of evaporated water $(ML^{-3})$ for the lake. If this concentration value is larger than the simulated concentration in the lake, then the evaporated water will be removed at the same concentration as the lake.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      "gwt-sft": "real or character value that defines the concentration of evaporated water $(ML^{-3})$ for the reach. If this concentration value is larger than the simulated concentration in the reach, then the evaporated water will be removed at the same concentration as the reach.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+      "real or character value that defines the concentration of evaporated water $(ML^{-3})$ for the lake. If this concentration value is larger than the simulated concentration in the lake, then the evaporated water will be removed at the same concentration as the lake.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+        "gwt-lkt"
+      ],
+      "real or character value that defines the concentration of evaporated water $(ML^{-3})$ for the reach. If this concentration value is larger than the simulated concentration in the reach, then the evaporated water will be removed at the same concentration as the reach.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+        "gwt-sft"
+      ],
+      "real or character value that defines the maximum evaporation rate $(LT^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+        "gwf-lak"
+      ],
+      "real or character value that defines the volumetric rate per unit area of water subtracted by evaporation from the streamflow routing reach. A positive evaporation rate should be provided. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. If the volumetric evaporation rate for a reach exceeds the sources of water to the reach (upstream and specified inflows, rainfall, and runoff but excluding groundwater leakage into the reach) the volumetric evaporation rate is limited to the sources of water to the reach. By default, evaporation rates are zero for each reach.": [
+        "gwf-sfr"
+      ],
+      "use of the EVAPORATION keyword is allowed in the LKE package; however, the specified value is not currently used in LKE calculations.  Instead, the latent heat of evaporation is multiplied by the simulated evaporation rate for determining the thermal energy lost from a stream reach.": [
+        "gwe-lke"
+      ],
+      "use of the EVAPORATION keyword is allowed in the SFE package; however, the specified value is not currently used in SFE calculations.  Instead, the latent heat of evaporation is multiplied by the simulated evaporation rate for determining the thermal energy lost from a stream reach.": [
+        "gwe-sfe"
+      ]
     }
   },
   "exchanges": {
     "exchanges": {
-      "sim-nam": "is the list of exchange types, exchange files, and model names."
+      "is the list of exchange types, exchange files, and model names.": [
+        "sim-nam"
+      ]
     }
   },
   "exit_solve_tolerance": {
     "options": {
-      "prt-prp": "the convergence tolerance for iterative solution of particle exit location and time in the generalized Pollock's method.  A value of 0.00001 works well for many problems, but the value that strikes the best balance between accuracy and runtime is problem-dependent."
+      "the convergence tolerance for iterative solution of particle exit location and time in the generalized Pollock's method.  A value of 0.00001 works well for many problems, but the value that strikes the best balance between accuracy and runtime is problem-dependent.": [
+        "prt-prp"
+      ]
     }
   },
   "explicit": {
     "options": {
-      "gwf-gnc": "keyword to indicate that the ghost node correction is applied in an explicit manner on the right-hand side of the matrix.  The explicit approach will likely require additional outer iterations.  If the keyword is not specified, then the correction will be applied in an implicit manner on the left-hand side.  The implicit approach will likely converge better, but may require additional memory.  If the EXPLICIT keyword is not specified, then the BICGSTAB linear acceleration option should be specified within the LINEAR block of the Sparse Matrix Solver."
+      "keyword to indicate that the ghost node correction is applied in an explicit manner on the right-hand side of the matrix.  The explicit approach will likely require additional outer iterations.  If the keyword is not specified, then the correction will be applied in an implicit manner on the left-hand side.  The implicit approach will likely converge better, but may require additional memory.  If the EXPLICIT keyword is not specified, then the BICGSTAB linear acceleration option should be specified within the LINEAR block of the Sparse Matrix Solver.": [
+        "gwf-gnc"
+      ]
     }
   },
   "export_array_ascii": {
     "options": {
-      "chf-dfw": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
-      "chf-disv1d": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
-      "chf-ic": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
-      "chf-sto": "keyword that specifies input grid arrays, which already support the layered keyword, should be written to layered ascii output files.",
-      "gwe-cnd": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
-      "gwe-dis": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
-      "gwe-disu": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
-      "gwe-disv": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
-      "gwe-ic": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
-      "gwf-dis": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
-      "gwf-disu": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
-      "gwf-disv": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
-      "gwf-ic": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
-      "gwf-npf": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
-      "gwf-sto": "keyword that specifies input grid arrays, which already support the layered keyword, should be written to layered ascii output files.",
-      "gwt-dis": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
-      "gwt-disu": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
-      "gwt-disv": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
-      "gwt-dsp": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
-      "gwt-ic": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
-      "olf-dfw": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
-      "olf-dis2d": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
-      "olf-disv1d": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
-      "olf-disv2d": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
-      "olf-ic": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
-      "olf-sto": "keyword that specifies input grid arrays, which already support the layered keyword, should be written to layered ascii output files.",
-      "prt-dis": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
-      "prt-disv": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
-      "prt-mip": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
-      "swf-dfw": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
-      "swf-dis2d": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
-      "swf-disv1d": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
-      "swf-disv2d": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
-      "swf-ic": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
-      "swf-sto": "keyword that specifies input grid arrays, which already support the layered keyword, should be written to layered ascii output files."
+      "keyword that specifies input grid arrays, which already support the layered keyword, should be written to layered ascii output files.": [
+        "chf-sto",
+        "gwf-sto",
+        "olf-sto",
+        "swf-sto"
+      ],
+      "keyword that specifies input griddata arrays should be written to layered ascii output files.": [
+        "chf-dfw",
+        "chf-disv1d",
+        "chf-ic",
+        "gwe-cnd",
+        "gwe-dis",
+        "gwe-disu",
+        "gwe-disv",
+        "gwe-ic",
+        "gwf-dis",
+        "gwf-disu",
+        "gwf-disv",
+        "gwf-ic",
+        "gwf-npf",
+        "gwt-dis",
+        "gwt-disu",
+        "gwt-disv",
+        "gwt-dsp",
+        "gwt-ic",
+        "olf-dfw",
+        "olf-dis2d",
+        "olf-disv1d",
+        "olf-disv2d",
+        "olf-ic",
+        "prt-dis",
+        "prt-disv",
+        "prt-mip",
+        "swf-dfw",
+        "swf-dis2d",
+        "swf-disv1d",
+        "swf-disv2d",
+        "swf-ic"
+      ]
     }
   },
   "export_array_netcdf": {
     "options": {
-      "gwe-cnd": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
-      "gwe-dis": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
-      "gwe-disv": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
-      "gwe-ic": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
-      "gwf-dis": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
-      "gwf-disv": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
-      "gwf-evta": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
-      "gwf-ic": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
-      "gwf-npf": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
-      "gwf-rcha": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
-      "gwf-sto": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
-      "gwt-dis": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
-      "gwt-disv": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
-      "gwt-dsp": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
-      "gwt-ic": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
-      "prt-dis": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
-      "prt-disv": "keyword that specifies input griddata arrays should be written to the model output netcdf file."
+      "keyword that specifies input griddata arrays should be written to the model output netcdf file.": [
+        "gwe-cnd",
+        "gwe-dis",
+        "gwe-disv",
+        "gwe-ic",
+        "gwf-dis",
+        "gwf-disv",
+        "gwf-evta",
+        "gwf-ic",
+        "gwf-npf",
+        "gwf-rcha",
+        "gwf-sto",
+        "gwt-dis",
+        "gwt-disv",
+        "gwt-dsp",
+        "gwt-ic",
+        "prt-dis",
+        "prt-disv"
+      ]
     }
   },
   "ext-inflow": {
     "period": {
-      "gwe-lke": "real or character value that defines the temperature of external inflow for the lake.  Users are free to use whatever temperature scale they want, which might include negative temperatures.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      "gwt-lkt": "real or character value that defines the concentration of external inflow $(ML^{-3})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+      "real or character value that defines the concentration of external inflow $(ML^{-3})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+        "gwt-lkt"
+      ],
+      "real or character value that defines the temperature of external inflow for the lake.  Users are free to use whatever temperature scale they want, which might include negative temperatures.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+        "gwe-lke"
+      ]
     }
   },
   "extend_tracking": {
     "options": {
-      "prt-prp": "indicates that particles should be tracked beyond the end of the simulation's final time step (using that time step's flows) until particles terminate or reach a specified stop time.  By default, particles are terminated at the end of the simulation's final time step."
+      "indicates that particles should be tracked beyond the end of the simulation's final time step (using that time step's flows) until particles terminate or reach a specified stop time.  By default, particles are terminated at the end of the simulation's final time step.": [
+        "prt-prp"
+      ]
     }
   },
   "filein": {
     "crosssections": {
-      "gwf-sfr": "keyword to specify that an input filename is expected next."
+      "keyword to specify that an input filename is expected next.": [
+        "gwf-sfr"
+      ]
     },
     "fileinput": {
-      "gwe-ssm": "keyword to specify that an input filename is expected next.",
-      "gwt-ssm": "keyword to specify that an input filename is expected next."
+      "keyword to specify that an input filename is expected next.": [
+        "gwe-ssm",
+        "gwt-ssm"
+      ]
     },
     "options": {
-      "chf-cdb": "keyword to specify that an input filename is expected next.",
-      "chf-chd": "keyword to specify that an input filename is expected next.",
-      "chf-dfw": "keyword to specify that an input filename is expected next.",
-      "chf-evp": "keyword to specify that an input filename is expected next.",
-      "chf-flw": "keyword to specify that an input filename is expected next.",
-      "chf-pcp": "keyword to specify that an input filename is expected next.",
-      "chf-zdg": "keyword to specify that an input filename is expected next.",
-      "exg-chfgwf": "keyword to specify that an input filename is expected next.",
-      "exg-gwegwe": "keyword to specify that an input filename is expected next.",
-      "exg-gwfgwf": "keyword to specify that an input filename is expected next.",
-      "exg-gwtgwt": "keyword to specify that an input filename is expected next.",
-      "exg-olfgwf": "keyword to specify that an input filename is expected next.",
-      "gwe-ctp": "keyword to specify that an input filename is expected next.",
-      "gwe-dis": "keyword to specify that an input filename is expected next.",
-      "gwe-disv": "keyword to specify that an input filename is expected next.",
-      "gwe-esl": "keyword to specify that an input filename is expected next.",
-      "gwe-lke": "keyword to specify that an input filename is expected next.",
-      "gwe-mwe": "keyword to specify that an input filename is expected next.",
-      "gwe-nam": "keyword to specify that an input filename is expected next.",
-      "gwe-sfe": "keyword to specify that an input filename is expected next.",
-      "gwe-uze": "keyword to specify that an input filename is expected next.",
-      "gwf-api": "keyword to specify that an input filename is expected next.",
-      "gwf-chd": "keyword to specify that an input filename is expected next.",
-      "gwf-csub": "keyword to specify that an input filename is expected next.",
-      "gwf-dis": "keyword to specify that an input filename is expected next.",
-      "gwf-disv": "keyword to specify that an input filename is expected next.",
-      "gwf-drn": "keyword to specify that an input filename is expected next.",
-      "gwf-evt": "keyword to specify that an input filename is expected next.",
-      "gwf-evta": "keyword to specify that an input filename is expected next.",
-      "gwf-ghb": "keyword to specify that an input filename is expected next.",
-      "gwf-lak": "keyword to specify that an input filename is expected next.",
-      "gwf-maw": "keyword to specify that an input filename is expected next.",
-      "gwf-nam": "keyword to specify that an input filename is expected next.",
-      "gwf-npf": "keyword to specify that an input filename is expected next.",
-      "gwf-rch": "keyword to specify that an input filename is expected next.",
-      "gwf-rcha": "keyword to specify that an input filename is expected next.",
-      "gwf-riv": "keyword to specify that an input filename is expected next.",
-      "gwf-sfr": "keyword to specify that an input filename is expected next.",
-      "gwf-sto": "keyword to specify that an input filename is expected next.",
-      "gwf-uzf": "keyword to specify that an input filename is expected next.",
-      "gwf-wel": "keyword to specify that an input filename is expected next.",
-      "gwt-api": "keyword to specify that an input filename is expected next.",
-      "gwt-cnc": "keyword to specify that an input filename is expected next.",
-      "gwt-dis": "keyword to specify that an input filename is expected next.",
-      "gwt-disv": "keyword to specify that an input filename is expected next.",
-      "gwt-lkt": "keyword to specify that an input filename is expected next.",
-      "gwt-mwt": "keyword to specify that an input filename is expected next.",
-      "gwt-nam": "keyword to specify that an input filename is expected next.",
-      "gwt-sft": "keyword to specify that an input filename is expected next.",
-      "gwt-src": "keyword to specify that an input filename is expected next.",
-      "gwt-uzt": "keyword to specify that an input filename is expected next.",
-      "olf-cdb": "keyword to specify that an input filename is expected next.",
-      "olf-chd": "keyword to specify that an input filename is expected next.",
-      "olf-dfw": "keyword to specify that an input filename is expected next.",
-      "olf-evp": "keyword to specify that an input filename is expected next.",
-      "olf-flw": "keyword to specify that an input filename is expected next.",
-      "olf-pcp": "keyword to specify that an input filename is expected next.",
-      "olf-zdg": "keyword to specify that an input filename is expected next.",
-      "prt-dis": "keyword to specify that an input filename is expected next.",
-      "prt-disv": "keyword to specify that an input filename is expected next.",
-      "sim-nam": "keyword to specify that an input filename is expected next.",
-      "sim-tdis": "keyword to specify that an input filename is expected next.",
-      "swf-cdb": "keyword to specify that an input filename is expected next.",
-      "swf-chd": "keyword to specify that an input filename is expected next.",
-      "swf-dfw": "keyword to specify that an input filename is expected next.",
-      "swf-evp": "keyword to specify that an input filename is expected next.",
-      "swf-flw": "keyword to specify that an input filename is expected next.",
-      "swf-pcp": "keyword to specify that an input filename is expected next.",
-      "swf-zdg": "keyword to specify that an input filename is expected next.",
-      "utl-spc": "keyword to specify that an input filename is expected next.",
-      "utl-spca": "keyword to specify that an input filename is expected next.",
-      "utl-tvk": "keyword to specify that an input filename is expected next.",
-      "utl-tvs": "keyword to specify that an input filename is expected next."
+      "keyword to specify that an input filename is expected next.": [
+        "chf-cdb",
+        "chf-chd",
+        "chf-dfw",
+        "chf-evp",
+        "chf-flw",
+        "chf-pcp",
+        "chf-zdg",
+        "exg-chfgwf",
+        "exg-gwegwe",
+        "exg-gwfgwf",
+        "exg-gwtgwt",
+        "exg-olfgwf",
+        "gwe-ctp",
+        "gwe-dis",
+        "gwe-disv",
+        "gwe-esl",
+        "gwe-lke",
+        "gwe-mwe",
+        "gwe-nam",
+        "gwe-sfe",
+        "gwe-uze",
+        "gwf-api",
+        "gwf-chd",
+        "gwf-csub",
+        "gwf-dis",
+        "gwf-disv",
+        "gwf-drn",
+        "gwf-evt",
+        "gwf-evta",
+        "gwf-ghb",
+        "gwf-lak",
+        "gwf-maw",
+        "gwf-nam",
+        "gwf-npf",
+        "gwf-rch",
+        "gwf-rcha",
+        "gwf-riv",
+        "gwf-sfr",
+        "gwf-sto",
+        "gwf-uzf",
+        "gwf-wel",
+        "gwt-api",
+        "gwt-cnc",
+        "gwt-dis",
+        "gwt-disv",
+        "gwt-lkt",
+        "gwt-mwt",
+        "gwt-nam",
+        "gwt-sft",
+        "gwt-src",
+        "gwt-uzt",
+        "olf-cdb",
+        "olf-chd",
+        "olf-dfw",
+        "olf-evp",
+        "olf-flw",
+        "olf-pcp",
+        "olf-zdg",
+        "prt-dis",
+        "prt-disv",
+        "sim-nam",
+        "sim-tdis",
+        "swf-cdb",
+        "swf-chd",
+        "swf-dfw",
+        "swf-evp",
+        "swf-flw",
+        "swf-pcp",
+        "swf-zdg",
+        "utl-spc",
+        "utl-spca",
+        "utl-tvk",
+        "utl-tvs"
+      ]
     },
     "packagedata": {
-      "gwe-fmi": "keyword to specify that an input filename is expected next.",
-      "gwt-fmi": "keyword to specify that an input filename is expected next.",
-      "prt-fmi": "keyword to specify that an input filename is expected next."
+      "keyword to specify that an input filename is expected next.": [
+        "gwe-fmi",
+        "gwt-fmi",
+        "prt-fmi"
+      ]
     },
     "period": {
-      "gwf-sfr": "keyword to specify that an input filename is expected next."
+      "keyword to specify that an input filename is expected next.": [
+        "gwf-sfr"
+      ]
     },
     "tables": {
-      "gwf-lak": "keyword to specify that an input filename is expected next."
+      "keyword to specify that an input filename is expected next.": [
+        "gwf-lak"
+      ]
     }
   },
   "fileout": {
     "continuous": {
-      "utl-obs": "keyword to specify that an output filename is expected next."
+      "keyword to specify that an output filename is expected next.": [
+        "utl-obs"
+      ]
     },
     "options": {
-      "chf-oc": "keyword to specify that an output filename is expected next.",
-      "gwe-lke": "keyword to specify that an output filename is expected next.",
-      "gwe-mve": "keyword to specify that an output filename is expected next.",
-      "gwe-mwe": "keyword to specify that an output filename is expected next.",
-      "gwe-nam": "keyword to specify that an output filename is expected next.",
-      "gwe-oc": "keyword to specify that an output filename is expected next.",
-      "gwe-sfe": "keyword to specify that an output filename is expected next.",
-      "gwe-uze": "keyword to specify that an output filename is expected next.",
-      "gwf-buy": "keyword to specify that an output filename is expected next.",
-      "gwf-csub": "keyword to specify that an output filename is expected next.",
-      "gwf-lak": "keyword to specify that an output filename is expected next.",
-      "gwf-maw": "keyword to specify that an output filename is expected next.",
-      "gwf-mvr": "keyword to specify that an output filename is expected next.",
-      "gwf-nam": "keyword to specify that an output filename is expected next.",
-      "gwf-oc": "keyword to specify that an output filename is expected next.",
-      "gwf-sfr": "keyword to specify that an output filename is expected next.",
-      "gwf-uzf": "keyword to specify that an output filename is expected next.",
-      "gwf-vsc": "keyword to specify that an output filename is expected next.",
-      "gwf-wel": "keyword to specify that an output filename is expected next.",
-      "gwt-ist": "keyword to specify that an output filename is expected next.",
-      "gwt-lkt": "keyword to specify that an output filename is expected next.",
-      "gwt-mst": "keyword to specify that an output filename is expected next.",
-      "gwt-mvt": "keyword to specify that an output filename is expected next.",
-      "gwt-mwt": "keyword to specify that an output filename is expected next.",
-      "gwt-nam": "keyword to specify that an output filename is expected next.",
-      "gwt-oc": "keyword to specify that an output filename is expected next.",
-      "gwt-sft": "keyword to specify that an output filename is expected next.",
-      "gwt-uzt": "keyword to specify that an output filename is expected next.",
-      "olf-oc": "keyword to specify that an output filename is expected next.",
-      "prt-oc": "keyword to specify that an output filename is expected next.",
-      "prt-prp": "keyword to specify that an output filename is expected next.",
-      "sln-ims": "keyword to specify that an output filename is expected next.",
-      "sln-pts": "keyword to specify that an output filename is expected next.",
-      "swf-oc": "keyword to specify that an output filename is expected next."
+      "keyword to specify that an output filename is expected next.": [
+        "chf-oc",
+        "gwe-lke",
+        "gwe-mve",
+        "gwe-mwe",
+        "gwe-nam",
+        "gwe-oc",
+        "gwe-sfe",
+        "gwe-uze",
+        "gwf-buy",
+        "gwf-csub",
+        "gwf-lak",
+        "gwf-maw",
+        "gwf-mvr",
+        "gwf-nam",
+        "gwf-oc",
+        "gwf-sfr",
+        "gwf-uzf",
+        "gwf-vsc",
+        "gwf-wel",
+        "gwt-ist",
+        "gwt-lkt",
+        "gwt-mst",
+        "gwt-mvt",
+        "gwt-mwt",
+        "gwt-nam",
+        "gwt-oc",
+        "gwt-sft",
+        "gwt-uzt",
+        "olf-oc",
+        "prt-oc",
+        "prt-prp",
+        "sln-ims",
+        "sln-pts",
+        "swf-oc"
+      ]
     }
   },
   "first": {
     "period": {
-      "chf-oc": "keyword to indicate save for first step in period. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
-      "gwe-oc": "keyword to indicate save for first step in period. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
-      "gwf-oc": "keyword to indicate save for first step in period. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
-      "gwt-oc": "keyword to indicate save for first step in period. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
-      "olf-oc": "keyword to indicate save for first step in period. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
-      "prt-oc": "keyword to indicate save for first step in period. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
-      "prt-prp": "keyword to indicate release at the start of the first time step in the period. This keyword may be used in conjunction with other RELEASESETTING options.",
-      "swf-oc": "keyword to indicate save for first step in period. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps."
+      "keyword to indicate release at the start of the first time step in the period. This keyword may be used in conjunction with other RELEASESETTING options.": [
+        "prt-prp"
+      ],
+      "keyword to indicate save for first step in period. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.": [
+        "chf-oc",
+        "gwe-oc",
+        "gwf-oc",
+        "gwt-oc",
+        "olf-oc",
+        "prt-oc",
+        "swf-oc"
+      ]
     }
   },
   "first_order_decay": {
     "options": {
-      "gwt-ist": "is a text keyword to indicate that first-order decay will occur.  Use of this keyword requires that DECAY and DECAY\\_SORBED (if sorption is active) are specified in the GRIDDATA block.",
-      "gwt-mst": "is a text keyword to indicate that first-order decay will occur.  Use of this keyword requires that DECAY and DECAY\\_SORBED (if sorption is active) are specified in the GRIDDATA block."
+      "is a text keyword to indicate that first-order decay will occur.  Use of this keyword requires that DECAY and DECAY\\_SORBED (if sorption is active) are specified in the GRIDDATA block.": [
+        "gwt-ist",
+        "gwt-mst"
+      ]
     }
   },
   "fixed_cell": {
     "options": {
-      "gwf-evt": "indicates that evapotranspiration will not be reassigned to a cell underlying the cell specified in the list if the specified cell is inactive.",
-      "gwf-evta": "indicates that evapotranspiration will not be reassigned to a cell underlying the cell specified in the list if the specified cell is inactive.",
-      "gwf-rch": "indicates that recharge will not be reassigned to a cell underlying the cell specified in the list if the specified cell is inactive.",
-      "gwf-rcha": "indicates that recharge will not be reassigned to a cell underlying the cell specified in the list if the specified cell is inactive."
+      "indicates that evapotranspiration will not be reassigned to a cell underlying the cell specified in the list if the specified cell is inactive.": [
+        "gwf-evt",
+        "gwf-evta"
+      ],
+      "indicates that recharge will not be reassigned to a cell underlying the cell specified in the list if the specified cell is inactive.": [
+        "gwf-rch",
+        "gwf-rcha"
+      ]
     }
   },
   "fixed_conductance": {
     "options": {
-      "exg-chfgwf": "keyword to indicate that the product of the bedleak and cfact input variables in the exchangedata block represents conductance.  This conductance is fixed and does not change as a function of head in the surface water and groundwater models.",
-      "exg-olfgwf": "keyword to indicate that the product of the bedleak and cfact input variables in the exchangedata block represents conductance.  This conductance is fixed and does not change as a function of head in the surface water and groundwater models."
+      "keyword to indicate that the product of the bedleak and cfact input variables in the exchangedata block represents conductance.  This conductance is fixed and does not change as a function of head in the surface water and groundwater models.": [
+        "exg-chfgwf",
+        "exg-olfgwf"
+      ]
     }
   },
   "flow_correction": {
     "options": {
-      "gwf-maw": "keyword that activates flow corrections in cases where the head in a multi-aquifer well is below the bottom of the screen for a connection or the head in a convertible cell connected to a multi-aquifer well is below the cell bottom. When flow corrections are activated, unit head gradients are used to calculate the flow between a multi-aquifer well and a connected GWF cell. By default, flow corrections are not made."
+      "keyword that activates flow corrections in cases where the head in a multi-aquifer well is below the bottom of the screen for a connection or the head in a convertible cell connected to a multi-aquifer well is below the cell bottom. When flow corrections are activated, unit head gradients are used to calculate the flow between a multi-aquifer well and a connected GWF cell. By default, flow corrections are not made.": [
+        "gwf-maw"
+      ]
     }
   },
   "flow_imbalance_correction": {
     "options": {
-      "gwe-fmi": "correct for an imbalance in flows by assuming that any residual flow error comes in or leaves at the temperature of the cell.  When this option is activated, the GWE Model budget written to the listing file will contain two additional entries: FLOW-ERROR and FLOW-CORRECTION.  These two entries will be equal but opposite in sign.  The FLOW-CORRECTION term is a mass flow that is added to offset the error caused by an imprecise flow balance.  If these terms are not relatively small, the flow model should be rerun with stricter convergence tolerances.",
-      "gwt-fmi": "correct for an imbalance in flows by assuming that any residual flow error comes in or leaves at the concentration of the cell.  When this option is activated, the GWT Model budget written to the listing file will contain two additional entries: FLOW-ERROR and FLOW-CORRECTION.  These two entries will be equal but opposite in sign.  The FLOW-CORRECTION term is a mass flow that is added to offset the error caused by an imprecise flow balance.  If these terms are not relatively small, the flow model should be rerun with stricter convergence tolerances."
+      "correct for an imbalance in flows by assuming that any residual flow error comes in or leaves at the concentration of the cell.  When this option is activated, the GWT Model budget written to the listing file will contain two additional entries: FLOW-ERROR and FLOW-CORRECTION.  These two entries will be equal but opposite in sign.  The FLOW-CORRECTION term is a mass flow that is added to offset the error caused by an imprecise flow balance.  If these terms are not relatively small, the flow model should be rerun with stricter convergence tolerances.": [
+        "gwt-fmi"
+      ],
+      "correct for an imbalance in flows by assuming that any residual flow error comes in or leaves at the temperature of the cell.  When this option is activated, the GWE Model budget written to the listing file will contain two additional entries: FLOW-ERROR and FLOW-CORRECTION.  These two entries will be equal but opposite in sign.  The FLOW-CORRECTION term is a mass flow that is added to offset the error caused by an imprecise flow balance.  If these terms are not relatively small, the flow model should be rerun with stricter convergence tolerances.": [
+        "gwe-fmi"
+      ]
     }
   },
   "flow_package_auxiliary_name": {
     "options": {
-      "gwe-lke": "keyword to specify the name of an auxiliary variable in the corresponding flow package.  If specified, then the simulated temperatures from this advanced transport package will be copied into the auxiliary variable specified with this name.  Note that the flow package must have an auxiliary variable with this name or the program will terminate with an error.  If the flows for this advanced transport package are read from a file, then this option will have no effect.",
-      "gwe-mwe": "keyword to specify the name of an auxiliary variable in the corresponding flow package.  If specified, then the simulated temperatures from this advanced transport package will be copied into the auxiliary variable specified with this name.  Note that the flow package must have an auxiliary variable with this name or the program will terminate with an error.  If the flows for this advanced transport package are read from a file, then this option will have no effect.",
-      "gwe-sfe": "keyword to specify the name of an auxiliary variable provided in the corresponding flow package (i.e., FLOW\\_PACKAGE\\_NAME).  If specified, then the simulated temperatures from this advanced energy transport package will be copied into the auxiliary variable specified with this name.  Note that the flow package must have an auxiliary variable with this name or the program will terminate with an error.  If the flows for this advanced energy transport package are read from a file, then this option will have no effect.",
-      "gwe-uze": "keyword to specify the name of an auxiliary variable in the corresponding flow package.  If specified, then the simulated temperatures from this advanced transport package will be copied into the auxiliary variable specified with this name.  Note that the flow package must have an auxiliary variable with this name or the program will terminate with an error.  If the flows for this advanced transport package are read from a file, then this option will have no effect.",
-      "gwt-lkt": "keyword to specify the name of an auxiliary variable in the corresponding flow package.  If specified, then the simulated concentrations from this advanced transport package will be copied into the auxiliary variable specified with this name.  Note that the flow package must have an auxiliary variable with this name or the program will terminate with an error.  If the flows for this advanced transport package are read from a file, then this option will have no effect.",
-      "gwt-mwt": "keyword to specify the name of an auxiliary variable in the corresponding flow package.  If specified, then the simulated concentrations from this advanced transport package will be copied into the auxiliary variable specified with this name.  Note that the flow package must have an auxiliary variable with this name or the program will terminate with an error.  If the flows for this advanced transport package are read from a file, then this option will have no effect.",
-      "gwt-sft": "keyword to specify the name of an auxiliary variable in the corresponding flow package.  If specified, then the simulated concentrations from this advanced transport package will be copied into the auxiliary variable specified with this name.  Note that the flow package must have an auxiliary variable with this name or the program will terminate with an error.  If the flows for this advanced transport package are read from a file, then this option will have no effect.",
-      "gwt-uzt": "keyword to specify the name of an auxiliary variable in the corresponding flow package.  If specified, then the simulated concentrations from this advanced transport package will be copied into the auxiliary variable specified with this name.  Note that the flow package must have an auxiliary variable with this name or the program will terminate with an error.  If the flows for this advanced transport package are read from a file, then this option will have no effect."
+      "keyword to specify the name of an auxiliary variable in the corresponding flow package.  If specified, then the simulated concentrations from this advanced transport package will be copied into the auxiliary variable specified with this name.  Note that the flow package must have an auxiliary variable with this name or the program will terminate with an error.  If the flows for this advanced transport package are read from a file, then this option will have no effect.": [
+        "gwt-lkt",
+        "gwt-mwt",
+        "gwt-sft",
+        "gwt-uzt"
+      ],
+      "keyword to specify the name of an auxiliary variable in the corresponding flow package.  If specified, then the simulated temperatures from this advanced transport package will be copied into the auxiliary variable specified with this name.  Note that the flow package must have an auxiliary variable with this name or the program will terminate with an error.  If the flows for this advanced transport package are read from a file, then this option will have no effect.": [
+        "gwe-lke",
+        "gwe-mwe",
+        "gwe-uze"
+      ],
+      "keyword to specify the name of an auxiliary variable provided in the corresponding flow package (i.e., FLOW\\_PACKAGE\\_NAME).  If specified, then the simulated temperatures from this advanced energy transport package will be copied into the auxiliary variable specified with this name.  Note that the flow package must have an auxiliary variable with this name or the program will terminate with an error.  If the flows for this advanced energy transport package are read from a file, then this option will have no effect.": [
+        "gwe-sfe"
+      ]
     }
   },
   "flow_package_name": {
     "options": {
-      "gwe-lke": "keyword to specify the name of the corresponding flow package.  If not specified, then the corresponding flow package must have the same name as this advanced transport package (the name associated with this package in the GWE name file).",
-      "gwe-mwe": "keyword to specify the name of the corresponding flow package.  If not specified, then the corresponding flow package must have the same name as this advanced transport package (the name associated with this package in the GWE name file).",
-      "gwe-sfe": "keyword to specify the name of the corresponding flow package.  If not specified, then the corresponding flow package must have the same name as this advanced transport package (the name associated with this package in the GWE name file).",
-      "gwe-uze": "keyword to specify the name of the corresponding flow package.  If not specified, then the corresponding flow package must have the same name as this advanced transport package (the name associated with this package in the GWE name file).",
-      "gwt-lkt": "keyword to specify the name of the corresponding flow package.  If not specified, then the corresponding flow package must have the same name as this advanced transport package (the name associated with this package in the GWT name file).",
-      "gwt-mwt": "keyword to specify the name of the corresponding flow package.  If not specified, then the corresponding flow package must have the same name as this advanced transport package (the name associated with this package in the GWT name file).",
-      "gwt-sft": "keyword to specify the name of the corresponding flow package.  If not specified, then the corresponding flow package must have the same name as this advanced transport package (the name associated with this package in the GWT name file).",
-      "gwt-uzt": "keyword to specify the name of the corresponding flow package.  If not specified, then the corresponding flow package must have the same name as this advanced transport package (the name associated with this package in the GWT name file)."
+      "keyword to specify the name of the corresponding flow package.  If not specified, then the corresponding flow package must have the same name as this advanced transport package (the name associated with this package in the GWE name file).": [
+        "gwe-lke",
+        "gwe-mwe",
+        "gwe-sfe",
+        "gwe-uze"
+      ],
+      "keyword to specify the name of the corresponding flow package.  If not specified, then the corresponding flow package must have the same name as this advanced transport package (the name associated with this package in the GWT name file).": [
+        "gwt-lkt",
+        "gwt-mwt",
+        "gwt-sft",
+        "gwt-uzt"
+      ]
     }
   },
   "flowing_well": {
     "period": {
-      "gwf-maw": "keyword to indicate the well is a flowing well.  The FLOWING\\_WELL option can be used to simulate flowing wells when the simulated well head exceeds the specified drainage elevation."
+      "keyword to indicate the well is a flowing well.  The FLOWING\\_WELL option can be used to simulate flowing wells when the simulated well head exceeds the specified drainage elevation.": [
+        "gwf-maw"
+      ]
     }
   },
   "flowing_wells": {
     "options": {
-      "gwf-maw": "keyword that activates the flowing wells option for the multi-aquifer well package."
+      "keyword that activates the flowing wells option for the multi-aquifer well package.": [
+        "gwf-maw"
+      ]
     }
   },
   "fraction": {
     "period": {
-      "prt-prp": "release particles after the specified fraction of the time step has elapsed. If FRACTION is not set, particles are released at the start of the specified time step(s). FRACTION must be a single value when used with ALL, FIRST, or FREQUENCY. When used with STEPS, FRACTION may be a single value or an array of the same length as STEPS. If a single FRACTION value is provided with STEPS, the fraction applies to all steps. NOTE: The FRACTION option has been removed. For fine control over release timing, specify times explicitly using the RELEASETIMES block."
+      "release particles after the specified fraction of the time step has elapsed. If FRACTION is not set, particles are released at the start of the specified time step(s). FRACTION must be a single value when used with ALL, FIRST, or FREQUENCY. When used with STEPS, FRACTION may be a single value or an array of the same length as STEPS. If a single FRACTION value is provided with STEPS, the fraction applies to all steps. NOTE: The FRACTION option has been removed. For fine control over release timing, specify times explicitly using the RELEASETIMES block.": [
+        "prt-prp"
+      ]
     }
   },
   "frequency": {
     "period": {
-      "chf-oc": "save at the specified time step frequency. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
-      "gwe-oc": "save at the specified time step frequency. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
-      "gwf-oc": "save at the specified time step frequency. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
-      "gwt-oc": "save at the specified time step frequency. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
-      "olf-oc": "save at the specified time step frequency. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
-      "prt-oc": "save at the specified time step frequency. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
-      "prt-prp": "release at the specified time step frequency. This keyword may be used in conjunction with other RELEASESETTING options.",
-      "swf-oc": "save at the specified time step frequency. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps."
+      "release at the specified time step frequency. This keyword may be used in conjunction with other RELEASESETTING options.": [
+        "prt-prp"
+      ],
+      "save at the specified time step frequency. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.": [
+        "chf-oc",
+        "gwe-oc",
+        "gwf-oc",
+        "gwt-oc",
+        "olf-oc",
+        "prt-oc",
+        "swf-oc"
+      ]
     }
   },
   "gnc6": {
     "options": {
-      "exg-gwfgwf": "keyword to specify that record corresponds to a ghost-node correction file."
+      "keyword to specify that record corresponds to a ghost-node correction file.": [
+        "exg-gwfgwf"
+      ]
     }
   },
   "gwfmodelname1": {
     "options": {
-      "exg-gwegwe": "keyword to specify name of first corresponding GWF Model.  In the simulation name file, the GWE6-GWE6 entry contains names for GWE Models (exgmnamea and exgmnameb).  The GWE Model with the name exgmnamea must correspond to the GWF Model with the name gwfmodelname1.",
-      "exg-gwtgwt": "keyword to specify name of first corresponding GWF Model.  In the simulation name file, the GWT6-GWT6 entry contains names for GWT Models (exgmnamea and exgmnameb).  The GWT Model with the name exgmnamea must correspond to the GWF Model with the name gwfmodelname1."
+      "keyword to specify name of first corresponding GWF Model.  In the simulation name file, the GWE6-GWE6 entry contains names for GWE Models (exgmnamea and exgmnameb).  The GWE Model with the name exgmnamea must correspond to the GWF Model with the name gwfmodelname1.": [
+        "exg-gwegwe"
+      ],
+      "keyword to specify name of first corresponding GWF Model.  In the simulation name file, the GWT6-GWT6 entry contains names for GWT Models (exgmnamea and exgmnameb).  The GWT Model with the name exgmnamea must correspond to the GWF Model with the name gwfmodelname1.": [
+        "exg-gwtgwt"
+      ]
     }
   },
   "gwfmodelname2": {
     "options": {
-      "exg-gwegwe": "keyword to specify name of second corresponding GWF Model.  In the simulation name file, the GWE6-GWE6 entry contains names for GWE Models (exgmnamea and exgmnameb).  The GWE Model with the name exgmnameb must correspond to the GWF Model with the name gwfmodelname2.",
-      "exg-gwtgwt": "keyword to specify name of second corresponding GWF Model.  In the simulation name file, the GWT6-GWT6 entry contains names for GWT Models (exgmnamea and exgmnameb).  The GWT Model with the name exgmnameb must correspond to the GWF Model with the name gwfmodelname2."
+      "keyword to specify name of second corresponding GWF Model.  In the simulation name file, the GWE6-GWE6 entry contains names for GWE Models (exgmnamea and exgmnameb).  The GWE Model with the name exgmnameb must correspond to the GWF Model with the name gwfmodelname2.": [
+        "exg-gwegwe"
+      ],
+      "keyword to specify name of second corresponding GWF Model.  In the simulation name file, the GWT6-GWT6 entry contains names for GWT Models (exgmnamea and exgmnameb).  The GWT Model with the name exgmnameb must correspond to the GWF Model with the name gwfmodelname2.": [
+        "exg-gwtgwt"
+      ]
     }
   },
   "head": {
     "options": {
-      "gwf-maw": "keyword to specify that record corresponds to head.",
-      "gwf-oc": "keyword to specify that record corresponds to head."
+      "keyword to specify that record corresponds to head.": [
+        "gwf-maw",
+        "gwf-oc"
+      ]
     }
   },
   "head_based": {
     "options": {
-      "gwf-csub": "keyword to indicate the head-based formulation will be used to simulate coarse-grained aquifer materials and no-delay and delay interbeds. Specifying HEAD\\_BASED also specifies the INITIAL\\_PRECONSOLIDATION\\_HEAD option."
+      "keyword to indicate the head-based formulation will be used to simulate coarse-grained aquifer materials and no-delay and delay interbeds. Specifying HEAD\\_BASED also specifies the INITIAL\\_PRECONSOLIDATION\\_HEAD option.": [
+        "gwf-csub"
+      ]
     }
   },
   "head_limit": {
     "period": {
-      "gwf-maw": "is the limiting water level (head) in the well, which is the minimum of the well RATE or the well inflow rate from the aquifer. HEAD\\_LIMIT can be applied to extraction wells (RATE $<$ 0) or injection wells (RATE $>$ 0). HEAD\\_LIMIT can be deactivated by specifying the text string `OFF'. The HEAD\\_LIMIT option is based on the HEAD\\_LIMIT functionality available in the MNW2~\\citep{konikow2009} package for MODFLOW-2005. The HEAD\\_LIMIT option has been included to facilitate backward compatibility with previous versions of MODFLOW but use of the RATE\\_SCALING option instead of the HEAD\\_LIMIT option is recommended. By default, HEAD\\_LIMIT is `OFF'."
+      "is the limiting water level (head) in the well, which is the minimum of the well RATE or the well inflow rate from the aquifer. HEAD\\_LIMIT can be applied to extraction wells (RATE $<$ 0) or injection wells (RATE $>$ 0). HEAD\\_LIMIT can be deactivated by specifying the text string `OFF'. The HEAD\\_LIMIT option is based on the HEAD\\_LIMIT functionality available in the MNW2~\\citep{konikow2009} package for MODFLOW-2005. The HEAD\\_LIMIT option has been included to facilitate backward compatibility with previous versions of MODFLOW but use of the RATE\\_SCALING option instead of the HEAD\\_LIMIT option is recommended. By default, HEAD\\_LIMIT is `OFF'.": [
+        "gwf-maw"
+      ]
     }
   },
   "heat_capacity_solid": {
     "griddata": {
-      "gwe-est": "is the mass-based heat capacity of dry solids (aquifer material). For example, units of J/kg/C may be used (or equivalent)."
+      "is the mass-based heat capacity of dry solids (aquifer material). For example, units of J/kg/C may be used (or equivalent).": [
+        "gwe-est"
+      ]
     }
   },
   "heat_capacity_water": {
     "options": {
-      "gwe-est": "heat capacity of water used by calculations related to heat storage and conduction.  This value is set to 4,184 J/kg/C if no overriding value is specified.  A user-specified value should be provided for models that use units other than kilograms, joules, and degrees Celsius or it is necessary to use a value other than the default."
+      "heat capacity of water used by calculations related to heat storage and conduction.  This value is set to 4,184 J/kg/C if no overriding value is specified.  A user-specified value should be provided for models that use units other than kilograms, joules, and degrees Celsius or it is necessary to use a value other than the default.": [
+        "gwe-est"
+      ]
     }
   },
   "hhformulation_rhs": {
     "options": {
-      "gwf-buy": "use the variable-density hydraulic head formulation and add off-diagonal terms to the right-hand.  This option will prevent the BUY Package from adding asymmetric terms to the flow matrix."
+      "use the variable-density hydraulic head formulation and add off-diagonal terms to the right-hand.  This option will prevent the BUY Package from adding asymmetric terms to the flow matrix.": [
+        "gwf-buy"
+      ]
     }
   },
   "hpc6": {
     "options": {
-      "sim-nam": "keyword to specify that record corresponds to a hpc file."
+      "keyword to specify that record corresponds to a hpc file.": [
+        "sim-nam"
+      ]
     }
   },
   "hwva": {
     "connectiondata": {
-      "gwe-disu": "is a symmetric array of size NJA.  For horizontal connections, entries in HWVA are the horizontal width perpendicular to flow.  For vertical connections, entries in HWVA are the vertical area for flow.  Thus, values in the HWVA array contain dimensions of both length and area.  Entries in the HWVA array have a one-to-one correspondence with the connections specified in the JA array.  Likewise, there is a one-to-one correspondence between entries in the HWVA array and entries in the IHC array, which specifies the connection type (horizontal or vertical).  Entries in the HWVA array must be symmetric; the program will terminate with an error if the value for HWVA for an n to m connection does not equal the value for HWVA for the corresponding n to m connection.",
-      "gwf-disu": "is a symmetric array of size NJA.  For horizontal connections, entries in HWVA are the horizontal width perpendicular to flow.  For vertical connections, entries in HWVA are the vertical area for flow.  Thus, values in the HWVA array contain dimensions of both length and area.  Entries in the HWVA array have a one-to-one correspondence with the connections specified in the JA array.  Likewise, there is a one-to-one correspondence between entries in the HWVA array and entries in the IHC array, which specifies the connection type (horizontal or vertical).  Entries in the HWVA array must be symmetric; the program will terminate with an error if the value for HWVA for an n to m connection does not equal the value for HWVA for the corresponding n to m connection.",
-      "gwt-disu": "is a symmetric array of size NJA.  For horizontal connections, entries in HWVA are the horizontal width perpendicular to flow.  For vertical connections, entries in HWVA are the vertical area for flow.  Thus, values in the HWVA array contain dimensions of both length and area.  Entries in the HWVA array have a one-to-one correspondence with the connections specified in the JA array.  Likewise, there is a one-to-one correspondence between entries in the HWVA array and entries in the IHC array, which specifies the connection type (horizontal or vertical).  Entries in the HWVA array must be symmetric; the program will terminate with an error if the value for HWVA for an n to m connection does not equal the value for HWVA for the corresponding n to m connection."
+      "is a symmetric array of size NJA.  For horizontal connections, entries in HWVA are the horizontal width perpendicular to flow.  For vertical connections, entries in HWVA are the vertical area for flow.  Thus, values in the HWVA array contain dimensions of both length and area.  Entries in the HWVA array have a one-to-one correspondence with the connections specified in the JA array.  Likewise, there is a one-to-one correspondence between entries in the HWVA array and entries in the IHC array, which specifies the connection type (horizontal or vertical).  Entries in the HWVA array must be symmetric; the program will terminate with an error if the value for HWVA for an n to m connection does not equal the value for HWVA for the corresponding n to m connection.": [
+        "gwe-disu",
+        "gwf-disu",
+        "gwt-disu"
+      ]
     }
   },
   "iac": {
     "connectiondata": {
-      "gwe-disu": "is the number of connections (plus 1) for each cell.  The sum of all the entries in IAC must be equal to NJA.",
-      "gwf-disu": "is the number of connections (plus 1) for each cell.  The sum of all the entries in IAC must be equal to NJA.",
-      "gwt-disu": "is the number of connections (plus 1) for each cell.  The sum of all the entries in IAC must be equal to NJA."
+      "is the number of connections (plus 1) for each cell.  The sum of all the entries in IAC must be equal to NJA.": [
+        "gwe-disu",
+        "gwf-disu",
+        "gwt-disu"
+      ]
     }
   },
   "icelltype": {
     "griddata": {
-      "gwf-npf": "flag for each cell that specifies how saturated thickness is treated.  0 means saturated thickness is held constant;  $>$0 means saturated thickness varies with computed head when head is below the cell top; $<$0 means saturated thickness varies with computed head unless the THICKSTRT option is in effect.  When THICKSTRT is in effect, a negative value for ICELLTYPE indicates that the saturated thickness value used in conductance calculations in the NPF Package will be computed as STRT-BOT and held constant.  If the THICKSTRT option is not in effect, then negative values provided by the user for ICELLTYPE are automatically reassigned by the program to a value of one."
+      "flag for each cell that specifies how saturated thickness is treated.  0 means saturated thickness is held constant;  $>$0 means saturated thickness varies with computed head when head is below the cell top; $<$0 means saturated thickness varies with computed head unless the THICKSTRT option is in effect.  When THICKSTRT is in effect, a negative value for ICELLTYPE indicates that the saturated thickness value used in conductance calculations in the NPF Package will be computed as STRT-BOT and held constant.  If the THICKSTRT option is not in effect, then negative values provided by the user for ICELLTYPE are automatically reassigned by the program to a value of one.": [
+        "gwf-npf"
+      ]
     }
   },
   "iconvert": {
     "griddata": {
-      "gwf-sto": "is a flag for each cell that specifies whether or not a cell is convertible for the storage calculation. 0 indicates confined storage is used. $>$0 indicates confined storage is used when head is above cell top and a mixed formulation of unconfined and confined storage is used when head is below cell top."
+      "is a flag for each cell that specifies whether or not a cell is convertible for the storage calculation. 0 indicates confined storage is used. $>$0 indicates confined storage is used when head is above cell top and a mixed formulation of unconfined and confined storage is used when head is below cell top.": [
+        "gwf-sto"
+      ]
     }
   },
   "idcxs": {
     "griddata": {
-      "chf-dfw": "integer value indication the cross section identifier in the Cross Section Package that applies to the reach.  If not provided then reach will be treated as hydraulically wide.",
-      "olf-dfw": "integer value indication the cross section identifier in the Cross Section Package that applies to the reach.  If not provided then reach will be treated as hydraulically wide.",
-      "swf-dfw": "integer value indication the cross section identifier in the Cross Section Package that applies to the reach.  If not provided then reach will be treated as hydraulically wide."
+      "integer value indication the cross section identifier in the Cross Section Package that applies to the reach.  If not provided then reach will be treated as hydraulically wide.": [
+        "chf-dfw",
+        "olf-dfw",
+        "swf-dfw"
+      ]
     }
   },
   "idomain": {
     "griddata": {
-      "chf-disv1d": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1, the cell exists in the simulation.",
-      "gwe-dis": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1, the cell exists in the simulation.  If the IDOMAIN value for a cell is -1, the cell does not exist in the simulation.  Furthermore, the first existing cell above will be connected to the first existing cell below.  This type of cell is referred to as a ``vertical pass through'' cell.",
-      "gwe-disu": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1 or greater, the cell exists in the simulation.  IDOMAIN values of -1 cannot be specified for the DISU Package.",
-      "gwe-disv": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1, the cell exists in the simulation.  If the IDOMAIN value for a cell is -1, the cell does not exist in the simulation.  Furthermore, the first existing cell above will be connected to the first existing cell below.  This type of cell is referred to as a ``vertical pass through'' cell.",
-      "gwf-dis": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1 or greater, the cell exists in the simulation.  If the IDOMAIN value for a cell is -1, the cell does not exist in the simulation.  Furthermore, the first existing cell above will be connected to the first existing cell below.  This type of cell is referred to as a ``vertical pass through'' cell.",
-      "gwf-disu": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1 or greater, the cell exists in the simulation.  IDOMAIN values of -1 cannot be specified for the DISU Package.",
-      "gwf-disv": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1 or greater, the cell exists in the simulation.  If the IDOMAIN value for a cell is -1, the cell does not exist in the simulation.  Furthermore, the first existing cell above will be connected to the first existing cell below.  This type of cell is referred to as a ``vertical pass through'' cell.",
-      "gwt-dis": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1, the cell exists in the simulation.  If the IDOMAIN value for a cell is -1, the cell does not exist in the simulation.  Furthermore, the first existing cell above will be connected to the first existing cell below.  This type of cell is referred to as a ``vertical pass through'' cell.",
-      "gwt-disu": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1 or greater, the cell exists in the simulation.  IDOMAIN values of -1 cannot be specified for the DISU Package.",
-      "gwt-disv": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1, the cell exists in the simulation.  If the IDOMAIN value for a cell is -1, the cell does not exist in the simulation.  Furthermore, the first existing cell above will be connected to the first existing cell below.  This type of cell is referred to as a ``vertical pass through'' cell.",
-      "olf-dis2d": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1, the cell exists in the simulation.  If the IDOMAIN value for a cell is -1, the cell does not exist in the simulation.  Furthermore, the first existing cell above will be connected to the first existing cell below.  This type of cell is referred to as a ``vertical pass through'' cell.",
-      "olf-disv1d": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1, the cell exists in the simulation.",
-      "olf-disv2d": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1 or greater, the cell exists in the simulation.  If the IDOMAIN value for a cell is -1, the cell does not exist in the simulation.  Furthermore, the first existing cell above will be connected to the first existing cell below.  This type of cell is referred to as a ``vertical pass through'' cell.",
-      "prt-dis": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1, the cell exists in the simulation.  If the IDOMAIN value for a cell is -1, the cell does not exist in the simulation.  Furthermore, the first existing cell above will be connected to the first existing cell below.  This type of cell is referred to as a ``vertical pass through'' cell.",
-      "prt-disv": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1, the cell exists in the simulation.  If the IDOMAIN value for a cell is -1, the cell does not exist in the simulation.  Furthermore, the first existing cell above will be connected to the first existing cell below.  This type of cell is referred to as a ``vertical pass through'' cell.",
-      "swf-dis2d": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1, the cell exists in the simulation.  If the IDOMAIN value for a cell is -1, the cell does not exist in the simulation.  Furthermore, the first existing cell above will be connected to the first existing cell below.  This type of cell is referred to as a ``vertical pass through'' cell.",
-      "swf-disv1d": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1, the cell exists in the simulation.",
-      "swf-disv2d": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1 or greater, the cell exists in the simulation.  If the IDOMAIN value for a cell is -1, the cell does not exist in the simulation.  Furthermore, the first existing cell above will be connected to the first existing cell below.  This type of cell is referred to as a ``vertical pass through'' cell."
+      "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1 or greater, the cell exists in the simulation.  IDOMAIN values of -1 cannot be specified for the DISU Package.": [
+        "gwe-disu",
+        "gwf-disu",
+        "gwt-disu"
+      ],
+      "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1 or greater, the cell exists in the simulation.  If the IDOMAIN value for a cell is -1, the cell does not exist in the simulation.  Furthermore, the first existing cell above will be connected to the first existing cell below.  This type of cell is referred to as a ``vertical pass through'' cell.": [
+        "gwf-dis",
+        "gwf-disv",
+        "olf-disv2d",
+        "swf-disv2d"
+      ],
+      "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1, the cell exists in the simulation.": [
+        "chf-disv1d",
+        "olf-disv1d",
+        "swf-disv1d"
+      ],
+      "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1, the cell exists in the simulation.  If the IDOMAIN value for a cell is -1, the cell does not exist in the simulation.  Furthermore, the first existing cell above will be connected to the first existing cell below.  This type of cell is referred to as a ``vertical pass through'' cell.": [
+        "gwe-dis",
+        "gwe-disv",
+        "gwt-dis",
+        "gwt-disv",
+        "olf-dis2d",
+        "prt-dis",
+        "prt-disv",
+        "swf-dis2d"
+      ]
     }
   },
   "ievt": {
     "period": {
-      "gwf-evta": "IEVT is the layer number that defines the layer in each vertical column where evapotranspiration is applied. If IEVT is omitted, evapotranspiration by default is applied to cells in layer 1.  If IEVT is specified, it must be specified as the first variable in the PERIOD block or MODFLOW will terminate with an error."
+      "IEVT is the layer number that defines the layer in each vertical column where evapotranspiration is applied. If IEVT is omitted, evapotranspiration by default is applied to cells in layer 1.  If IEVT is specified, it must be specified as the first variable in the PERIOD block or MODFLOW will terminate with an error.": [
+        "gwf-evta"
+      ]
     }
   },
   "ihc": {
     "connectiondata": {
-      "gwe-disu": "is an index array indicating the direction between node n and all of its m connections.  If IHC = 0 then cell n and cell m are connected in the vertical direction.  Cell n overlies cell m if the cell number for n is less than m; cell m overlies cell n if the cell number for m is less than n.  If IHC = 1 then cell n and cell m are connected in the horizontal direction.  If IHC = 2 then cell n and cell m are connected in the horizontal direction, and the connection is vertically staggered.  A vertically staggered connection is one in which a cell is horizontally connected to more than one cell in a horizontal connection.",
-      "gwf-disu": "is an index array indicating the direction between node n and all of its m connections.  If IHC = 0 then cell n and cell m are connected in the vertical direction.  Cell n overlies cell m if the cell number for n is less than m; cell m overlies cell n if the cell number for m is less than n.  If IHC = 1 then cell n and cell m are connected in the horizontal direction.  If IHC = 2 then cell n and cell m are connected in the horizontal direction, and the connection is vertically staggered.  A vertically staggered connection is one in which a cell is horizontally connected to more than one cell in a horizontal connection.",
-      "gwt-disu": "is an index array indicating the direction between node n and all of its m connections.  If IHC = 0 then cell n and cell m are connected in the vertical direction.  Cell n overlies cell m if the cell number for n is less than m; cell m overlies cell n if the cell number for m is less than n.  If IHC = 1 then cell n and cell m are connected in the horizontal direction.  If IHC = 2 then cell n and cell m are connected in the horizontal direction, and the connection is vertically staggered.  A vertically staggered connection is one in which a cell is horizontally connected to more than one cell in a horizontal connection."
+      "is an index array indicating the direction between node n and all of its m connections.  If IHC = 0 then cell n and cell m are connected in the vertical direction.  Cell n overlies cell m if the cell number for n is less than m; cell m overlies cell n if the cell number for m is less than n.  If IHC = 1 then cell n and cell m are connected in the horizontal direction.  If IHC = 2 then cell n and cell m are connected in the horizontal direction, and the connection is vertically staggered.  A vertically staggered connection is one in which a cell is horizontally connected to more than one cell in a horizontal connection.": [
+        "gwe-disu",
+        "gwf-disu",
+        "gwt-disu"
+      ]
     }
   },
   "ihdwet": {
     "options": {
-      "gwf-npf": "is a keyword and integer flag that determines which equation is used to define the initial head at cells that become wet.  If IHDWET is 0, h = BOT + WETFCT (hm - BOT). If IHDWET is not 0, h = BOT + WETFCT (THRESH)."
+      "is a keyword and integer flag that determines which equation is used to define the initial head at cells that become wet.  If IHDWET is 0, h = BOT + WETFCT (hm - BOT). If IHDWET is not 0, h = BOT + WETFCT (THRESH).": [
+        "gwf-npf"
+      ]
     }
   },
   "infiltration": {
     "period": {
-      "gwe-uze": "real or character value that defines the temperature of the infiltration $(e.g.,\\:^{\\circ}C\\:or\\:^{\\circ}F)$ for the UZF cell. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      "gwt-uzt": "real or character value that defines the infiltration solute concentration $(ML^{-3})$ for the UZF cell. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+      "real or character value that defines the infiltration solute concentration $(ML^{-3})$ for the UZF cell. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+        "gwt-uzt"
+      ],
+      "real or character value that defines the temperature of the infiltration $(e.g.,\\:^{\\circ}C\\:or\\:^{\\circ}F)$ for the UZF cell. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+        "gwe-uze"
+      ]
     }
   },
   "inflow": {
     "period": {
-      "gwe-sfe": "real or character value that defines the temperature of inflow $(e.g.,\\:^{\\circ}C\\:or\\:^{\\circ}F)$ for the reach. Users are free to use whatever temperature scale they want, which might include negative temperatures.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      "gwf-lak": "real or character value that defines the volumetric inflow rate $(L^3 T^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, inflow rates are zero for each lake.",
-      "gwf-sfr": "real or character value that defines the volumetric inflow rate for the streamflow routing reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, inflow rates are zero for each reach.",
-      "gwt-sft": "real or character value that defines the concentration of inflow $(ML^{-3})$ for the reach. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+      "real or character value that defines the concentration of inflow $(ML^{-3})$ for the reach. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+        "gwt-sft"
+      ],
+      "real or character value that defines the temperature of inflow $(e.g.,\\:^{\\circ}C\\:or\\:^{\\circ}F)$ for the reach. Users are free to use whatever temperature scale they want, which might include negative temperatures.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+        "gwe-sfe"
+      ],
+      "real or character value that defines the volumetric inflow rate $(L^3 T^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, inflow rates are zero for each lake.": [
+        "gwf-lak"
+      ],
+      "real or character value that defines the volumetric inflow rate for the streamflow routing reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, inflow rates are zero for each reach.": [
+        "gwf-sfr"
+      ]
     }
   },
   "initial_preconsolidation_head": {
     "options": {
-      "gwf-csub": "keyword to indicate that preconsolidation heads will be specified for no-delay and delay interbeds in the PACKAGEDATA block. If the SPECIFIED\\_INITIAL\\_INTERBED\\_STATE option is specified in the OPTIONS block, user-specified preconsolidation heads in the PACKAGEDATA block are absolute values. Otherwise, user-specified preconsolidation heads in the PACKAGEDATA block are relative to steady-state or initial heads."
+      "keyword to indicate that preconsolidation heads will be specified for no-delay and delay interbeds in the PACKAGEDATA block. If the SPECIFIED\\_INITIAL\\_INTERBED\\_STATE option is specified in the OPTIONS block, user-specified preconsolidation heads in the PACKAGEDATA block are absolute values. Otherwise, user-specified preconsolidation heads in the PACKAGEDATA block are relative to steady-state or initial heads.": [
+        "gwf-csub"
+      ]
     }
   },
   "inner_dvclose": {
     "linear": {
-      "sln-ims": "real value defining the dependent-variable (for example, head) change criterion for convergence of the inner (linear) iterations, in units of the dependent-variable (for example, length for head). When the maximum absolute value of the dependent-variable change at all nodes during an iteration is less than or equal to INNER\\_DVCLOSE, the matrix solver assumes convergence. Commonly, INNER\\_DVCLOSE is set equal to or an order of magnitude less than the OUTER\\_DVCLOSE value specified for the NONLINEAR block. The keyword, INNER\\_HCLOSE can be still be specified instead of INNER\\_DVCLOSE for backward compatibility with previous versions of MODFLOW 6 but eventually INNER\\_HCLOSE will be deprecated and specification of INNER\\_HCLOSE will cause MODFLOW 6 to terminate with an error."
+      "real value defining the dependent-variable (for example, head) change criterion for convergence of the inner (linear) iterations, in units of the dependent-variable (for example, length for head). When the maximum absolute value of the dependent-variable change at all nodes during an iteration is less than or equal to INNER\\_DVCLOSE, the matrix solver assumes convergence. Commonly, INNER\\_DVCLOSE is set equal to or an order of magnitude less than the OUTER\\_DVCLOSE value specified for the NONLINEAR block. The keyword, INNER\\_HCLOSE can be still be specified instead of INNER\\_DVCLOSE for backward compatibility with previous versions of MODFLOW 6 but eventually INNER\\_HCLOSE will be deprecated and specification of INNER\\_HCLOSE will cause MODFLOW 6 to terminate with an error.": [
+        "sln-ims"
+      ]
     }
   },
   "inner_hclose": {
     "linear": {
-      "sln-ims": "real value defining the head change criterion for convergence of the inner (linear) iterations, in units of length. When the maximum absolute value of the head change at all nodes during an iteration is less than or equal to INNER\\_HCLOSE, the matrix solver assumes convergence. Commonly, INNER\\_HCLOSE is set equal to or an order of magnitude less than the OUTER\\_HCLOSE value specified for the NONLINEAR block.  The INNER\\_HCLOSE keyword has been deprecated in favor of the more general INNER\\_DVCLOSE (for dependent variable), however either one can be specified in order to maintain backward compatibility."
+      "real value defining the head change criterion for convergence of the inner (linear) iterations, in units of length. When the maximum absolute value of the head change at all nodes during an iteration is less than or equal to INNER\\_HCLOSE, the matrix solver assumes convergence. Commonly, INNER\\_HCLOSE is set equal to or an order of magnitude less than the OUTER\\_HCLOSE value specified for the NONLINEAR block.  The INNER\\_HCLOSE keyword has been deprecated in favor of the more general INNER\\_DVCLOSE (for dependent variable), however either one can be specified in order to maintain backward compatibility.": [
+        "sln-ims"
+      ]
     }
   },
   "inner_maximum": {
     "linear": {
-      "sln-ims": "integer value defining the maximum number of inner (linear) iterations. The number typically depends on the characteristics of the matrix solution scheme being used. For nonlinear problems, INNER\\_MAXIMUM usually ranges from 60 to 600; a value of 100 will be sufficient for most linear problems."
+      "integer value defining the maximum number of inner (linear) iterations. The number typically depends on the characteristics of the matrix solution scheme being used. For nonlinear problems, INNER\\_MAXIMUM usually ranges from 60 to 600; a value of 100 will be sufficient for most linear problems.": [
+        "sln-ims"
+      ]
     }
   },
   "inner_rclose": {
     "linear": {
-      "sln-ims": "real value that defines the flow residual tolerance for convergence of the IMS linear solver and specific flow residual criteria used. This value represents the maximum allowable residual at any single node.  Value is in units of length cubed per time, and must be consistent with \\mf length and time units. Usually a value of $1.0 \\times 10^{-1}$ is sufficient for the flow-residual criteria when meters and seconds are the defined \\mf length and time."
+      "real value that defines the flow residual tolerance for convergence of the IMS linear solver and specific flow residual criteria used. This value represents the maximum allowable residual at any single node.  Value is in units of length cubed per time, and must be consistent with \\mf length and time units. Usually a value of $1.0 \\times 10^{-1}$ is sufficient for the flow-residual criteria when meters and seconds are the defined \\mf length and time.": [
+        "sln-ims"
+      ]
     }
   },
   "invert": {
     "period": {
-      "gwf-lak": "real or character value that defines the invert elevation for the lake outlet. A specified INVERT value is only used for active lakes if COUTTYPE for lake outlet OUTLETNO is not SPECIFIED. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+      "real or character value that defines the invert elevation for the lake outlet. A specified INVERT value is only used for active lakes if COUTTYPE for lake outlet OUTLETNO is not SPECIFIED. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+        "gwf-lak"
+      ]
     }
   },
   "irch": {
     "period": {
-      "gwf-rcha": "IRCH is the layer number that defines the layer in each vertical column where recharge is applied. If IRCH is omitted, recharge by default is applied to cells in layer 1.  IRCH can only be used if READASARRAYS is specified in the OPTIONS block.  If IRCH is specified, it must be specified as the first variable in the PERIOD block or MODFLOW will terminate with an error."
+      "IRCH is the layer number that defines the layer in each vertical column where recharge is applied. If IRCH is omitted, recharge by default is applied to cells in layer 1.  IRCH can only be used if READASARRAYS is specified in the OPTIONS block.  If IRCH is specified, it must be specified as the first variable in the PERIOD block or MODFLOW will terminate with an error.": [
+        "gwf-rcha"
+      ]
     }
   },
   "istopzone": {
     "options": {
-      "prt-prp": "integer value defining the stop zone number.  If cells have been assigned IZONE values in the GRIDDATA block, a particle terminates if it enters a cell whose IZONE value matches ISTOPZONE.  An ISTOPZONE value of zero indicates that there is no stop zone.  The default value is zero."
+      "integer value defining the stop zone number.  If cells have been assigned IZONE values in the GRIDDATA block, a particle terminates if it enters a cell whose IZONE value matches ISTOPZONE.  An ISTOPZONE value of zero indicates that there is no stop zone.  The default value is zero.": [
+        "prt-prp"
+      ]
     }
   },
   "iwetit": {
     "options": {
-      "gwf-npf": "is a keyword and iteration interval for attempting to wet cells. Wetting is attempted every IWETIT iteration. This applies to outer iterations and not inner iterations. If IWETIT is specified as zero or less, then the value is changed to 1."
+      "is a keyword and iteration interval for attempting to wet cells. Wetting is attempted every IWETIT iteration. This applies to outer iterations and not inner iterations. If IWETIT is specified as zero or less, then the value is changed to 1.": [
+        "gwf-npf"
+      ]
     }
   },
   "izone": {
     "griddata": {
-      "prt-mip": "is an integer zone number assigned to each cell.  IZONE may be positive, negative, or zero.  The current cell's zone number is recorded with each particle track datum.  If a PRP package's ISTOPZONE option is set to any value other than zero, particles released by that PRP Package terminate if they enter a cell whose IZONE value matches ISTOPZONE.  If ISTOPZONE is not specified or is set to zero in a PRP Package, IZONE has no effect on the termination of particles released by that PRP Package.  Each PRP Package may configure a single ISTOPZONE value."
+      "is an integer zone number assigned to each cell.  IZONE may be positive, negative, or zero.  The current cell's zone number is recorded with each particle track datum.  If a PRP package's ISTOPZONE option is set to any value other than zero, particles released by that PRP Package terminate if they enter a cell whose IZONE value matches ISTOPZONE.  If ISTOPZONE is not specified or is set to zero in a PRP Package, IZONE has no effect on the termination of particles released by that PRP Package.  Each PRP Package may configure a single ISTOPZONE value.": [
+        "prt-mip"
+      ]
     }
   },
   "ja": {
     "connectiondata": {
-      "gwe-disu": "is a list of cell number (n) followed by its connecting cell numbers (m) for each of the m cells connected to cell n. The number of values to provide for cell n is IAC(n).  This list is sequentially provided for the first to the last cell. The first value in the list must be cell n itself, and the remaining cells must be listed in an increasing order (sorted from lowest number to highest).  Note that the cell and its connections are only supplied for the GWE cells and their connections to the other GWE cells.  Also note that the JA list input may be divided such that every node and its connectivity list can be on a separate line for ease in readability of the file. To further ease readability of the file, the node number of the cell whose connectivity is subsequently listed, may be expressed as a negative number, the sign of which is subsequently converted to positive by the code.",
-      "gwf-disu": "is a list of cell number (n) followed by its connecting cell numbers (m) for each of the m cells connected to cell n. The number of values to provide for cell n is IAC(n).  This list is sequentially provided for the first to the last cell. The first value in the list must be cell n itself, and the remaining cells must be listed in an increasing order (sorted from lowest number to highest).  Note that the cell and its connections are only supplied for the GWF cells and their connections to the other GWF cells.  Also note that the JA list input may be divided such that every node and its connectivity list can be on a separate line for ease in readability of the file. To further ease readability of the file, the node number of the cell whose connectivity is subsequently listed, may be expressed as a negative number, the sign of which is subsequently converted to positive by the code.",
-      "gwt-disu": "is a list of cell number (n) followed by its connecting cell numbers (m) for each of the m cells connected to cell n. The number of values to provide for cell n is IAC(n).  This list is sequentially provided for the first to the last cell. The first value in the list must be cell n itself, and the remaining cells must be listed in an increasing order (sorted from lowest number to highest).  Note that the cell and its connections are only supplied for the GWT cells and their connections to the other GWT cells.  Also note that the JA list input may be divided such that every node and its connectivity list can be on a separate line for ease in readability of the file. To further ease readability of the file, the node number of the cell whose connectivity is subsequently listed, may be expressed as a negative number, the sign of which is subsequently converted to positive by the code."
+      "is a list of cell number (n) followed by its connecting cell numbers (m) for each of the m cells connected to cell n. The number of values to provide for cell n is IAC(n).  This list is sequentially provided for the first to the last cell. The first value in the list must be cell n itself, and the remaining cells must be listed in an increasing order (sorted from lowest number to highest).  Note that the cell and its connections are only supplied for the GWE cells and their connections to the other GWE cells.  Also note that the JA list input may be divided such that every node and its connectivity list can be on a separate line for ease in readability of the file. To further ease readability of the file, the node number of the cell whose connectivity is subsequently listed, may be expressed as a negative number, the sign of which is subsequently converted to positive by the code.": [
+        "gwe-disu"
+      ],
+      "is a list of cell number (n) followed by its connecting cell numbers (m) for each of the m cells connected to cell n. The number of values to provide for cell n is IAC(n).  This list is sequentially provided for the first to the last cell. The first value in the list must be cell n itself, and the remaining cells must be listed in an increasing order (sorted from lowest number to highest).  Note that the cell and its connections are only supplied for the GWF cells and their connections to the other GWF cells.  Also note that the JA list input may be divided such that every node and its connectivity list can be on a separate line for ease in readability of the file. To further ease readability of the file, the node number of the cell whose connectivity is subsequently listed, may be expressed as a negative number, the sign of which is subsequently converted to positive by the code.": [
+        "gwf-disu"
+      ],
+      "is a list of cell number (n) followed by its connecting cell numbers (m) for each of the m cells connected to cell n. The number of values to provide for cell n is IAC(n).  This list is sequentially provided for the first to the last cell. The first value in the list must be cell n itself, and the remaining cells must be listed in an increasing order (sorted from lowest number to highest).  Note that the cell and its connections are only supplied for the GWT cells and their connections to the other GWT cells.  Also note that the JA list input may be divided such that every node and its connectivity list can be on a separate line for ease in readability of the file. To further ease readability of the file, the node number of the cell whose connectivity is subsequently listed, may be expressed as a negative number, the sign of which is subsequently converted to positive by the code.": [
+        "gwt-disu"
+      ]
     }
   },
   "k": {
     "griddata": {
-      "gwf-npf": "is the hydraulic conductivity.  For the common case in which the user would like to specify the horizontal hydraulic conductivity and the vertical hydraulic conductivity, then K should be assigned as the horizontal hydraulic conductivity, K33 should be assigned as the vertical hydraulic conductivity, and K22 and the three rotation angles should not be specified.  When more sophisticated anisotropy is required, then K corresponds to the K11 hydraulic conductivity axis.  All included cells (IDOMAIN $>$ 0) must have a K value greater than zero."
+      "is the hydraulic conductivity.  For the common case in which the user would like to specify the horizontal hydraulic conductivity and the vertical hydraulic conductivity, then K should be assigned as the horizontal hydraulic conductivity, K33 should be assigned as the vertical hydraulic conductivity, and K22 and the three rotation angles should not be specified.  When more sophisticated anisotropy is required, then K corresponds to the K11 hydraulic conductivity axis.  All included cells (IDOMAIN $>$ 0) must have a K value greater than zero.": [
+        "gwf-npf"
+      ]
     },
     "period": {
-      "utl-tvk": "is the new value to be assigned as the cell's hydraulic conductivity from the start of the specified stress period, as per K in the NPF package.  If the OPTIONS block includes a TS6 entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+      "is the new value to be assigned as the cell's hydraulic conductivity from the start of the specified stress period, as per K in the NPF package.  If the OPTIONS block includes a TS6 entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+        "utl-tvk"
+      ]
     }
   },
   "k22": {
     "griddata": {
-      "gwf-npf": "is the hydraulic conductivity of the second ellipsoid axis (or the ratio of K22/K if the K22OVERK option is specified); for an unrotated case this is the hydraulic conductivity in the y direction.  If K22 is not included in the GRIDDATA block, then K22 is set equal to K.  For a regular MODFLOW grid (DIS Package is used) in which no rotation angles are specified, K22 is the hydraulic conductivity along columns in the y direction. For an unstructured DISU grid, the user must assign principal x and y axes and provide the angle for each cell face relative to the assigned x direction.  All included cells (IDOMAIN $>$ 0) must have a K22 value greater than zero."
+      "is the hydraulic conductivity of the second ellipsoid axis (or the ratio of K22/K if the K22OVERK option is specified); for an unrotated case this is the hydraulic conductivity in the y direction.  If K22 is not included in the GRIDDATA block, then K22 is set equal to K.  For a regular MODFLOW grid (DIS Package is used) in which no rotation angles are specified, K22 is the hydraulic conductivity along columns in the y direction. For an unstructured DISU grid, the user must assign principal x and y axes and provide the angle for each cell face relative to the assigned x direction.  All included cells (IDOMAIN $>$ 0) must have a K22 value greater than zero.": [
+        "gwf-npf"
+      ]
     },
     "period": {
-      "utl-tvk": "is the new value to be assigned as the cell's hydraulic conductivity of the second ellipsoid axis (or the ratio of K22/K if the K22OVERK NPF package option is specified) from the start of the specified stress period, as per K22 in the NPF package.  For an unrotated case this is the hydraulic conductivity in the y direction.  If the OPTIONS block includes a TS6 entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+      "is the new value to be assigned as the cell's hydraulic conductivity of the second ellipsoid axis (or the ratio of K22/K if the K22OVERK NPF package option is specified) from the start of the specified stress period, as per K22 in the NPF package.  For an unrotated case this is the hydraulic conductivity in the y direction.  If the OPTIONS block includes a TS6 entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+        "utl-tvk"
+      ]
     }
   },
   "k22overk": {
     "options": {
-      "gwf-npf": "keyword to indicate that specified K22 is a ratio of K22 divided by K.  If this option is specified, then the K22 array entered in the NPF Package will be multiplied by K after being read."
+      "keyword to indicate that specified K22 is a ratio of K22 divided by K.  If this option is specified, then the K22 array entered in the NPF Package will be multiplied by K after being read.": [
+        "gwf-npf"
+      ]
     }
   },
   "k33": {
     "griddata": {
-      "gwf-npf": "is the hydraulic conductivity of the third ellipsoid axis (or the ratio of K33/K if the K33OVERK option is specified); for an unrotated case, this is the vertical hydraulic conductivity.  When anisotropy is applied, K33 corresponds to the K33 tensor component.  All included cells (IDOMAIN $>$ 0) must have a K33 value greater than zero."
+      "is the hydraulic conductivity of the third ellipsoid axis (or the ratio of K33/K if the K33OVERK option is specified); for an unrotated case, this is the vertical hydraulic conductivity.  When anisotropy is applied, K33 corresponds to the K33 tensor component.  All included cells (IDOMAIN $>$ 0) must have a K33 value greater than zero.": [
+        "gwf-npf"
+      ]
     },
     "period": {
-      "utl-tvk": "is the new value to be assigned as the cell's hydraulic conductivity of the third ellipsoid axis (or the ratio of K33/K if the K33OVERK NPF package option is specified) from the start of the specified stress period, as per K33 in the NPF package.  For an unrotated case, this is the vertical hydraulic conductivity.  If the OPTIONS block includes a TS6 entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+      "is the new value to be assigned as the cell's hydraulic conductivity of the third ellipsoid axis (or the ratio of K33/K if the K33OVERK NPF package option is specified) from the start of the specified stress period, as per K33 in the NPF package.  For an unrotated case, this is the vertical hydraulic conductivity.  If the OPTIONS block includes a TS6 entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+        "utl-tvk"
+      ]
     }
   },
   "k33overk": {
     "options": {
-      "gwf-npf": "keyword to indicate that specified K33 is a ratio of K33 divided by K.  If this option is specified, then the K33 array entered in the NPF Package will be multiplied by K after being read."
+      "keyword to indicate that specified K33 is a ratio of K33 divided by K.  If this option is specified, then the K33 array entered in the NPF Package will be multiplied by K after being read.": [
+        "gwf-npf"
+      ]
     }
   },
   "kts": {
     "griddata": {
-      "gwe-cnd": "thermal conductivity of the solid aquifer material"
+      "thermal conductivity of the solid aquifer material": [
+        "gwe-cnd"
+      ]
     }
   },
   "ktw": {
     "griddata": {
-      "gwe-cnd": "thermal conductivity of the simulated fluid.   Note that the CND Package does not account for the tortuosity of the flow paths when solving for the conductive spread of heat.  If tortuosity plays an important role in the thermal conductivity calculation, its effect should be reflected in the value specified for KTW."
+      "thermal conductivity of the simulated fluid.   Note that the CND Package does not account for the tortuosity of the flow paths when solving for the conductive spread of heat.  If tortuosity plays an important role in the thermal conductivity calculation, its effect should be reflected in the value specified for KTW.": [
+        "gwe-cnd"
+      ]
     }
   },
   "last": {
     "period": {
-      "chf-oc": "keyword to indicate save for last step in period. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
-      "gwe-oc": "keyword to indicate save for last step in period. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
-      "gwf-oc": "keyword to indicate save for last step in period. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
-      "gwt-oc": "keyword to indicate save for last step in period. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
-      "olf-oc": "keyword to indicate save for last step in period. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
-      "prt-oc": "keyword to indicate save for last step in period. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
-      "prt-prp": "keyword to indicate release at the start of the last time step in the period. This keyword may be used in conjunction with other RELEASESETTING options.",
-      "swf-oc": "keyword to indicate save for last step in period. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps."
+      "keyword to indicate release at the start of the last time step in the period. This keyword may be used in conjunction with other RELEASESETTING options.": [
+        "prt-prp"
+      ],
+      "keyword to indicate save for last step in period. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.": [
+        "chf-oc",
+        "gwe-oc",
+        "gwf-oc",
+        "gwt-oc",
+        "olf-oc",
+        "prt-oc",
+        "swf-oc"
+      ]
     }
   },
   "latent_heat_vaporization": {
     "options": {
-      "gwe-est": "latent heat of vaporization is the amount of energy that is required to convert a given quantity of liquid into a gas and is associated with evaporative cooling.  While the EST package does not simulate evaporation, multiple other packages in a GWE simulation may.  To avoid having to specify the latent heat of vaporization in multiple packages, it is specified in a single location and accessed wherever it is needed.  For example, evaporation may occur from the surface of streams or lakes and the energy consumed by the change in phase would be needed in both the SFE and LKE packages.  This value is set to 2,453,500 J/kg if no overriding value is specified.  A user-specified value should be provided for models that use units other than joules and kilograms or if it is necessary to use a value other than the default."
+      "latent heat of vaporization is the amount of energy that is required to convert a given quantity of liquid into a gas and is associated with evaporative cooling.  While the EST package does not simulate evaporation, multiple other packages in a GWE simulation may.  To avoid having to specify the latent heat of vaporization in multiple packages, it is specified in a single location and accessed wherever it is needed.  For example, evaporation may occur from the surface of streams or lakes and the energy consumed by the change in phase would be needed in both the SFE and LKE packages.  This value is set to 2,453,500 J/kg if no overriding value is specified.  A user-specified value should be provided for models that use units other than joules and kilograms or if it is necessary to use a value other than the default.": [
+        "gwe-est"
+      ]
     }
   },
   "latitude": {
     "griddata": {
-      "utl-ncf": "cell center latitude."
+      "cell center latitude.": [
+        "utl-ncf"
+      ]
     }
   },
   "length": {
     "griddata": {
-      "olf-disv1d": "length for each one-dimensional cell"
+      "length for each one-dimensional cell": [
+        "olf-disv1d"
+      ]
     }
   },
   "length_conversion": {
     "options": {
-      "chf-dfw": "real value that is used to convert user-specified Manning's roughness coefficients from meters to model length units. LENGTH\\_CONVERSION should be set to 3.28081, 1.0, and 100.0 when using length units (LENGTH\\_UNITS) of feet, meters, or centimeters in the simulation, respectively. LENGTH\\_CONVERSION does not need to be specified if LENGTH\\_UNITS are meters.",
-      "gwf-lak": "real value that is used to convert outlet user-specified Manning's roughness coefficients or gravitational acceleration used to calculate outlet flows from meters to model length units. LENGTH\\_CONVERSION should be set to 3.28081, 1.0, and 100.0 when using length units (LENGTH\\_UNITS) of feet, meters, or centimeters in the simulation, respectively. LENGTH\\_CONVERSION does not need to be specified if no lake outlets are specified or LENGTH\\_UNITS are meters.",
-      "gwf-sfr": "real value that is used to convert user-specified Manning's roughness coefficients from meters to model length units. LENGTH\\_CONVERSION should be set to 3.28081, 1.0, and 100.0 when using length units (LENGTH\\_UNITS) of feet, meters, or centimeters in the simulation, respectively. LENGTH\\_CONVERSION does not need to be specified if LENGTH\\_UNITS are meters.",
-      "olf-dfw": "real value that is used to convert user-specified Manning's roughness coefficients from meters to model length units. LENGTH\\_CONVERSION should be set to 3.28081, 1.0, and 100.0 when using length units (LENGTH\\_UNITS) of feet, meters, or centimeters in the simulation, respectively. LENGTH\\_CONVERSION does not need to be specified if LENGTH\\_UNITS are meters.",
-      "swf-dfw": "real value that is used to convert user-specified Manning's roughness coefficients from meters to model length units. LENGTH\\_CONVERSION should be set to 3.28081, 1.0, and 100.0 when using length units (LENGTH\\_UNITS) of feet, meters, or centimeters in the simulation, respectively. LENGTH\\_CONVERSION does not need to be specified if LENGTH\\_UNITS are meters."
+      "real value that is used to convert outlet user-specified Manning's roughness coefficients or gravitational acceleration used to calculate outlet flows from meters to model length units. LENGTH\\_CONVERSION should be set to 3.28081, 1.0, and 100.0 when using length units (LENGTH\\_UNITS) of feet, meters, or centimeters in the simulation, respectively. LENGTH\\_CONVERSION does not need to be specified if no lake outlets are specified or LENGTH\\_UNITS are meters.": [
+        "gwf-lak"
+      ],
+      "real value that is used to convert user-specified Manning's roughness coefficients from meters to model length units. LENGTH\\_CONVERSION should be set to 3.28081, 1.0, and 100.0 when using length units (LENGTH\\_UNITS) of feet, meters, or centimeters in the simulation, respectively. LENGTH\\_CONVERSION does not need to be specified if LENGTH\\_UNITS are meters.": [
+        "chf-dfw",
+        "gwf-sfr",
+        "olf-dfw",
+        "swf-dfw"
+      ]
     }
   },
   "length_units": {
     "options": {
-      "chf-disv1d": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.",
-      "gwe-dis": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.",
-      "gwe-disu": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.",
-      "gwe-disv": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.",
-      "gwf-dis": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.",
-      "gwf-disu": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.",
-      "gwf-disv": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.",
-      "gwt-dis": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.",
-      "gwt-disu": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.",
-      "gwt-disv": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.",
-      "olf-dis2d": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.",
-      "olf-disv1d": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.",
-      "olf-disv2d": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.",
-      "prt-dis": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.",
-      "prt-disv": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.",
-      "swf-dis2d": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.",
-      "swf-disv1d": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.",
-      "swf-disv2d": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''."
+      "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.": [
+        "chf-disv1d",
+        "gwe-dis",
+        "gwe-disu",
+        "gwe-disv",
+        "gwf-dis",
+        "gwf-disu",
+        "gwf-disv",
+        "gwt-dis",
+        "gwt-disu",
+        "gwt-disv",
+        "olf-dis2d",
+        "olf-disv1d",
+        "olf-disv2d",
+        "prt-dis",
+        "prt-disv",
+        "swf-dis2d",
+        "swf-disv1d",
+        "swf-disv2d"
+      ]
     }
   },
   "linear_acceleration": {
     "linear": {
-      "sln-ims": "a keyword that defines the linear acceleration method used by the default IMS linear solvers.  CG - preconditioned conjugate gradient method.  BICGSTAB - preconditioned bi-conjugate gradient stabilized method."
+      "a keyword that defines the linear acceleration method used by the default IMS linear solvers.  CG - preconditioned conjugate gradient method.  BICGSTAB - preconditioned bi-conjugate gradient stabilized method.": [
+        "sln-ims"
+      ]
     }
   },
   "linear_gwet": {
     "options": {
-      "gwf-uzf": "keyword specifying that groundwater ET will be simulated using the original ET formulation of MODFLOW-2005."
+      "keyword specifying that groundwater ET will be simulated using the original ET formulation of MODFLOW-2005.": [
+        "gwf-uzf"
+      ]
     }
   },
   "list": {
     "options": {
-      "chf-nam": "is name of the listing file to create for this CHF model.  If not specified, then the name of the list file will be the basename of the CHF model name file and the '.lst' extension.  For example, if the CHF name file is called ``my.model.nam'' then the list file will be called ``my.model.lst''.",
-      "gwe-nam": "is name of the listing file to create for this GWE model.  If not specified, then the name of the list file will be the basename of the GWE model name file and the ``.lst'' extension.  For example, if the GWE name file is called ``my.model.nam'' then the list file will be called ``my.model.lst''.",
-      "gwf-nam": "is name of the listing file to create for this GWF model.  If not specified, then the name of the list file will be the basename of the GWF model name file and the '.lst' extension.  For example, if the GWF name file is called ``my.model.nam'' then the list file will be called ``my.model.lst''.",
-      "gwt-nam": "is name of the listing file to create for this GWT model.  If not specified, then the name of the list file will be the basename of the GWT model name file and the '.lst' extension.  For example, if the GWT name file is called ``my.model.nam'' then the list file will be called ``my.model.lst''.",
-      "olf-nam": "is name of the listing file to create for this OLF model.  If not specified, then the name of the list file will be the basename of the OLF model name file and the '.lst' extension.  For example, if the OLF name file is called ``my.model.nam'' then the list file will be called ``my.model.lst''.",
-      "prt-nam": "is name of the listing file to create for this PRT model.  If not specified, then the name of the list file will be the basename of the PRT model name file and the '.lst' extension.  For example, if the PRT name file is called ``my.model.nam'' then the list file will be called ``my.model.lst''.",
-      "swf-nam": "is name of the listing file to create for this SWF model.  If not specified, then the name of the list file will be the basename of the SWF model name file and the '.lst' extension.  For example, if the SWF name file is called ``my.model.nam'' then the list file will be called ``my.model.lst''."
+      "is name of the listing file to create for this CHF model.  If not specified, then the name of the list file will be the basename of the CHF model name file and the '.lst' extension.  For example, if the CHF name file is called ``my.model.nam'' then the list file will be called ``my.model.lst''.": [
+        "chf-nam"
+      ],
+      "is name of the listing file to create for this GWE model.  If not specified, then the name of the list file will be the basename of the GWE model name file and the ``.lst'' extension.  For example, if the GWE name file is called ``my.model.nam'' then the list file will be called ``my.model.lst''.": [
+        "gwe-nam"
+      ],
+      "is name of the listing file to create for this GWF model.  If not specified, then the name of the list file will be the basename of the GWF model name file and the '.lst' extension.  For example, if the GWF name file is called ``my.model.nam'' then the list file will be called ``my.model.lst''.": [
+        "gwf-nam"
+      ],
+      "is name of the listing file to create for this GWT model.  If not specified, then the name of the list file will be the basename of the GWT model name file and the '.lst' extension.  For example, if the GWT name file is called ``my.model.nam'' then the list file will be called ``my.model.lst''.": [
+        "gwt-nam"
+      ],
+      "is name of the listing file to create for this OLF model.  If not specified, then the name of the list file will be the basename of the OLF model name file and the '.lst' extension.  For example, if the OLF name file is called ``my.model.nam'' then the list file will be called ``my.model.lst''.": [
+        "olf-nam"
+      ],
+      "is name of the listing file to create for this PRT model.  If not specified, then the name of the list file will be the basename of the PRT model name file and the '.lst' extension.  For example, if the PRT name file is called ``my.model.nam'' then the list file will be called ``my.model.lst''.": [
+        "prt-nam"
+      ],
+      "is name of the listing file to create for this SWF model.  If not specified, then the name of the list file will be the basename of the SWF model name file and the '.lst' extension.  For example, if the SWF name file is called ``my.model.nam'' then the list file will be called ``my.model.lst''.": [
+        "swf-nam"
+      ]
     }
   },
   "local_z": {
     "options": {
-      "prt-prp": "indicates that ``zrpt'' defines the local z coordinate of the release point within the cell, with value of 0 at the bottom and 1 at the top of the cell.  If the cell is partially saturated at release time, the top of the cell is considered to be the water table elevation (the head in the cell) rather than the top defined by the user."
+      "indicates that ``zrpt'' defines the local z coordinate of the release point within the cell, with value of 0 at the bottom and 1 at the top of the cell.  If the cell is partially saturated at release time, the top of the cell is considered to be the water table elevation (the head in the cell) rather than the top defined by the user.": [
+        "prt-prp"
+      ]
     }
   },
   "longitude": {
     "griddata": {
-      "utl-ncf": "cell center longitude."
+      "cell center longitude.": [
+        "utl-ncf"
+      ]
     }
   },
   "manning": {
     "period": {
-      "gwf-sfr": "real or character value that defines the Manning's roughness coefficient for the reach. MANNING must be greater than zero.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+      "real or character value that defines the Manning's roughness coefficient for the reach. MANNING must be greater than zero.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+        "gwf-sfr"
+      ]
     }
   },
   "manningsn": {
     "griddata": {
-      "chf-dfw": "mannings roughness coefficient",
-      "olf-dfw": "mannings roughness coefficient",
-      "swf-dfw": "mannings roughness coefficient"
+      "mannings roughness coefficient": [
+        "chf-dfw",
+        "olf-dfw",
+        "swf-dfw"
+      ]
     }
   },
   "maw_flow_reduce_csv": {
     "options": {
-      "gwf-maw": "keyword to specify that record corresponds to the output option in which a new record is written for each multi-aquifer well and for each time step in which the user-requested extraction or injection rate is reduced by the program."
+      "keyword to specify that record corresponds to the output option in which a new record is written for each multi-aquifer well and for each time step in which the user-requested extraction or injection rate is reduced by the program.": [
+        "gwf-maw"
+      ]
     }
   },
   "maxats": {
     "dimensions": {
-      "utl-ats": "is the number of records in the subsequent perioddata block that will be used for adaptive time stepping."
+      "is the number of records in the subsequent perioddata block that will be used for adaptive time stepping.": [
+        "utl-ats"
+      ]
     }
   },
   "maxbound": {
     "dimensions": {
-      "chf-cdb": "integer value specifying the maximum number of critical depth boundary cells that will be specified for use during any stress period.",
-      "chf-chd": "integer value specifying the maximum number of constant-head cells that will be specified for use during any stress period.",
-      "chf-evp": "integer value specifying the maximum number of evaporation cells cells that will be specified for use during any stress period.",
-      "chf-flw": "integer value specifying the maximum number of inflow cells that will be specified for use during any stress period.",
-      "chf-pcp": "integer value specifying the maximum number of precipitation cells cells that will be specified for use during any stress period.",
-      "chf-zdg": "integer value specifying the maximum number of zero-depth-gradient boundary cells that will be specified for use during any stress period.",
-      "gwe-ctp": "integer value specifying the maximum number of constant temperature cells that will be specified for use during any stress period.",
-      "gwe-esl": "integer value specifying the maximum number of source cells that will be specified for use during any stress period.",
-      "gwf-api": "integer value specifying the maximum number of api boundary cells that will be specified for use during any stress period.",
-      "gwf-chd": "integer value specifying the maximum number of constant-head cells that will be specified for use during any stress period.",
-      "gwf-drn": "integer value specifying the maximum number of drains cells that will be specified for use during any stress period.",
-      "gwf-evt": "integer value specifying the maximum number of evapotranspiration cells cells that will be specified for use during any stress period.",
-      "gwf-ghb": "integer value specifying the maximum number of general-head boundary cells that will be specified for use during any stress period.",
-      "gwf-rch": "integer value specifying the maximum number of recharge cells cells that will be specified for use during any stress period.",
-      "gwf-riv": "integer value specifying the maximum number of rivers cells that will be specified for use during any stress period.",
-      "gwf-wel": "integer value specifying the maximum number of wells cells that will be specified for use during any stress period.",
-      "gwt-api": "integer value specifying the maximum number of api boundary cells that will be specified for use during any stress period.",
-      "gwt-cnc": "integer value specifying the maximum number of constant concentrations cells that will be specified for use during any stress period.",
-      "gwt-src": "integer value specifying the maximum number of sources cells that will be specified for use during any stress period.",
-      "olf-cdb": "integer value specifying the maximum number of critical depth boundary cells that will be specified for use during any stress period.",
-      "olf-chd": "integer value specifying the maximum number of constant-head cells that will be specified for use during any stress period.",
-      "olf-evp": "integer value specifying the maximum number of evaporation cells cells that will be specified for use during any stress period.",
-      "olf-flw": "integer value specifying the maximum number of inflow cells that will be specified for use during any stress period.",
-      "olf-pcp": "integer value specifying the maximum number of precipitation cells cells that will be specified for use during any stress period.",
-      "olf-zdg": "integer value specifying the maximum number of zero-depth-gradient boundary cells that will be specified for use during any stress period.",
-      "swf-cdb": "integer value specifying the maximum number of critical depth boundary cells that will be specified for use during any stress period.",
-      "swf-chd": "integer value specifying the maximum number of constant-head cells that will be specified for use during any stress period.",
-      "swf-evp": "integer value specifying the maximum number of evaporation cells cells that will be specified for use during any stress period.",
-      "swf-flw": "integer value specifying the maximum number of inflow cells that will be specified for use during any stress period.",
-      "swf-pcp": "integer value specifying the maximum number of precipitation cells cells that will be specified for use during any stress period.",
-      "swf-zdg": "integer value specifying the maximum number of zero-depth-gradient boundary cells that will be specified for use during any stress period.",
-      "utl-spc": "integer value specifying the maximum number of spc cells that will be specified for use during any stress period."
+      "integer value specifying the maximum number of api boundary cells that will be specified for use during any stress period.": [
+        "gwf-api",
+        "gwt-api"
+      ],
+      "integer value specifying the maximum number of constant concentrations cells that will be specified for use during any stress period.": [
+        "gwt-cnc"
+      ],
+      "integer value specifying the maximum number of constant temperature cells that will be specified for use during any stress period.": [
+        "gwe-ctp"
+      ],
+      "integer value specifying the maximum number of constant-head cells that will be specified for use during any stress period.": [
+        "chf-chd",
+        "gwf-chd",
+        "olf-chd",
+        "swf-chd"
+      ],
+      "integer value specifying the maximum number of critical depth boundary cells that will be specified for use during any stress period.": [
+        "chf-cdb",
+        "olf-cdb",
+        "swf-cdb"
+      ],
+      "integer value specifying the maximum number of drains cells that will be specified for use during any stress period.": [
+        "gwf-drn"
+      ],
+      "integer value specifying the maximum number of evaporation cells cells that will be specified for use during any stress period.": [
+        "chf-evp",
+        "olf-evp",
+        "swf-evp"
+      ],
+      "integer value specifying the maximum number of evapotranspiration cells cells that will be specified for use during any stress period.": [
+        "gwf-evt"
+      ],
+      "integer value specifying the maximum number of general-head boundary cells that will be specified for use during any stress period.": [
+        "gwf-ghb"
+      ],
+      "integer value specifying the maximum number of inflow cells that will be specified for use during any stress period.": [
+        "chf-flw",
+        "olf-flw",
+        "swf-flw"
+      ],
+      "integer value specifying the maximum number of precipitation cells cells that will be specified for use during any stress period.": [
+        "chf-pcp",
+        "olf-pcp",
+        "swf-pcp"
+      ],
+      "integer value specifying the maximum number of recharge cells cells that will be specified for use during any stress period.": [
+        "gwf-rch"
+      ],
+      "integer value specifying the maximum number of rivers cells that will be specified for use during any stress period.": [
+        "gwf-riv"
+      ],
+      "integer value specifying the maximum number of source cells that will be specified for use during any stress period.": [
+        "gwe-esl"
+      ],
+      "integer value specifying the maximum number of sources cells that will be specified for use during any stress period.": [
+        "gwt-src"
+      ],
+      "integer value specifying the maximum number of spc cells that will be specified for use during any stress period.": [
+        "utl-spc"
+      ],
+      "integer value specifying the maximum number of wells cells that will be specified for use during any stress period.": [
+        "gwf-wel"
+      ],
+      "integer value specifying the maximum number of zero-depth-gradient boundary cells that will be specified for use during any stress period.": [
+        "chf-zdg",
+        "olf-zdg",
+        "swf-zdg"
+      ]
     }
   },
   "maxerrors": {
     "options": {
-      "sim-nam": "maximum number of errors that will be stored and printed."
+      "maximum number of errors that will be stored and printed.": [
+        "sim-nam"
+      ]
     }
   },
   "maxhfb": {
     "dimensions": {
-      "gwf-hfb": "integer value specifying the maximum number of horizontal flow barriers that will be entered in this input file.  The value of MAXHFB is used to allocate memory for the horizontal flow barriers."
+      "integer value specifying the maximum number of horizontal flow barriers that will be entered in this input file.  The value of MAXHFB is used to allocate memory for the horizontal flow barriers.": [
+        "gwf-hfb"
+      ]
     }
   },
   "maximum_depth_change": {
     "options": {
-      "gwf-sfr": "real value that defines the depth closure tolerance. By default, MAXIMUM\\_DEPTH\\_CHANGE is equal to $1 \\times 10^{-5}$. The MAXIMUM\\_STAGE\\_CHANGE would only need to be increased or decreased from the default value if the water budget error for one or more reach is too small or too large, respectively."
+      "real value that defines the depth closure tolerance. By default, MAXIMUM\\_DEPTH\\_CHANGE is equal to $1 \\times 10^{-5}$. The MAXIMUM\\_STAGE\\_CHANGE would only need to be increased or decreased from the default value if the water budget error for one or more reach is too small or too large, respectively.": [
+        "gwf-sfr"
+      ]
     }
   },
   "maximum_iterations": {
     "options": {
-      "gwf-lak": "integer value that defines the maximum number of Newton-Raphson iterations allowed for a lake. By default, MAXIMUM\\_ITERATIONS is equal to 100. MAXIMUM\\_ITERATIONS would only need to be increased from the default value if one or more lakes in a simulation has a large water budget error.",
-      "gwf-sfr": "integer value that defines the maximum number of Streamflow Routing Newton-Raphson iterations allowed for a reach. By default, MAXIMUM\\_ITERATIONS is equal to 100. MAXIMUM\\_ITERATIONS would only need to be increased from the default value if one or more reach in a simulation has a large water budget error."
+      "integer value that defines the maximum number of Newton-Raphson iterations allowed for a lake. By default, MAXIMUM\\_ITERATIONS is equal to 100. MAXIMUM\\_ITERATIONS would only need to be increased from the default value if one or more lakes in a simulation has a large water budget error.": [
+        "gwf-lak"
+      ],
+      "integer value that defines the maximum number of Streamflow Routing Newton-Raphson iterations allowed for a reach. By default, MAXIMUM\\_ITERATIONS is equal to 100. MAXIMUM\\_ITERATIONS would only need to be increased from the default value if one or more reach in a simulation has a large water budget error.": [
+        "gwf-sfr"
+      ]
     }
   },
   "maximum_picard_iterations": {
     "options": {
-      "gwf-sfr": "integer value that defines the maximum number of Streamflow Routing picard iterations allowed when solving for reach stages and flows as part of the GWF formulate step. Picard iterations are used to minimize differences in SFR package results between subsequent GWF picard (non-linear) iterations as a result of non-optimal reach numbering. If reaches are numbered in order, from upstream to downstream, MAXIMUM\\_PICARD\\_ITERATIONS can be set to 1 to reduce model run time. By default, MAXIMUM\\_PICARD\\_ITERATIONS is equal to 100."
+      "integer value that defines the maximum number of Streamflow Routing picard iterations allowed when solving for reach stages and flows as part of the GWF formulate step. Picard iterations are used to minimize differences in SFR package results between subsequent GWF picard (non-linear) iterations as a result of non-optimal reach numbering. If reaches are numbered in order, from upstream to downstream, MAXIMUM\\_PICARD\\_ITERATIONS can be set to 1 to reduce model run time. By default, MAXIMUM\\_PICARD\\_ITERATIONS is equal to 100.": [
+        "gwf-sfr"
+      ]
     }
   },
   "maximum_stage_change": {
     "options": {
-      "gwf-lak": "real value that defines the lake stage closure tolerance. By default, MAXIMUM\\_STAGE\\_CHANGE is equal to $1 \\times 10^{-5}$. The MAXIMUM\\_STAGE\\_CHANGE would only need to be increased or decreased from the default value if the water budget error for one or more lakes is too small or too large, respectively."
+      "real value that defines the lake stage closure tolerance. By default, MAXIMUM\\_STAGE\\_CHANGE is equal to $1 \\times 10^{-5}$. The MAXIMUM\\_STAGE\\_CHANGE would only need to be increased or decreased from the default value if the water budget error for one or more lakes is too small or too large, respectively.": [
+        "gwf-lak"
+      ]
     }
   },
   "maxmvr": {
     "dimensions": {
-      "gwf-mvr": "integer value specifying the maximum number of water mover entries that will specified for any stress period."
+      "integer value specifying the maximum number of water mover entries that will specified for any stress period.": [
+        "gwf-mvr"
+      ]
     }
   },
   "maxpackages": {
     "dimensions": {
-      "gwf-mvr": "integer value specifying the number of unique packages that are included in this water mover input file."
+      "integer value specifying the number of unique packages that are included in this water mover input file.": [
+        "gwf-mvr"
+      ]
     }
   },
   "maxsig0": {
     "dimensions": {
-      "gwf-csub": "is the maximum number of cells that can have a specified stress offset.  More than 1 stress offset can be assigned to a GWF cell. By default, MAXSIG0 is 0."
+      "is the maximum number of cells that can have a specified stress offset.  More than 1 stress offset can be assigned to a GWF cell. By default, MAXSIG0 is 0.": [
+        "gwf-csub"
+      ]
     }
   },
   "memory_print_option": {
     "options": {
-      "sim-nam": "is a flag that controls printing of detailed memory manager usage to the end of the simulation list file.  NONE means do not print detailed information. SUMMARY means print only the total memory for each simulation component. ALL means print information for each variable stored in the memory manager. NONE is default if MEMORY\\_PRINT\\_OPTION is not specified."
+      "is a flag that controls printing of detailed memory manager usage to the end of the simulation list file.  NONE means do not print detailed information. SUMMARY means print only the total memory for each simulation component. ALL means print information for each variable stored in the memory manager. NONE is default if MEMORY\\_PRINT\\_OPTION is not specified.": [
+        "sim-nam"
+      ]
     }
   },
   "method": {
     "attributes": {
-      "utl-tas": "xxx",
-      "utl-ts": "xxx"
+      "xxx": [
+        "utl-tas",
+        "utl-ts"
+      ]
     }
   },
   "methods": {
     "attributes": {
-      "utl-ts": "xxx"
+      "xxx": [
+        "utl-ts"
+      ]
     }
   },
   "mixed": {
     "fileinput": {
-      "gwe-ssm": "keyword to specify that these stress package boundaries will have the mixed condition.  The MIXED condition is described in the SOURCES block for AUXMIXED.  The MIXED condition allows for water to be withdrawn at a temperature that is less than the cell temperature.  It is intended primarily for representing evapotranspiration.",
-      "gwt-ssm": "keyword to specify that these stress package boundaries will have the mixed condition.  The MIXED condition is described in the SOURCES block for AUXMIXED.  The MIXED condition allows for water to be withdrawn at a concentration that is less than the cell concentration.  It is intended primarily for representing evapotranspiration."
+      "keyword to specify that these stress package boundaries will have the mixed condition.  The MIXED condition is described in the SOURCES block for AUXMIXED.  The MIXED condition allows for water to be withdrawn at a concentration that is less than the cell concentration.  It is intended primarily for representing evapotranspiration.": [
+        "gwt-ssm"
+      ],
+      "keyword to specify that these stress package boundaries will have the mixed condition.  The MIXED condition is described in the SOURCES block for AUXMIXED.  The MIXED condition allows for water to be withdrawn at a temperature that is less than the cell temperature.  It is intended primarily for representing evapotranspiration.": [
+        "gwe-ssm"
+      ]
     }
   },
   "modelnames": {
     "options": {
-      "gwf-mvr": "keyword to indicate that all package names will be preceded by the model name for the package.  Model names are required when the Mover Package is used with a GWF-GWF Exchange.  The MODELNAME keyword should not be used for a Mover Package that is for a single GWF Model."
+      "keyword to indicate that all package names will be preceded by the model name for the package.  Model names are required when the Mover Package is used with a GWF-GWF Exchange.  The MODELNAME keyword should not be used for a Mover Package that is for a single GWF Model.": [
+        "gwf-mvr"
+      ]
     }
   },
   "models": {
     "models": {
-      "sim-nam": "is the list of model types, model name files, and model names."
+      "is the list of model types, model name files, and model names.": [
+        "sim-nam"
+      ]
     }
   },
   "modflow6_attr_off": {
     "options": {
-      "utl-ncf": "is the keyword used to turn off internal input tagging in the model netcdf file. Tagging adds internal modflow 6 attribute(s) to variables which facilitate identification. Currently this applies to gridded arrays."
+      "is the keyword used to turn off internal input tagging in the model netcdf file. Tagging adds internal modflow 6 attribute(s) to variables which facilitate identification. Currently this applies to gridded arrays.": [
+        "utl-ncf"
+      ]
     }
   },
   "mover": {
     "options": {
-      "gwf-api": "keyword to indicate that this instance of the api boundary Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.",
-      "gwf-drn": "keyword to indicate that this instance of the Drain Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.",
-      "gwf-ghb": "keyword to indicate that this instance of the General-Head Boundary Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.",
-      "gwf-lak": "keyword to indicate that this instance of the LAK Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.",
-      "gwf-maw": "keyword to indicate that this instance of the MAW Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.",
-      "gwf-riv": "keyword to indicate that this instance of the River Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.",
-      "gwf-sfr": "keyword to indicate that this instance of the SFR Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.",
-      "gwf-uzf": "keyword to indicate that this instance of the UZF Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.",
-      "gwf-wel": "keyword to indicate that this instance of the Well Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.",
-      "gwt-api": "keyword to indicate that this instance of the api boundary Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water."
+      "keyword to indicate that this instance of the Drain Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.": [
+        "gwf-drn"
+      ],
+      "keyword to indicate that this instance of the General-Head Boundary Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.": [
+        "gwf-ghb"
+      ],
+      "keyword to indicate that this instance of the LAK Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.": [
+        "gwf-lak"
+      ],
+      "keyword to indicate that this instance of the MAW Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.": [
+        "gwf-maw"
+      ],
+      "keyword to indicate that this instance of the River Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.": [
+        "gwf-riv"
+      ],
+      "keyword to indicate that this instance of the SFR Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.": [
+        "gwf-sfr"
+      ],
+      "keyword to indicate that this instance of the UZF Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.": [
+        "gwf-uzf"
+      ],
+      "keyword to indicate that this instance of the Well Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.": [
+        "gwf-wel"
+      ],
+      "keyword to indicate that this instance of the api boundary Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.": [
+        "gwf-api",
+        "gwt-api"
+      ]
     }
   },
   "mve6": {
     "options": {
-      "exg-gwegwe": "keyword to specify that record corresponds to an energy transport mover file."
+      "keyword to specify that record corresponds to an energy transport mover file.": [
+        "exg-gwegwe"
+      ]
     }
   },
   "mvr6": {
     "options": {
-      "exg-gwfgwf": "keyword to specify that record corresponds to a mover file."
+      "keyword to specify that record corresponds to a mover file.": [
+        "exg-gwfgwf"
+      ]
     }
   },
   "mvt6": {
     "options": {
-      "exg-gwtgwt": "keyword to specify that record corresponds to a transport mover file."
+      "keyword to specify that record corresponds to a transport mover file.": [
+        "exg-gwtgwt"
+      ]
     }
   },
   "mxiter": {
     "solutiongroup": {
-      "sim-nam": "is the maximum number of outer iterations for this solution group.  The default value is 1.  If there is only one solution in the solution group, then MXITER must be 1."
+      "is the maximum number of outer iterations for this solution group.  The default value is 1.  If there is only one solution in the solution group, then MXITER must be 1.": [
+        "sim-nam"
+      ]
     }
   },
   "name": {
     "attributes": {
-      "utl-tas": "xxx"
+      "xxx": [
+        "utl-tas"
+      ]
     }
   },
   "names": {
     "attributes": {
-      "utl-ts": "xxx"
+      "xxx": [
+        "utl-ts"
+      ]
     }
   },
   "ncf6": {
     "options": {
-      "gwe-dis": "keyword to specify that record corresponds to a netcdf configuration (NCF) file.",
-      "gwe-disv": "keyword to specify that record corresponds to a netcdf configuration (NCF) file.",
-      "gwf-dis": "keyword to specify that record corresponds to a netcdf configuration (NCF) file.",
-      "gwf-disv": "keyword to specify that record corresponds to a netcdf configuration (NCF) file.",
-      "gwt-dis": "keyword to specify that record corresponds to a netcdf configuration (NCF) file.",
-      "gwt-disv": "keyword to specify that record corresponds to a netcdf configuration (NCF) file.",
-      "prt-dis": "keyword to specify that record corresponds to a netcdf configuration (NCF) file.",
-      "prt-disv": "keyword to specify that record corresponds to a netcdf configuration (NCF) file."
+      "keyword to specify that record corresponds to a netcdf configuration (NCF) file.": [
+        "gwe-dis",
+        "gwe-disv",
+        "gwf-dis",
+        "gwf-disv",
+        "gwt-dis",
+        "gwt-disv",
+        "prt-dis",
+        "prt-disv"
+      ]
     }
   },
   "ncol": {
     "dimensions": {
-      "gwe-dis": "is the number of columns in the model grid.",
-      "gwf-dis": "is the number of columns in the model grid.",
-      "gwt-dis": "is the number of columns in the model grid.",
-      "olf-dis2d": "is the number of columns in the model grid.",
-      "prt-dis": "is the number of columns in the model grid.",
-      "swf-dis2d": "is the number of columns in the model grid.",
-      "utl-laktab": "integer value specifying the number of columns in the lake table. There must be NCOL columns of data in the TABLE block. For lakes with HORIZONTAL and/or VERTICAL CTYPE connections, NCOL must be equal to 3. For lakes with EMBEDDEDH or EMBEDDEDV CTYPE connections, NCOL must be equal to 4.",
-      "utl-sfrtab": "integer value specifying the number of columns in the reach cross-section table. There must be NCOL columns of data in the TABLE block. NCOL must be equal to 2 if MANFRACTION is not specified or 3 otherwise."
+      "integer value specifying the number of columns in the lake table. There must be NCOL columns of data in the TABLE block. For lakes with HORIZONTAL and/or VERTICAL CTYPE connections, NCOL must be equal to 3. For lakes with EMBEDDEDH or EMBEDDEDV CTYPE connections, NCOL must be equal to 4.": [
+        "utl-laktab"
+      ],
+      "integer value specifying the number of columns in the reach cross-section table. There must be NCOL columns of data in the TABLE block. NCOL must be equal to 2 if MANFRACTION is not specified or 3 otherwise.": [
+        "utl-sfrtab"
+      ],
+      "is the number of columns in the model grid.": [
+        "gwe-dis",
+        "gwf-dis",
+        "gwt-dis",
+        "olf-dis2d",
+        "prt-dis",
+        "swf-dis2d"
+      ]
     }
   },
   "ncpl": {
     "dimensions": {
-      "gwe-disv": "is the number of cells per layer.  This is a constant value for the grid and it applies to all layers.",
-      "gwf-disv": "is the number of cells per layer.  This is a constant value for the grid and it applies to all layers.",
-      "gwt-disv": "is the number of cells per layer.  This is a constant value for the grid and it applies to all layers.",
-      "prt-disv": "is the number of cells per layer.  This is a constant value for the grid and it applies to all layers.",
-      "utl-ncf": "is the number of cells in a projected plane layer."
+      "is the number of cells in a projected plane layer.": [
+        "utl-ncf"
+      ],
+      "is the number of cells per layer.  This is a constant value for the grid and it applies to all layers.": [
+        "gwe-disv",
+        "gwf-disv",
+        "gwt-disv",
+        "prt-disv"
+      ]
     }
   },
   "ndelaycells": {
     "options": {
-      "gwf-csub": "number of nodes used to discretize delay interbeds. If not specified, then a default value of 19 is assigned."
+      "number of nodes used to discretize delay interbeds. If not specified, then a default value of 19 is assigned.": [
+        "gwf-csub"
+      ]
     }
   },
   "netcdf": {
     "options": {
-      "gwe-nam": "keyword to specify that record corresponds to a netcdf input file.",
-      "gwf-nam": "keyword to specify that record corresponds to a netcdf input file.",
-      "gwt-nam": "keyword to specify that record corresponds to a netcdf input file."
+      "keyword to specify that record corresponds to a netcdf input file.": [
+        "gwe-nam",
+        "gwf-nam",
+        "gwt-nam"
+      ]
     }
   },
   "netcdf_mesh2d": {
     "options": {
-      "gwe-nam": "keyword to specify that record corresponds to a layered mesh netcdf file.",
-      "gwf-nam": "keyword to specify that record corresponds to a layered mesh netcdf file. ",
-      "gwt-nam": "keyword to specify that record corresponds to a layered mesh netcdf file."
+      "keyword to specify that record corresponds to a layered mesh netcdf file.": [
+        "gwe-nam",
+        "gwt-nam"
+      ],
+      "keyword to specify that record corresponds to a layered mesh netcdf file. ": [
+        "gwf-nam"
+      ]
     }
   },
   "netcdf_structured": {
     "options": {
-      "gwe-nam": "keyword to specify that record corresponds to a structured netcdf file.",
-      "gwf-nam": "keyword to specify that record corresponds to a structured netcdf file.",
-      "gwt-nam": "keyword to specify that record corresponds to a structured netcdf file."
+      "keyword to specify that record corresponds to a structured netcdf file.": [
+        "gwe-nam",
+        "gwf-nam",
+        "gwt-nam"
+      ]
     }
   },
   "newton": {
     "options": {
-      "chf-nam": "keyword that activates the Newton-Raphson formulation for surface water flow between connected reaches and stress packages that support calculation of Newton-Raphson terms. ",
-      "exg-gwfgwf": "keyword that activates the Newton-Raphson formulation for groundwater flow between connected, convertible groundwater cells. Cells will not dry when this option is used.",
-      "gwf-nam": "keyword that activates the Newton-Raphson formulation for groundwater flow between connected, convertible groundwater cells and stress packages that support calculation of Newton-Raphson terms for groundwater exchanges. Cells will not dry when this option is used. By default, the Newton-Raphson formulation is not applied.",
-      "olf-nam": "keyword that activates the Newton-Raphson formulation for surface water flow between connected reaches and stress packages that support calculation of Newton-Raphson terms. ",
-      "swf-nam": "keyword that activates the Newton-Raphson formulation for surface water flow between connected reaches and stress packages that support calculation of Newton-Raphson terms. "
+      "keyword that activates the Newton-Raphson formulation for groundwater flow between connected, convertible groundwater cells and stress packages that support calculation of Newton-Raphson terms for groundwater exchanges. Cells will not dry when this option is used. By default, the Newton-Raphson formulation is not applied.": [
+        "gwf-nam"
+      ],
+      "keyword that activates the Newton-Raphson formulation for groundwater flow between connected, convertible groundwater cells. Cells will not dry when this option is used.": [
+        "exg-gwfgwf"
+      ],
+      "keyword that activates the Newton-Raphson formulation for surface water flow between connected reaches and stress packages that support calculation of Newton-Raphson terms. ": [
+        "chf-nam",
+        "olf-nam",
+        "swf-nam"
+      ]
     }
   },
   "newtonoptions": {
     "options": {
-      "chf-nam": "none",
-      "gwf-nam": "none",
-      "olf-nam": "none",
-      "swf-nam": "none"
+      "none": [
+        "chf-nam",
+        "gwf-nam",
+        "olf-nam",
+        "swf-nam"
+      ]
     }
   },
   "nexg": {
     "dimensions": {
-      "exg-chfgwf": "keyword and integer value specifying the number of SWF-GWF exchanges.",
-      "exg-gwegwe": "keyword and integer value specifying the number of GWE-GWE exchanges.",
-      "exg-gwfgwf": "keyword and integer value specifying the number of GWF-GWF exchanges.",
-      "exg-gwtgwt": "keyword and integer value specifying the number of GWT-GWT exchanges.",
-      "exg-olfgwf": "keyword and integer value specifying the number of SWF-GWF exchanges."
+      "keyword and integer value specifying the number of GWE-GWE exchanges.": [
+        "exg-gwegwe"
+      ],
+      "keyword and integer value specifying the number of GWF-GWF exchanges.": [
+        "exg-gwfgwf"
+      ],
+      "keyword and integer value specifying the number of GWT-GWT exchanges.": [
+        "exg-gwtgwt"
+      ],
+      "keyword and integer value specifying the number of SWF-GWF exchanges.": [
+        "exg-chfgwf",
+        "exg-olfgwf"
+      ]
     }
   },
   "ninterbeds": {
     "dimensions": {
-      "gwf-csub": "is the number of CSUB interbed systems.  More than 1 CSUB interbed systems can be assigned to a GWF cell; however, only 1 GWF cell can be assigned to a single CSUB interbed system."
+      "is the number of CSUB interbed systems.  More than 1 CSUB interbed systems can be assigned to a GWF cell; however, only 1 GWF cell can be assigned to a single CSUB interbed system.": [
+        "gwf-csub"
+      ]
     }
   },
   "nja": {
     "dimensions": {
-      "gwe-disu": "is the sum of the number of connections and NODES.  When calculating the total number of connections, the connection between cell n and cell m is considered to be different from the connection between cell m and cell n.  Thus, NJA is equal to the total number of connections, including n to m and m to n, and the total number of cells.",
-      "gwf-disu": "is the sum of the number of connections and NODES.  When calculating the total number of connections, the connection between cell n and cell m is considered to be different from the connection between cell m and cell n.  Thus, NJA is equal to the total number of connections, including n to m and m to n, and the total number of cells.",
-      "gwt-disu": "is the sum of the number of connections and NODES.  When calculating the total number of connections, the connection between cell n and cell m is considered to be different from the connection between cell m and cell n.  Thus, NJA is equal to the total number of connections, including n to m and m to n, and the total number of cells."
+      "is the sum of the number of connections and NODES.  When calculating the total number of connections, the connection between cell n and cell m is considered to be different from the connection between cell m and cell n.  Thus, NJA is equal to the total number of connections, including n to m and m to n, and the total number of cells.": [
+        "gwe-disu",
+        "gwf-disu",
+        "gwt-disu"
+      ]
     }
   },
   "nlakes": {
     "dimensions": {
-      "gwf-lak": "value specifying the number of lakes that will be simulated for all stress periods."
+      "value specifying the number of lakes that will be simulated for all stress periods.": [
+        "gwf-lak"
+      ]
     }
   },
   "nlay": {
     "dimensions": {
-      "gwe-dis": "is the number of layers in the model grid.",
-      "gwe-disv": "is the number of layers in the model grid.",
-      "gwf-dis": "is the number of layers in the model grid.",
-      "gwf-disv": "is the number of layers in the model grid.",
-      "gwt-dis": "is the number of layers in the model grid.",
-      "gwt-disv": "is the number of layers in the model grid.",
-      "prt-dis": "is the number of layers in the model grid.",
-      "prt-disv": "is the number of layers in the model grid."
+      "is the number of layers in the model grid.": [
+        "gwe-dis",
+        "gwe-disv",
+        "gwf-dis",
+        "gwf-disv",
+        "gwt-dis",
+        "gwt-disv",
+        "prt-dis",
+        "prt-disv"
+      ]
     }
   },
   "nmawwells": {
     "dimensions": {
-      "gwf-maw": "integer value specifying the number of multi-aquifer wells that will be simulated for all stress periods."
+      "integer value specifying the number of multi-aquifer wells that will be simulated for all stress periods.": [
+        "gwf-maw"
+      ]
     }
   },
   "no_ptc": {
     "options": {
-      "sln-ims": "is a flag that is used to disable pseudo-transient continuation (PTC). Option only applies to steady-state stress periods for models using the Newton-Raphson formulation. For many problems, PTC can significantly improve convergence behavior for steady-state simulations, and for this reason it is active by default.  In some cases, however, PTC can worsen the convergence behavior, especially when the initial conditions are similar to the solution.  When the initial conditions are similar to, or exactly the same as, the solution and convergence is slow, then the NO\\_PTC FIRST option should be used to deactivate PTC for the first stress period.  The NO\\_PTC ALL option should also be used in order to compare convergence behavior with other MODFLOW versions, as PTC is only available in MODFLOW 6.",
-      "sln-pts": "is a flag that is used to disable pseudo-transient continuation (PTC). Option only applies to steady-state stress periods for models using the Newton-Raphson formulation. For many problems, PTC can significantly improve convergence behavior for steady-state simulations, and for this reason it is active by default.  In some cases, however, PTC can worsen the convergence behavior, especially when the initial conditions are similar to the solution.  When the initial conditions are similar to, or exactly the same as, the solution and convergence is slow, then the NO\\_PTC FIRST option should be used to deactivate PTC for the first stress period.  The NO\\_PTC ALL option should also be used in order to compare convergence behavior with other MODFLOW versions, as PTC is only available in MODFLOW 6."
+      "is a flag that is used to disable pseudo-transient continuation (PTC). Option only applies to steady-state stress periods for models using the Newton-Raphson formulation. For many problems, PTC can significantly improve convergence behavior for steady-state simulations, and for this reason it is active by default.  In some cases, however, PTC can worsen the convergence behavior, especially when the initial conditions are similar to the solution.  When the initial conditions are similar to, or exactly the same as, the solution and convergence is slow, then the NO\\_PTC FIRST option should be used to deactivate PTC for the first stress period.  The NO\\_PTC ALL option should also be used in order to compare convergence behavior with other MODFLOW versions, as PTC is only available in MODFLOW 6.": [
+        "sln-ims",
+        "sln-pts"
+      ]
     }
   },
   "no_well_storage": {
     "options": {
-      "gwf-maw": "keyword that deactivates inclusion of well storage contributions to the multi-aquifer well package continuity equation."
+      "keyword that deactivates inclusion of well storage contributions to the multi-aquifer well package continuity equation.": [
+        "gwf-maw"
+      ]
     }
   },
   "nocheck": {
     "options": {
-      "sim-nam": "keyword flag to indicate that the model input check routines should not be called prior to each time step. Checks are performed by default."
+      "keyword flag to indicate that the model input check routines should not be called prior to each time step. Checks are performed by default.": [
+        "sim-nam"
+      ]
     }
   },
   "nodes": {
     "dimensions": {
-      "chf-disv1d": "is the number of linear cells.",
-      "gwe-disu": "is the number of cells in the model grid.",
-      "gwf-disu": "is the number of cells in the model grid.",
-      "gwt-disu": "is the number of cells in the model grid.",
-      "olf-disv1d": "is the number of linear cells.",
-      "olf-disv2d": "is the number of cells per layer.  This is a constant value for the grid and it applies to all layers.",
-      "swf-disv1d": "is the number of linear cells.",
-      "swf-disv2d": "is the number of cells per layer.  This is a constant value for the grid and it applies to all layers."
+      "is the number of cells in the model grid.": [
+        "gwe-disu",
+        "gwf-disu",
+        "gwt-disu"
+      ],
+      "is the number of cells per layer.  This is a constant value for the grid and it applies to all layers.": [
+        "olf-disv2d",
+        "swf-disv2d"
+      ],
+      "is the number of linear cells.": [
+        "chf-disv1d",
+        "olf-disv1d",
+        "swf-disv1d"
+      ]
     }
   },
   "nogrb": {
     "options": {
-      "chf-disv1d": "keyword to deactivate writing of the binary grid file.",
-      "gwe-dis": "keyword to deactivate writing of the binary grid file.",
-      "gwe-disu": "keyword to deactivate writing of the binary grid file.",
-      "gwe-disv": "keyword to deactivate writing of the binary grid file.",
-      "gwf-dis": "keyword to deactivate writing of the binary grid file.",
-      "gwf-disu": "keyword to deactivate writing of the binary grid file.",
-      "gwf-disv": "keyword to deactivate writing of the binary grid file.",
-      "gwt-dis": "keyword to deactivate writing of the binary grid file.",
-      "gwt-disu": "keyword to deactivate writing of the binary grid file.",
-      "gwt-disv": "keyword to deactivate writing of the binary grid file.",
-      "olf-dis2d": "keyword to deactivate writing of the binary grid file.",
-      "olf-disv1d": "keyword to deactivate writing of the binary grid file.",
-      "olf-disv2d": "keyword to deactivate writing of the binary grid file.",
-      "prt-dis": "keyword to deactivate writing of the binary grid file.",
-      "prt-disv": "keyword to deactivate writing of the binary grid file.",
-      "swf-dis2d": "keyword to deactivate writing of the binary grid file.",
-      "swf-disv1d": "keyword to deactivate writing of the binary grid file.",
-      "swf-disv2d": "keyword to deactivate writing of the binary grid file."
+      "keyword to deactivate writing of the binary grid file.": [
+        "chf-disv1d",
+        "gwe-dis",
+        "gwe-disu",
+        "gwe-disv",
+        "gwf-dis",
+        "gwf-disu",
+        "gwf-disv",
+        "gwt-dis",
+        "gwt-disu",
+        "gwt-disv",
+        "olf-dis2d",
+        "olf-disv1d",
+        "olf-disv2d",
+        "prt-dis",
+        "prt-disv",
+        "swf-dis2d",
+        "swf-disv1d",
+        "swf-disv2d"
+      ]
     }
   },
   "noutlets": {
     "dimensions": {
-      "gwf-lak": "value specifying the number of outlets that will be simulated for all stress periods. If NOUTLETS is not specified, a default value of zero is used."
+      "value specifying the number of outlets that will be simulated for all stress periods. If NOUTLETS is not specified, a default value of zero is used.": [
+        "gwf-lak"
+      ]
     }
   },
   "nper": {
     "dimensions": {
-      "sim-tdis": "is the number of stress periods for the simulation."
+      "is the number of stress periods for the simulation.": [
+        "sim-tdis"
+      ]
     }
   },
   "npoints": {
     "dimensions": {
-      "chf-cxs": "integer value specifying the total number of cross-section points defined for all reaches.  There must be NPOINTS entries in the CROSSSECTIONDATA block.",
-      "olf-cxs": "integer value specifying the total number of cross-section points defined for all reaches.  There must be NPOINTS entries in the CROSSSECTIONDATA block.",
-      "swf-cxs": "integer value specifying the total number of cross-section points defined for all reaches.  There must be NPOINTS entries in the CROSSSECTIONDATA block."
+      "integer value specifying the total number of cross-section points defined for all reaches.  There must be NPOINTS entries in the CROSSSECTIONDATA block.": [
+        "chf-cxs",
+        "olf-cxs",
+        "swf-cxs"
+      ]
     }
   },
   "nreaches": {
     "dimensions": {
-      "gwf-sfr": "integer value specifying the number of stream reaches.  There must be NREACHES entries in the PACKAGEDATA block."
+      "integer value specifying the number of stream reaches.  There must be NREACHES entries in the PACKAGEDATA block.": [
+        "gwf-sfr"
+      ]
     }
   },
   "nreleasepts": {
     "dimensions": {
-      "prt-prp": "is the number of particle release points."
+      "is the number of particle release points.": [
+        "prt-prp"
+      ]
     }
   },
   "nreleasetimes": {
     "dimensions": {
-      "prt-prp": "is the number of particle release times specified in the RELEASETIMES block. This is not necessarily the total number of release times; release times are the union of RELEASE\\_TIME\\_FREQUENCY, RELEASETIMES block, and PERIOD block RELEASESETTING selections."
+      "is the number of particle release times specified in the RELEASETIMES block. This is not necessarily the total number of release times; release times are the union of RELEASE\\_TIME\\_FREQUENCY, RELEASETIMES block, and PERIOD block RELEASESETTING selections.": [
+        "prt-prp"
+      ]
     }
   },
   "nrhospecies": {
     "dimensions": {
-      "gwf-buy": "number of species used in density equation of state.  This value must be one or greater if the BUY package is activated.  "
+      "number of species used in density equation of state.  This value must be one or greater if the BUY package is activated.  ": [
+        "gwf-buy"
+      ]
     }
   },
   "nrow": {
     "dimensions": {
-      "gwe-dis": "is the number of rows in the model grid.",
-      "gwf-dis": "is the number of rows in the model grid.",
-      "gwt-dis": "is the number of rows in the model grid.",
-      "olf-dis2d": "is the number of rows in the model grid.",
-      "prt-dis": "is the number of rows in the model grid.",
-      "swf-dis2d": "is the number of rows in the model grid.",
-      "utl-laktab": "integer value specifying the number of rows in the lake table. There must be NROW rows of data in the TABLE block.",
-      "utl-sfrtab": "integer value specifying the number of rows in the reach cross-section table. There must be NROW rows of data in the TABLE block."
+      "integer value specifying the number of rows in the lake table. There must be NROW rows of data in the TABLE block.": [
+        "utl-laktab"
+      ],
+      "integer value specifying the number of rows in the reach cross-section table. There must be NROW rows of data in the TABLE block.": [
+        "utl-sfrtab"
+      ],
+      "is the number of rows in the model grid.": [
+        "gwe-dis",
+        "gwf-dis",
+        "gwt-dis",
+        "olf-dis2d",
+        "prt-dis",
+        "swf-dis2d"
+      ]
     }
   },
   "nsections": {
     "dimensions": {
-      "chf-cxs": "integer value specifying the number of cross sections that will be defined.  There must be NSECTIONS entries in the PACKAGEDATA block.",
-      "olf-cxs": "integer value specifying the number of cross sections that will be defined.  There must be NSECTIONS entries in the PACKAGEDATA block.",
-      "swf-cxs": "integer value specifying the number of cross sections that will be defined.  There must be NSECTIONS entries in the PACKAGEDATA block."
+      "integer value specifying the number of cross sections that will be defined.  There must be NSECTIONS entries in the PACKAGEDATA block.": [
+        "chf-cxs",
+        "olf-cxs",
+        "swf-cxs"
+      ]
     }
   },
   "nseg": {
     "dimensions": {
-      "gwf-evt": "number of ET segments.  Default is one.  When NSEG is greater than 1, the PXDP and PETM arrays must be of size NSEG - 1 and be listed in order from the uppermost segment down. Values for PXDP must be listed first followed by the values for PETM.  PXDP defines the extinction-depth proportion at the bottom of a segment. PETM defines the proportion of the maximum ET flux rate at the bottom of a segment."
+      "number of ET segments.  Default is one.  When NSEG is greater than 1, the PXDP and PETM arrays must be of size NSEG - 1 and be listed in order from the uppermost segment down. Values for PXDP must be listed first followed by the values for PETM.  PXDP defines the extinction-depth proportion at the bottom of a segment. PETM defines the proportion of the maximum ET flux rate at the bottom of a segment.": [
+        "gwf-evt"
+      ]
     }
   },
   "ntables": {
     "dimensions": {
-      "gwf-lak": "value specifying the number of lakes tables that will be used to define the lake stage, volume relation, and surface area. If NTABLES is not specified, a default value of zero is used."
+      "value specifying the number of lakes tables that will be used to define the lake stage, volume relation, and surface area. If NTABLES is not specified, a default value of zero is used.": [
+        "gwf-lak"
+      ]
     }
   },
   "ntracktimes": {
     "dimensions": {
-      "prt-oc": "is the number of user-specified particle tracking times in the TRACKTIMES block."
+      "is the number of user-specified particle tracking times in the TRACKTIMES block.": [
+        "prt-oc"
+      ]
     }
   },
   "ntrailwaves": {
     "dimensions": {
-      "gwf-uzf": "is the number of trailing waves.  A recommended value of 7 can be used for NTRAILWAVES.  This value can be increased to lower mass balance error in the unsaturated zone."
+      "is the number of trailing waves.  A recommended value of 7 can be used for NTRAILWAVES.  This value can be increased to lower mass balance error in the unsaturated zone.": [
+        "gwf-uzf"
+      ]
     }
   },
   "numalphaj": {
     "dimensions": {
-      "gwf-gnc": "is the number of contributing factors."
+      "is the number of contributing factors.": [
+        "gwf-gnc"
+      ]
     }
   },
   "number_orthogonalizations": {
     "linear": {
-      "sln-ims": "optional integer value defining the interval used to explicitly recalculate the residual of the flow equation using the solver coefficient matrix, the latest dependent-variable (for example, head) estimates, and the right hand side. For problems that benefit from explicit recalculation of the residual, a number between 4 and 10 is appropriate. By default, NUMBER\\_ORTHOGONALIZATIONS is zero."
+      "optional integer value defining the interval used to explicitly recalculate the residual of the flow equation using the solver coefficient matrix, the latest dependent-variable (for example, head) estimates, and the right hand side. For problems that benefit from explicit recalculation of the residual, a number between 4 and 10 is appropriate. By default, NUMBER\\_ORTHOGONALIZATIONS is zero.": [
+        "sln-ims"
+      ]
     }
   },
   "numgnc": {
     "dimensions": {
-      "gwf-gnc": "is the number of GNC entries."
+      "is the number of GNC entries.": [
+        "gwf-gnc"
+      ]
     }
   },
   "nuzfcells": {
     "dimensions": {
-      "gwf-uzf": "is the number of UZF cells.  More than one UZF cell can be assigned to a GWF cell; however, only one GWF cell can be assigned to a single UZF cell. If more than one UZF cell is assigned to a GWF cell, then an auxiliary variable should be used to reduce the surface area of the UZF cell with the AUXMULTNAME option."
+      "is the number of UZF cells.  More than one UZF cell can be assigned to a GWF cell; however, only one GWF cell can be assigned to a single UZF cell. If more than one UZF cell is assigned to a GWF cell, then an auxiliary variable should be used to reduce the surface area of the UZF cell with the AUXMULTNAME option.": [
+        "gwf-uzf"
+      ]
     }
   },
   "nvert": {
     "dimensions": {
-      "chf-disv1d": "is the total number of (x, y, z) vertex pairs used to characterize the model grid.",
-      "gwe-disu": "is the total number of (x, y) vertex pairs used to define the plan-view shape of each cell in the model grid.  If NVERT is not specified or is specified as zero, then the VERTICES and CELL2D blocks below are not read.  NVERT and the accompanying VERTICES and CELL2D blocks should be specified for most simulations.  If the XT3D or SAVE\\_SPECIFIC\\_DISCHARGE options are specified in the NPF Package, then this information is required.",
-      "gwe-disv": "is the total number of (x, y) vertex pairs used to characterize the horizontal configuration of the model grid.",
-      "gwf-disu": "is the total number of (x, y) vertex pairs used to define the plan-view shape of each cell in the model grid.  If NVERT is not specified or is specified as zero, then the VERTICES and CELL2D blocks below are not read.  NVERT and the accompanying VERTICES and CELL2D blocks should be specified for most simulations.  If the XT3D or SAVE\\_SPECIFIC\\_DISCHARGE options are specified in the NPF Package, then this information is required.",
-      "gwf-disv": "is the total number of (x, y) vertex pairs used to characterize the horizontal configuration of the model grid.",
-      "gwt-disu": "is the total number of (x, y) vertex pairs used to define the plan-view shape of each cell in the model grid.  If NVERT is not specified or is specified as zero, then the VERTICES and CELL2D blocks below are not read.  NVERT and the accompanying VERTICES and CELL2D blocks should be specified for most simulations.  If the XT3D or SAVE\\_SPECIFIC\\_DISCHARGE options are specified in the NPF Package, then this information is required.",
-      "gwt-disv": "is the total number of (x, y) vertex pairs used to characterize the horizontal configuration of the model grid.",
-      "olf-disv1d": "is the total number of (x, y, z) vertex pairs used to characterize the model grid.",
-      "olf-disv2d": "is the total number of (x, y) vertex pairs used to characterize the horizontal configuration of the model grid.",
-      "prt-disv": "is the total number of (x, y) vertex pairs used to characterize the horizontal configuration of the model grid.",
-      "swf-disv1d": "is the total number of (x, y, z) vertex pairs used to characterize the model grid.",
-      "swf-disv2d": "is the total number of (x, y) vertex pairs used to characterize the horizontal configuration of the model grid."
+      "is the total number of (x, y) vertex pairs used to characterize the horizontal configuration of the model grid.": [
+        "gwe-disv",
+        "gwf-disv",
+        "gwt-disv",
+        "olf-disv2d",
+        "prt-disv",
+        "swf-disv2d"
+      ],
+      "is the total number of (x, y) vertex pairs used to define the plan-view shape of each cell in the model grid.  If NVERT is not specified or is specified as zero, then the VERTICES and CELL2D blocks below are not read.  NVERT and the accompanying VERTICES and CELL2D blocks should be specified for most simulations.  If the XT3D or SAVE\\_SPECIFIC\\_DISCHARGE options are specified in the NPF Package, then this information is required.": [
+        "gwe-disu",
+        "gwf-disu",
+        "gwt-disu"
+      ],
+      "is the total number of (x, y, z) vertex pairs used to characterize the model grid.": [
+        "chf-disv1d",
+        "olf-disv1d",
+        "swf-disv1d"
+      ]
     }
   },
   "nviscspecies": {
     "dimensions": {
-      "gwf-vsc": "number of species used in the viscosity equation of state.  If either concentrations or temperature (or both) are used to update viscosity then then nrhospecies needs to be at least one."
+      "number of species used in the viscosity equation of state.  If either concentrations or temperature (or both) are used to update viscosity then then nrhospecies needs to be at least one.": [
+        "gwf-vsc"
+      ]
     }
   },
   "nwavesets": {
     "dimensions": {
-      "gwf-uzf": "is the number of wave sets.  A recommended value of 40 can be used for NWAVESETS.  This value can be increased if more waves are required to resolve variations in water content within the unsaturated zone."
+      "is the number of wave sets.  A recommended value of 40 can be used for NWAVESETS.  This value can be increased if more waves are required to resolve variations in water content within the unsaturated zone.": [
+        "gwf-uzf"
+      ]
     }
   },
   "obs6": {
     "options": {
-      "chf-cdb": "keyword to specify that record corresponds to an observations file.",
-      "chf-chd": "keyword to specify that record corresponds to an observations file.",
-      "chf-dfw": "keyword to specify that record corresponds to an observations file.",
-      "chf-evp": "keyword to specify that record corresponds to an observations file.",
-      "chf-flw": "keyword to specify that record corresponds to an observations file.",
-      "chf-pcp": "keyword to specify that record corresponds to an observations file.",
-      "chf-zdg": "keyword to specify that record corresponds to an observations file.",
-      "exg-chfgwf": "keyword to specify that record corresponds to an observations file.",
-      "exg-gwegwe": "keyword to specify that record corresponds to an observations file.",
-      "exg-gwfgwf": "keyword to specify that record corresponds to an observations file.",
-      "exg-gwtgwt": "keyword to specify that record corresponds to an observations file.",
-      "exg-olfgwf": "keyword to specify that record corresponds to an observations file.",
-      "gwe-ctp": "keyword to specify that record corresponds to an observations file.",
-      "gwe-esl": "keyword to specify that record corresponds to an observations file.",
-      "gwe-lke": "keyword to specify that record corresponds to an observations file.",
-      "gwe-mwe": "keyword to specify that record corresponds to an observations file.",
-      "gwe-sfe": "keyword to specify that record corresponds to an observations file.",
-      "gwe-uze": "keyword to specify that record corresponds to an observations file.",
-      "gwf-api": "keyword to specify that record corresponds to an observations file.",
-      "gwf-chd": "keyword to specify that record corresponds to an observations file.",
-      "gwf-csub": "keyword to specify that record corresponds to an observations file.",
-      "gwf-drn": "keyword to specify that record corresponds to an observations file.",
-      "gwf-evt": "keyword to specify that record corresponds to an observations file.",
-      "gwf-evta": "keyword to specify that record corresponds to an observations file.",
-      "gwf-ghb": "keyword to specify that record corresponds to an observations file.",
-      "gwf-lak": "keyword to specify that record corresponds to an observations file.",
-      "gwf-maw": "keyword to specify that record corresponds to an observations file.",
-      "gwf-rch": "keyword to specify that record corresponds to an observations file.",
-      "gwf-rcha": "keyword to specify that record corresponds to an observations file.",
-      "gwf-riv": "keyword to specify that record corresponds to an observations file.",
-      "gwf-sfr": "keyword to specify that record corresponds to an observations file.",
-      "gwf-uzf": "keyword to specify that record corresponds to an observations file.",
-      "gwf-wel": "keyword to specify that record corresponds to an observations file.",
-      "gwt-api": "keyword to specify that record corresponds to an observations file.",
-      "gwt-cnc": "keyword to specify that record corresponds to an observations file.",
-      "gwt-lkt": "keyword to specify that record corresponds to an observations file.",
-      "gwt-mwt": "keyword to specify that record corresponds to an observations file.",
-      "gwt-sft": "keyword to specify that record corresponds to an observations file.",
-      "gwt-src": "keyword to specify that record corresponds to an observations file.",
-      "gwt-uzt": "keyword to specify that record corresponds to an observations file.",
-      "olf-cdb": "keyword to specify that record corresponds to an observations file.",
-      "olf-chd": "keyword to specify that record corresponds to an observations file.",
-      "olf-dfw": "keyword to specify that record corresponds to an observations file.",
-      "olf-evp": "keyword to specify that record corresponds to an observations file.",
-      "olf-flw": "keyword to specify that record corresponds to an observations file.",
-      "olf-pcp": "keyword to specify that record corresponds to an observations file.",
-      "olf-zdg": "keyword to specify that record corresponds to an observations file.",
-      "swf-cdb": "keyword to specify that record corresponds to an observations file.",
-      "swf-chd": "keyword to specify that record corresponds to an observations file.",
-      "swf-dfw": "keyword to specify that record corresponds to an observations file.",
-      "swf-evp": "keyword to specify that record corresponds to an observations file.",
-      "swf-flw": "keyword to specify that record corresponds to an observations file.",
-      "swf-pcp": "keyword to specify that record corresponds to an observations file.",
-      "swf-zdg": "keyword to specify that record corresponds to an observations file."
+      "keyword to specify that record corresponds to an observations file.": [
+        "chf-cdb",
+        "chf-chd",
+        "chf-dfw",
+        "chf-evp",
+        "chf-flw",
+        "chf-pcp",
+        "chf-zdg",
+        "exg-chfgwf",
+        "exg-gwegwe",
+        "exg-gwfgwf",
+        "exg-gwtgwt",
+        "exg-olfgwf",
+        "gwe-ctp",
+        "gwe-esl",
+        "gwe-lke",
+        "gwe-mwe",
+        "gwe-sfe",
+        "gwe-uze",
+        "gwf-api",
+        "gwf-chd",
+        "gwf-csub",
+        "gwf-drn",
+        "gwf-evt",
+        "gwf-evta",
+        "gwf-ghb",
+        "gwf-lak",
+        "gwf-maw",
+        "gwf-rch",
+        "gwf-rcha",
+        "gwf-riv",
+        "gwf-sfr",
+        "gwf-uzf",
+        "gwf-wel",
+        "gwt-api",
+        "gwt-cnc",
+        "gwt-lkt",
+        "gwt-mwt",
+        "gwt-sft",
+        "gwt-src",
+        "gwt-uzt",
+        "olf-cdb",
+        "olf-chd",
+        "olf-dfw",
+        "olf-evp",
+        "olf-flw",
+        "olf-pcp",
+        "olf-zdg",
+        "swf-cdb",
+        "swf-chd",
+        "swf-dfw",
+        "swf-evp",
+        "swf-flw",
+        "swf-pcp",
+        "swf-zdg"
+      ]
     }
   },
   "outer_dvclose": {
     "nonlinear": {
-      "sln-ims": "real value defining the dependent-variable (for example, head) change criterion for convergence of the outer (nonlinear) iterations, in units of the dependent-variable (for example, length for head). When the maximum absolute value of the dependent-variable change at all nodes during an iteration is less than or equal to OUTER\\_DVCLOSE, iteration stops. Commonly, OUTER\\_DVCLOSE equals 0.01. The keyword, OUTER\\_HCLOSE can be still be specified instead of OUTER\\_DVCLOSE for backward compatibility with previous versions of MODFLOW 6 but eventually OUTER\\_HCLOSE will be deprecated and specification of OUTER\\_HCLOSE will cause MODFLOW 6 to terminate with an error."
+      "real value defining the dependent-variable (for example, head) change criterion for convergence of the outer (nonlinear) iterations, in units of the dependent-variable (for example, length for head). When the maximum absolute value of the dependent-variable change at all nodes during an iteration is less than or equal to OUTER\\_DVCLOSE, iteration stops. Commonly, OUTER\\_DVCLOSE equals 0.01. The keyword, OUTER\\_HCLOSE can be still be specified instead of OUTER\\_DVCLOSE for backward compatibility with previous versions of MODFLOW 6 but eventually OUTER\\_HCLOSE will be deprecated and specification of OUTER\\_HCLOSE will cause MODFLOW 6 to terminate with an error.": [
+        "sln-ims"
+      ]
     }
   },
   "outer_hclose": {
     "nonlinear": {
-      "sln-ims": "real value defining the head change criterion for convergence of the outer (nonlinear) iterations, in units of length. When the maximum absolute value of the head change at all nodes during an iteration is less than or equal to OUTER\\_HCLOSE, iteration stops. Commonly, OUTER\\_HCLOSE equals 0.01.  The OUTER\\_HCLOSE option has been deprecated in favor of the more general OUTER\\_DVCLOSE (for dependent variable), however either one can be specified in order to maintain backward compatibility."
+      "real value defining the head change criterion for convergence of the outer (nonlinear) iterations, in units of length. When the maximum absolute value of the head change at all nodes during an iteration is less than or equal to OUTER\\_HCLOSE, iteration stops. Commonly, OUTER\\_HCLOSE equals 0.01.  The OUTER\\_HCLOSE option has been deprecated in favor of the more general OUTER\\_DVCLOSE (for dependent variable), however either one can be specified in order to maintain backward compatibility.": [
+        "sln-ims"
+      ]
     }
   },
   "outer_maximum": {
     "nonlinear": {
-      "sln-ims": "integer value defining the maximum number of outer (nonlinear) iterations -- that is, calls to the solution routine. For a linear problem OUTER\\_MAXIMUM should be 1."
+      "integer value defining the maximum number of outer (nonlinear) iterations -- that is, calls to the solution routine. For a linear problem OUTER\\_MAXIMUM should be 1.": [
+        "sln-ims"
+      ]
     }
   },
   "outer_rclosebnd": {
     "nonlinear": {
-      "sln-ims": "real value defining the residual tolerance for convergence of model packages that solve a separate equation not solved by the IMS linear solver. This value represents the maximum allowable residual between successive outer iterations at any single model package element. An example of a model package that would use OUTER\\_RCLOSEBND to evaluate convergence is the SFR package which solves a continuity equation for each reach.  The OUTER\\_RCLOSEBND option is deprecated and has no effect on simulation results as of version 6.1.1.  The keyword, OUTER\\_RCLOSEBND can be still be specified for backward compatibility with previous versions of MODFLOW 6 but eventually specification of OUTER\\_RCLOSEBND will cause MODFLOW 6 to terminate with an error."
+      "real value defining the residual tolerance for convergence of model packages that solve a separate equation not solved by the IMS linear solver. This value represents the maximum allowable residual between successive outer iterations at any single model package element. An example of a model package that would use OUTER\\_RCLOSEBND to evaluate convergence is the SFR package which solves a continuity equation for each reach.  The OUTER\\_RCLOSEBND option is deprecated and has no effect on simulation results as of version 6.1.1.  The keyword, OUTER\\_RCLOSEBND can be still be specified for backward compatibility with previous versions of MODFLOW 6 but eventually specification of OUTER\\_RCLOSEBND will cause MODFLOW 6 to terminate with an error.": [
+        "sln-ims"
+      ]
     }
   },
   "package_convergence": {
     "options": {
-      "gwf-csub": "keyword to specify that record corresponds to the package convergence comma spaced values file. Package convergence data is for delay interbeds. A warning message will be issued if package convergence data is requested but delay interbeds are not included in the package.",
-      "gwf-lak": "keyword to specify that record corresponds to the package convergence comma spaced values file.",
-      "gwf-sfr": "keyword to specify that record corresponds to the package convergence comma spaced values file.",
-      "gwf-uzf": "keyword to specify that record corresponds to the package convergence comma spaced values file."
+      "keyword to specify that record corresponds to the package convergence comma spaced values file.": [
+        "gwf-lak",
+        "gwf-sfr",
+        "gwf-uzf"
+      ],
+      "keyword to specify that record corresponds to the package convergence comma spaced values file. Package convergence data is for delay interbeds. A warning message will be issued if package convergence data is requested but delay interbeds are not included in the package.": [
+        "gwf-csub"
+      ]
     }
   },
   "partitions": {
     "partitions": {
-      "utl-hpc": "is the list of zero-based partition numbers."
+      "is the list of zero-based partition numbers.": [
+        "utl-hpc"
+      ]
     }
   },
   "perched": {
     "options": {
-      "gwf-npf": "keyword to indicate that when a cell is overlying a dewatered convertible cell, the head difference used in Darcy's Law is equal to the head in the overlying cell minus the bottom elevation of the overlying cell.  If not specified, then the default is to use the head difference between the two cells."
+      "keyword to indicate that when a cell is overlying a dewatered convertible cell, the head difference used in Darcy's Law is equal to the head in the overlying cell minus the bottom elevation of the overlying cell.  If not specified, then the default is to use the head difference between the two cells.": [
+        "gwf-npf"
+      ]
     }
   },
   "porosity": {
     "griddata": {
-      "gwe-est": "is the mobile domain porosity, defined as the mobile domain pore volume per mobile domain volume.  The GWE model does not support the concept of an immobile domain in the context of heat transport. ",
-      "gwt-ist": "porosity of the immobile domain specified as the immobile domain pore volume per immobile domain volume.",
-      "gwt-mst": "is the mobile domain porosity, defined as the mobile domain pore volume per mobile domain volume.  Additional information on porosity within the context of mobile and immobile domain transport simulations is included in the MODFLOW 6 Supplemental Technical Information document. ",
-      "prt-mip": "is the aquifer porosity."
+      "is the aquifer porosity.": [
+        "prt-mip"
+      ],
+      "is the mobile domain porosity, defined as the mobile domain pore volume per mobile domain volume.  Additional information on porosity within the context of mobile and immobile domain transport simulations is included in the MODFLOW 6 Supplemental Technical Information document. ": [
+        "gwt-mst"
+      ],
+      "is the mobile domain porosity, defined as the mobile domain pore volume per mobile domain volume.  The GWE model does not support the concept of an immobile domain in the context of heat transport. ": [
+        "gwe-est"
+      ],
+      "porosity of the immobile domain specified as the immobile domain pore volume per immobile domain volume.": [
+        "gwt-ist"
+      ]
     }
   },
   "preconditioner_drop_tolerance": {
     "linear": {
-      "sln-ims": "optional real value that defines the drop tolerance used to drop preconditioner terms based on the magnitude of matrix entries in the ILUT and MILUT preconditioners. A value of $10^{-4}$ works well for most problems. By default, PRECONDITIONER\\_DROP\\_TOLERANCE is zero and the zero-fill incomplete LU factorization preconditioners (ILU(0) and MILU(0)) are used."
+      "optional real value that defines the drop tolerance used to drop preconditioner terms based on the magnitude of matrix entries in the ILUT and MILUT preconditioners. A value of $10^{-4}$ works well for most problems. By default, PRECONDITIONER\\_DROP\\_TOLERANCE is zero and the zero-fill incomplete LU factorization preconditioners (ILU(0) and MILU(0)) are used.": [
+        "sln-ims"
+      ]
     }
   },
   "preconditioner_levels": {
     "linear": {
-      "sln-ims": "optional integer value defining the level of fill for ILU decomposition used in the ILUT and MILUT preconditioners. Higher levels of fill provide more robustness but also require more memory. For optimal performance, it is suggested that a large level of fill be applied (7 or 8) with use of a drop tolerance. Specification of a PRECONDITIONER\\_LEVELS value greater than zero results in use of the ILUT preconditioner. By default, PRECONDITIONER\\_LEVELS is zero and the zero-fill incomplete LU factorization preconditioners (ILU(0) and MILU(0)) are used."
+      "optional integer value defining the level of fill for ILU decomposition used in the ILUT and MILUT preconditioners. Higher levels of fill provide more robustness but also require more memory. For optimal performance, it is suggested that a large level of fill be applied (7 or 8) with use of a drop tolerance. Specification of a PRECONDITIONER\\_LEVELS value greater than zero results in use of the ILUT preconditioner. By default, PRECONDITIONER\\_LEVELS is zero and the zero-fill incomplete LU factorization preconditioners (ILU(0) and MILU(0)) are used.": [
+        "sln-ims"
+      ]
     }
   },
   "print": {
     "period": {
-      "chf-oc": "keyword to indicate that information will be printed this stress period.",
-      "gwe-oc": "keyword to indicate that information will be printed this stress period.",
-      "gwf-oc": "keyword to indicate that information will be printed this stress period.",
-      "gwt-oc": "keyword to indicate that information will be printed this stress period.",
-      "olf-oc": "keyword to indicate that information will be printed this stress period.",
-      "prt-oc": "keyword to indicate that information will be printed this stress period.",
-      "swf-oc": "keyword to indicate that information will be printed this stress period."
+      "keyword to indicate that information will be printed this stress period.": [
+        "chf-oc",
+        "gwe-oc",
+        "gwf-oc",
+        "gwt-oc",
+        "olf-oc",
+        "prt-oc",
+        "swf-oc"
+      ]
     }
   },
   "print_concentration": {
     "options": {
-      "gwt-lkt": "keyword to indicate that the list of lake concentration will be printed to the listing file for every stress period in which ``CONCENTRATION PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_CONCENTRATION is specified, then concentration are printed for the last time step of each stress period.",
-      "gwt-mwt": "keyword to indicate that the list of well concentration will be printed to the listing file for every stress period in which ``CONCENTRATION PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_CONCENTRATION is specified, then concentration are printed for the last time step of each stress period.",
-      "gwt-sft": "keyword to indicate that the list of reach concentration will be printed to the listing file for every stress period in which ``CONCENTRATION PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_CONCENTRATION is specified, then concentration are printed for the last time step of each stress period.",
-      "gwt-uzt": "keyword to indicate that the list of UZF cell concentration will be printed to the listing file for every stress period in which ``CONCENTRATION PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_CONCENTRATION is specified, then concentration are printed for the last time step of each stress period."
+      "keyword to indicate that the list of UZF cell concentration will be printed to the listing file for every stress period in which ``CONCENTRATION PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_CONCENTRATION is specified, then concentration are printed for the last time step of each stress period.": [
+        "gwt-uzt"
+      ],
+      "keyword to indicate that the list of lake concentration will be printed to the listing file for every stress period in which ``CONCENTRATION PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_CONCENTRATION is specified, then concentration are printed for the last time step of each stress period.": [
+        "gwt-lkt"
+      ],
+      "keyword to indicate that the list of reach concentration will be printed to the listing file for every stress period in which ``CONCENTRATION PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_CONCENTRATION is specified, then concentration are printed for the last time step of each stress period.": [
+        "gwt-sft"
+      ],
+      "keyword to indicate that the list of well concentration will be printed to the listing file for every stress period in which ``CONCENTRATION PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_CONCENTRATION is specified, then concentration are printed for the last time step of each stress period.": [
+        "gwt-mwt"
+      ]
     }
   },
   "print_flows": {
     "options": {
-      "chf-cdb": "keyword to indicate that the list of critical depth boundary flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "chf-chd": "keyword to indicate that the list of constant-head flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "chf-dfw": "keyword to indicate that calculated flows between cells will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control. If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.  This option can produce extremely large list files because all cell-by-cell flows are printed.  It should only be used with the DFW Package for models that have a small number of cells.",
-      "chf-evp": "keyword to indicate that the list of evaporation flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "chf-flw": "keyword to indicate that the list of inflow flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "chf-nam": "keyword to indicate that the list of all model package flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "chf-pcp": "keyword to indicate that the list of precipitation flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "chf-zdg": "keyword to indicate that the list of zero-depth-gradient boundary flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "exg-chfgwf": "keyword to indicate that the list of exchange flow rates will be printed to the listing file for every stress period in which ``SAVE BUDGET'' is specified in Output Control.",
-      "exg-gwegwe": "keyword to indicate that the list of exchange flow rates will be printed to the listing file for every stress period in which ``SAVE BUDGET'' is specified in Output Control.",
-      "exg-gwfgwf": "keyword to indicate that the list of exchange flow rates will be printed to the listing file for every stress period in which ``SAVE BUDGET'' is specified in Output Control.",
-      "exg-gwtgwt": "keyword to indicate that the list of exchange flow rates will be printed to the listing file for every stress period in which ``SAVE BUDGET'' is specified in Output Control.",
-      "exg-olfgwf": "keyword to indicate that the list of exchange flow rates will be printed to the listing file for every stress period in which ``SAVE BUDGET'' is specified in Output Control.",
-      "gwe-ctp": "keyword to indicate that the list of constant temperature flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "gwe-esl": "keyword to indicate that the list of energy source loading flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "gwe-lke": "keyword to indicate that the list of lake flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "gwe-mve": "keyword to indicate that the list of lake flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "gwe-mwe": "keyword to indicate that the list of well flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "gwe-nam": "keyword to indicate that the list of all model package flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "gwe-sfe": "keyword to indicate that the list of reach flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "gwe-ssm": "keyword to indicate that the list of SSM flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "gwe-uze": "keyword to indicate that the list of unsaturated zone flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "gwf-api": "keyword to indicate that the list of api boundary flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "gwf-chd": "keyword to indicate that the list of constant-head flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "gwf-drn": "keyword to indicate that the list of drain flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "gwf-evt": "keyword to indicate that the list of evapotranspiration flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "gwf-evta": "keyword to indicate that the list of evapotranspiration flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "gwf-ghb": "keyword to indicate that the list of general-head boundary flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "gwf-gnc": "keyword to indicate that the list of GNC flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "gwf-lak": "keyword to indicate that the list of lake flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "gwf-maw": "keyword to indicate that the list of multi-aquifer well flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "gwf-mvr": "keyword to indicate that the list of MVR flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "gwf-nam": "keyword to indicate that the list of all model package flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "gwf-npf": "keyword to indicate that calculated flows between cells will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control. If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.  This option can produce extremely large list files because all cell-by-cell flows are printed.  It should only be used with the NPF Package for models that have a small number of cells.",
-      "gwf-rch": "keyword to indicate that the list of recharge flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "gwf-rcha": "keyword to indicate that the list of recharge flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "gwf-riv": "keyword to indicate that the list of river flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "gwf-sfr": "keyword to indicate that the list of stream reach flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "gwf-uzf": "keyword to indicate that the list of UZF flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "gwf-wel": "keyword to indicate that the list of well flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "gwt-api": "keyword to indicate that the list of api boundary flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "gwt-cnc": "keyword to indicate that the list of constant concentration flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "gwt-lkt": "keyword to indicate that the list of lake flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "gwt-mvt": "keyword to indicate that the list of lake flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "gwt-mwt": "keyword to indicate that the list of well flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "gwt-nam": "keyword to indicate that the list of all model package flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "gwt-sft": "keyword to indicate that the list of reach flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "gwt-src": "keyword to indicate that the list of mass source flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "gwt-ssm": "keyword to indicate that the list of SSM flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "gwt-uzt": "keyword to indicate that the list of unsaturated zone flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "olf-cdb": "keyword to indicate that the list of critical depth boundary flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "olf-chd": "keyword to indicate that the list of constant-head flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "olf-dfw": "keyword to indicate that calculated flows between cells will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control. If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.  This option can produce extremely large list files because all cell-by-cell flows are printed.  It should only be used with the DFW Package for models that have a small number of cells.",
-      "olf-evp": "keyword to indicate that the list of evaporation flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "olf-flw": "keyword to indicate that the list of inflow flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "olf-nam": "keyword to indicate that the list of all model package flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "olf-pcp": "keyword to indicate that the list of precipitation flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "olf-zdg": "keyword to indicate that the list of zero-depth-gradient boundary flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "prt-nam": "keyword to indicate that the list of all model package flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "swf-cdb": "keyword to indicate that the list of critical depth boundary flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "swf-chd": "keyword to indicate that the list of constant-head flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "swf-dfw": "keyword to indicate that calculated flows between cells will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control. If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.  This option can produce extremely large list files because all cell-by-cell flows are printed.  It should only be used with the DFW Package for models that have a small number of cells.",
-      "swf-evp": "keyword to indicate that the list of evaporation flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "swf-flw": "keyword to indicate that the list of inflow flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "swf-nam": "keyword to indicate that the list of all model package flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "swf-pcp": "keyword to indicate that the list of precipitation flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      "swf-zdg": "keyword to indicate that the list of zero-depth-gradient boundary flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period."
+      "keyword to indicate that calculated flows between cells will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control. If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.  This option can produce extremely large list files because all cell-by-cell flows are printed.  It should only be used with the DFW Package for models that have a small number of cells.": [
+        "chf-dfw",
+        "olf-dfw",
+        "swf-dfw"
+      ],
+      "keyword to indicate that calculated flows between cells will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control. If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.  This option can produce extremely large list files because all cell-by-cell flows are printed.  It should only be used with the NPF Package for models that have a small number of cells.": [
+        "gwf-npf"
+      ],
+      "keyword to indicate that the list of GNC flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.": [
+        "gwf-gnc"
+      ],
+      "keyword to indicate that the list of MVR flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.": [
+        "gwf-mvr"
+      ],
+      "keyword to indicate that the list of SSM flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.": [
+        "gwe-ssm",
+        "gwt-ssm"
+      ],
+      "keyword to indicate that the list of UZF flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.": [
+        "gwf-uzf"
+      ],
+      "keyword to indicate that the list of all model package flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.": [
+        "chf-nam",
+        "gwe-nam",
+        "gwf-nam",
+        "gwt-nam",
+        "olf-nam",
+        "prt-nam",
+        "swf-nam"
+      ],
+      "keyword to indicate that the list of api boundary flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.": [
+        "gwf-api",
+        "gwt-api"
+      ],
+      "keyword to indicate that the list of constant concentration flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.": [
+        "gwt-cnc"
+      ],
+      "keyword to indicate that the list of constant temperature flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.": [
+        "gwe-ctp"
+      ],
+      "keyword to indicate that the list of constant-head flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.": [
+        "chf-chd",
+        "gwf-chd",
+        "olf-chd",
+        "swf-chd"
+      ],
+      "keyword to indicate that the list of critical depth boundary flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.": [
+        "chf-cdb",
+        "olf-cdb",
+        "swf-cdb"
+      ],
+      "keyword to indicate that the list of drain flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.": [
+        "gwf-drn"
+      ],
+      "keyword to indicate that the list of energy source loading flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.": [
+        "gwe-esl"
+      ],
+      "keyword to indicate that the list of evaporation flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.": [
+        "chf-evp",
+        "olf-evp",
+        "swf-evp"
+      ],
+      "keyword to indicate that the list of evapotranspiration flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.": [
+        "gwf-evt",
+        "gwf-evta"
+      ],
+      "keyword to indicate that the list of exchange flow rates will be printed to the listing file for every stress period in which ``SAVE BUDGET'' is specified in Output Control.": [
+        "exg-chfgwf",
+        "exg-gwegwe",
+        "exg-gwfgwf",
+        "exg-gwtgwt",
+        "exg-olfgwf"
+      ],
+      "keyword to indicate that the list of general-head boundary flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.": [
+        "gwf-ghb"
+      ],
+      "keyword to indicate that the list of inflow flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.": [
+        "chf-flw",
+        "olf-flw",
+        "swf-flw"
+      ],
+      "keyword to indicate that the list of lake flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.": [
+        "gwe-lke",
+        "gwe-mve",
+        "gwf-lak",
+        "gwt-lkt",
+        "gwt-mvt"
+      ],
+      "keyword to indicate that the list of mass source flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.": [
+        "gwt-src"
+      ],
+      "keyword to indicate that the list of multi-aquifer well flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.": [
+        "gwf-maw"
+      ],
+      "keyword to indicate that the list of precipitation flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.": [
+        "chf-pcp",
+        "olf-pcp",
+        "swf-pcp"
+      ],
+      "keyword to indicate that the list of reach flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.": [
+        "gwe-sfe",
+        "gwt-sft"
+      ],
+      "keyword to indicate that the list of recharge flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.": [
+        "gwf-rch",
+        "gwf-rcha"
+      ],
+      "keyword to indicate that the list of river flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.": [
+        "gwf-riv"
+      ],
+      "keyword to indicate that the list of stream reach flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.": [
+        "gwf-sfr"
+      ],
+      "keyword to indicate that the list of unsaturated zone flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.": [
+        "gwe-uze",
+        "gwt-uzt"
+      ],
+      "keyword to indicate that the list of well flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.": [
+        "gwe-mwe",
+        "gwf-wel",
+        "gwt-mwt"
+      ],
+      "keyword to indicate that the list of zero-depth-gradient boundary flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.": [
+        "chf-zdg",
+        "olf-zdg",
+        "swf-zdg"
+      ]
     }
   },
   "print_format": {
     "options": {
-      "chf-oc": "keyword to specify format for printing to the listing file.",
-      "gwe-oc": "keyword to specify format for printing to the listing file.",
-      "gwf-oc": "keyword to specify format for printing to the listing file.",
-      "gwt-ist": "keyword to specify format for printing to the listing file.",
-      "gwt-oc": "keyword to specify format for printing to the listing file.",
-      "olf-oc": "keyword to specify format for printing to the listing file.",
-      "swf-oc": "keyword to specify format for printing to the listing file."
+      "keyword to specify format for printing to the listing file.": [
+        "chf-oc",
+        "gwe-oc",
+        "gwf-oc",
+        "gwt-ist",
+        "gwt-oc",
+        "olf-oc",
+        "swf-oc"
+      ]
     }
   },
   "print_head": {
     "options": {
-      "gwf-maw": "keyword to indicate that the list of multi-aquifer well heads will be printed to the listing file for every stress period in which ``HEAD PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_HEAD is specified, then heads are printed for the last time step of each stress period."
+      "keyword to indicate that the list of multi-aquifer well heads will be printed to the listing file for every stress period in which ``HEAD PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_HEAD is specified, then heads are printed for the last time step of each stress period.": [
+        "gwf-maw"
+      ]
     }
   },
   "print_input": {
     "options": {
-      "chf-cdb": "keyword to indicate that the list of critical depth boundary information will be written to the listing file immediately after it is read.",
-      "chf-chd": "keyword to indicate that the list of constant-head information will be written to the listing file immediately after it is read.",
-      "chf-cxs": "keyword to indicate that the list of stream reach information will be written to the listing file immediately after it is read.",
-      "chf-evp": "keyword to indicate that the list of evaporation information will be written to the listing file immediately after it is read.",
-      "chf-flw": "keyword to indicate that the list of inflow information will be written to the listing file immediately after it is read.",
-      "chf-nam": "keyword to indicate that the list of all model stress package information will be written to the listing file immediately after it is read.",
-      "chf-pcp": "keyword to indicate that the list of precipitation information will be written to the listing file immediately after it is read.",
-      "chf-zdg": "keyword to indicate that the list of zero-depth-gradient boundary information will be written to the listing file immediately after it is read.",
-      "exg-chfgwf": "keyword to indicate that the list of exchange entries will be echoed to the listing file immediately after it is read.",
-      "exg-gwegwe": "keyword to indicate that the list of exchange entries will be echoed to the listing file immediately after it is read.",
-      "exg-gwfgwf": "keyword to indicate that the list of exchange entries will be echoed to the listing file immediately after it is read.",
-      "exg-gwtgwt": "keyword to indicate that the list of exchange entries will be echoed to the listing file immediately after it is read.",
-      "exg-olfgwf": "keyword to indicate that the list of exchange entries will be echoed to the listing file immediately after it is read.",
-      "gwe-ctp": "keyword to indicate that the list of constant temperature information will be written to the listing file immediately after it is read.",
-      "gwe-esl": "keyword to indicate that the list of energy source loading information will be written to the listing file immediately after it is read.",
-      "gwe-lke": "keyword to indicate that the list of lake information will be written to the listing file immediately after it is read.",
-      "gwe-mve": "keyword to indicate that the list of mover information will be written to the listing file immediately after it is read.",
-      "gwe-mwe": "keyword to indicate that the list of well information will be written to the listing file immediately after it is read.",
-      "gwe-nam": "keyword to indicate that the list of all model stress package information will be written to the listing file immediately after it is read.",
-      "gwe-sfe": "keyword to indicate that the list of reach information will be written to the listing file immediately after it is read.",
-      "gwe-uze": "keyword to indicate that the list of unsaturated zone flow information will be written to the listing file immediately after it is read.",
-      "gwf-api": "keyword to indicate that the list of api boundary information will be written to the listing file immediately after it is read.",
-      "gwf-chd": "keyword to indicate that the list of constant-head information will be written to the listing file immediately after it is read.",
-      "gwf-csub": "keyword to indicate that the list of CSUB information will be written to the listing file immediately after it is read.",
-      "gwf-drn": "keyword to indicate that the list of drain information will be written to the listing file immediately after it is read.",
-      "gwf-evt": "keyword to indicate that the list of evapotranspiration information will be written to the listing file immediately after it is read.",
-      "gwf-evta": "keyword to indicate that the list of evapotranspiration information will be written to the listing file immediately after it is read.",
-      "gwf-ghb": "keyword to indicate that the list of general-head boundary information will be written to the listing file immediately after it is read.",
-      "gwf-gnc": "keyword to indicate that the list of GNC information will be written to the listing file immediately after it is read.",
-      "gwf-hfb": "keyword to indicate that the list of horizontal flow barriers will be written to the listing file immediately after it is read.",
-      "gwf-lak": "keyword to indicate that the list of lake information will be written to the listing file immediately after it is read.",
-      "gwf-maw": "keyword to indicate that the list of multi-aquifer well information will be written to the listing file immediately after it is read.",
-      "gwf-mvr": "keyword to indicate that the list of MVR information will be written to the listing file immediately after it is read.",
-      "gwf-nam": "keyword to indicate that the list of all model stress package information will be written to the listing file immediately after it is read.",
-      "gwf-rch": "keyword to indicate that the list of recharge information will be written to the listing file immediately after it is read.",
-      "gwf-rcha": "keyword to indicate that the list of recharge information will be written to the listing file immediately after it is read.",
-      "gwf-riv": "keyword to indicate that the list of river information will be written to the listing file immediately after it is read.",
-      "gwf-sfr": "keyword to indicate that the list of stream reach information will be written to the listing file immediately after it is read.",
-      "gwf-uzf": "keyword to indicate that the list of UZF information will be written to the listing file immediately after it is read.",
-      "gwf-wel": "keyword to indicate that the list of well information will be written to the listing file immediately after it is read.",
-      "gwt-api": "keyword to indicate that the list of api boundary information will be written to the listing file immediately after it is read.",
-      "gwt-cnc": "keyword to indicate that the list of constant concentration information will be written to the listing file immediately after it is read.",
-      "gwt-lkt": "keyword to indicate that the list of lake information will be written to the listing file immediately after it is read.",
-      "gwt-mvt": "keyword to indicate that the list of mover information will be written to the listing file immediately after it is read.",
-      "gwt-mwt": "keyword to indicate that the list of well information will be written to the listing file immediately after it is read.",
-      "gwt-nam": "keyword to indicate that the list of all model stress package information will be written to the listing file immediately after it is read.",
-      "gwt-sft": "keyword to indicate that the list of reach information will be written to the listing file immediately after it is read.",
-      "gwt-src": "keyword to indicate that the list of mass source information will be written to the listing file immediately after it is read.",
-      "gwt-uzt": "keyword to indicate that the list of unsaturated zone flow information will be written to the listing file immediately after it is read.",
-      "olf-cdb": "keyword to indicate that the list of critical depth boundary information will be written to the listing file immediately after it is read.",
-      "olf-chd": "keyword to indicate that the list of constant-head information will be written to the listing file immediately after it is read.",
-      "olf-cxs": "keyword to indicate that the list of stream reach information will be written to the listing file immediately after it is read.",
-      "olf-evp": "keyword to indicate that the list of evaporation information will be written to the listing file immediately after it is read.",
-      "olf-flw": "keyword to indicate that the list of inflow information will be written to the listing file immediately after it is read.",
-      "olf-nam": "keyword to indicate that the list of all model stress package information will be written to the listing file immediately after it is read.",
-      "olf-pcp": "keyword to indicate that the list of precipitation information will be written to the listing file immediately after it is read.",
-      "olf-zdg": "keyword to indicate that the list of zero-depth-gradient boundary information will be written to the listing file immediately after it is read.",
-      "prt-nam": "keyword to indicate that the list of all model stress package information will be written to the listing file immediately after it is read.",
-      "prt-prp": "keyword to indicate that the list of all model stress package information will be written to the listing file immediately after it is read.",
-      "sim-nam": "keyword to activate printing of simulation input summaries to the simulation list file (mfsim.lst). With this keyword, input summaries will be written for those packages that support newer input data model routines.  Not all packages are supported yet by the newer input data model routines.",
-      "swf-cdb": "keyword to indicate that the list of critical depth boundary information will be written to the listing file immediately after it is read.",
-      "swf-chd": "keyword to indicate that the list of constant-head information will be written to the listing file immediately after it is read.",
-      "swf-cxs": "keyword to indicate that the list of stream reach information will be written to the listing file immediately after it is read.",
-      "swf-evp": "keyword to indicate that the list of evaporation information will be written to the listing file immediately after it is read.",
-      "swf-flw": "keyword to indicate that the list of inflow information will be written to the listing file immediately after it is read.",
-      "swf-nam": "keyword to indicate that the list of all model stress package information will be written to the listing file immediately after it is read.",
-      "swf-pcp": "keyword to indicate that the list of precipitation information will be written to the listing file immediately after it is read.",
-      "swf-zdg": "keyword to indicate that the list of zero-depth-gradient boundary information will be written to the listing file immediately after it is read.",
-      "utl-obs": "keyword to indicate that the list of observation information will be written to the listing file immediately after it is read.",
-      "utl-spc": "keyword to indicate that the list of spc information will be written to the listing file immediately after it is read.",
-      "utl-spca": "keyword to indicate that the list of spc information will be written to the listing file immediately after it is read.",
-      "utl-tvk": "keyword to indicate that information for each change to the hydraulic conductivity in a cell will be written to the model listing file.",
-      "utl-tvs": "keyword to indicate that information for each change to a storage property in a cell will be written to the model listing file."
+      "keyword to activate printing of simulation input summaries to the simulation list file (mfsim.lst). With this keyword, input summaries will be written for those packages that support newer input data model routines.  Not all packages are supported yet by the newer input data model routines.": [
+        "sim-nam"
+      ],
+      "keyword to indicate that information for each change to a storage property in a cell will be written to the model listing file.": [
+        "utl-tvs"
+      ],
+      "keyword to indicate that information for each change to the hydraulic conductivity in a cell will be written to the model listing file.": [
+        "utl-tvk"
+      ],
+      "keyword to indicate that the list of CSUB information will be written to the listing file immediately after it is read.": [
+        "gwf-csub"
+      ],
+      "keyword to indicate that the list of GNC information will be written to the listing file immediately after it is read.": [
+        "gwf-gnc"
+      ],
+      "keyword to indicate that the list of MVR information will be written to the listing file immediately after it is read.": [
+        "gwf-mvr"
+      ],
+      "keyword to indicate that the list of UZF information will be written to the listing file immediately after it is read.": [
+        "gwf-uzf"
+      ],
+      "keyword to indicate that the list of all model stress package information will be written to the listing file immediately after it is read.": [
+        "chf-nam",
+        "gwe-nam",
+        "gwf-nam",
+        "gwt-nam",
+        "olf-nam",
+        "prt-nam",
+        "prt-prp",
+        "swf-nam"
+      ],
+      "keyword to indicate that the list of api boundary information will be written to the listing file immediately after it is read.": [
+        "gwf-api",
+        "gwt-api"
+      ],
+      "keyword to indicate that the list of constant concentration information will be written to the listing file immediately after it is read.": [
+        "gwt-cnc"
+      ],
+      "keyword to indicate that the list of constant temperature information will be written to the listing file immediately after it is read.": [
+        "gwe-ctp"
+      ],
+      "keyword to indicate that the list of constant-head information will be written to the listing file immediately after it is read.": [
+        "chf-chd",
+        "gwf-chd",
+        "olf-chd",
+        "swf-chd"
+      ],
+      "keyword to indicate that the list of critical depth boundary information will be written to the listing file immediately after it is read.": [
+        "chf-cdb",
+        "olf-cdb",
+        "swf-cdb"
+      ],
+      "keyword to indicate that the list of drain information will be written to the listing file immediately after it is read.": [
+        "gwf-drn"
+      ],
+      "keyword to indicate that the list of energy source loading information will be written to the listing file immediately after it is read.": [
+        "gwe-esl"
+      ],
+      "keyword to indicate that the list of evaporation information will be written to the listing file immediately after it is read.": [
+        "chf-evp",
+        "olf-evp",
+        "swf-evp"
+      ],
+      "keyword to indicate that the list of evapotranspiration information will be written to the listing file immediately after it is read.": [
+        "gwf-evt",
+        "gwf-evta"
+      ],
+      "keyword to indicate that the list of exchange entries will be echoed to the listing file immediately after it is read.": [
+        "exg-chfgwf",
+        "exg-gwegwe",
+        "exg-gwfgwf",
+        "exg-gwtgwt",
+        "exg-olfgwf"
+      ],
+      "keyword to indicate that the list of general-head boundary information will be written to the listing file immediately after it is read.": [
+        "gwf-ghb"
+      ],
+      "keyword to indicate that the list of horizontal flow barriers will be written to the listing file immediately after it is read.": [
+        "gwf-hfb"
+      ],
+      "keyword to indicate that the list of inflow information will be written to the listing file immediately after it is read.": [
+        "chf-flw",
+        "olf-flw",
+        "swf-flw"
+      ],
+      "keyword to indicate that the list of lake information will be written to the listing file immediately after it is read.": [
+        "gwe-lke",
+        "gwf-lak",
+        "gwt-lkt"
+      ],
+      "keyword to indicate that the list of mass source information will be written to the listing file immediately after it is read.": [
+        "gwt-src"
+      ],
+      "keyword to indicate that the list of mover information will be written to the listing file immediately after it is read.": [
+        "gwe-mve",
+        "gwt-mvt"
+      ],
+      "keyword to indicate that the list of multi-aquifer well information will be written to the listing file immediately after it is read.": [
+        "gwf-maw"
+      ],
+      "keyword to indicate that the list of observation information will be written to the listing file immediately after it is read.": [
+        "utl-obs"
+      ],
+      "keyword to indicate that the list of precipitation information will be written to the listing file immediately after it is read.": [
+        "chf-pcp",
+        "olf-pcp",
+        "swf-pcp"
+      ],
+      "keyword to indicate that the list of reach information will be written to the listing file immediately after it is read.": [
+        "gwe-sfe",
+        "gwt-sft"
+      ],
+      "keyword to indicate that the list of recharge information will be written to the listing file immediately after it is read.": [
+        "gwf-rch",
+        "gwf-rcha"
+      ],
+      "keyword to indicate that the list of river information will be written to the listing file immediately after it is read.": [
+        "gwf-riv"
+      ],
+      "keyword to indicate that the list of spc information will be written to the listing file immediately after it is read.": [
+        "utl-spc",
+        "utl-spca"
+      ],
+      "keyword to indicate that the list of stream reach information will be written to the listing file immediately after it is read.": [
+        "chf-cxs",
+        "gwf-sfr",
+        "olf-cxs",
+        "swf-cxs"
+      ],
+      "keyword to indicate that the list of unsaturated zone flow information will be written to the listing file immediately after it is read.": [
+        "gwe-uze",
+        "gwt-uzt"
+      ],
+      "keyword to indicate that the list of well information will be written to the listing file immediately after it is read.": [
+        "gwe-mwe",
+        "gwf-wel",
+        "gwt-mwt"
+      ],
+      "keyword to indicate that the list of zero-depth-gradient boundary information will be written to the listing file immediately after it is read.": [
+        "chf-zdg",
+        "olf-zdg",
+        "swf-zdg"
+      ]
     }
   },
   "print_option": {
     "options": {
-      "sln-ims": "is a flag that controls printing of convergence information from the solver.  NONE means print nothing. SUMMARY means print only the total number of iterations and nonlinear residual reduction summaries. ALL means print linear matrix solver convergence information to the solution listing file and model specific linear matrix solver convergence information to each model listing file in addition to SUMMARY information. NONE is default if PRINT\\_OPTION is not specified.",
-      "sln-pts": "is a flag that controls printing of convergence information from the solver.  NONE means print nothing. SUMMARY means print only the total number of iterations and nonlinear residual reduction summaries. ALL means print linear matrix solver convergence information to the solution listing file and model specific linear matrix solver convergence information to each model listing file in addition to SUMMARY information. NONE is default if PRINT\\_OPTION is not specified."
+      "is a flag that controls printing of convergence information from the solver.  NONE means print nothing. SUMMARY means print only the total number of iterations and nonlinear residual reduction summaries. ALL means print linear matrix solver convergence information to the solution listing file and model specific linear matrix solver convergence information to each model listing file in addition to SUMMARY information. NONE is default if PRINT\\_OPTION is not specified.": [
+        "sln-ims",
+        "sln-pts"
+      ]
     }
   },
   "print_stage": {
     "options": {
-      "gwf-lak": "keyword to indicate that the list of lake stages will be printed to the listing file for every stress period in which ``HEAD PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_STAGE is specified, then stages are printed for the last time step of each stress period.",
-      "gwf-sfr": "keyword to indicate that the list of stream reach stages will be printed to the listing file for every stress period in which ``HEAD PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_STAGE is specified, then stages are printed for the last time step of each stress period."
+      "keyword to indicate that the list of lake stages will be printed to the listing file for every stress period in which ``HEAD PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_STAGE is specified, then stages are printed for the last time step of each stress period.": [
+        "gwf-lak"
+      ],
+      "keyword to indicate that the list of stream reach stages will be printed to the listing file for every stress period in which ``HEAD PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_STAGE is specified, then stages are printed for the last time step of each stress period.": [
+        "gwf-sfr"
+      ]
     }
   },
   "print_table": {
     "options": {
-      "utl-hpc": "keyword to indicate that the partition table will be printed to the listing file."
+      "keyword to indicate that the partition table will be printed to the listing file.": [
+        "utl-hpc"
+      ]
     }
   },
   "print_temperature": {
     "options": {
-      "gwe-lke": "keyword to indicate that the list of lake temperature will be printed to the listing file for every stress period in which ``TEMPERATURE PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_TEMPERATURE is specified, then temperature are printed for the last time step of each stress period.",
-      "gwe-mwe": "keyword to indicate that the list of well temperature will be printed to the listing file for every stress period in which ``TEMPERATURE PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_TEMPERATURE is specified, then temperature are printed for the last time step of each stress period.",
-      "gwe-sfe": "keyword to indicate that the list of reach temperatures will be printed to the listing file for every stress period in which ``TEMPERATURE PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_TEMPERATURE is specified, then temperatures are printed for the last time step of each stress period.",
-      "gwe-uze": "keyword to indicate that the list of UZF cell temperatures will be printed to the listing file for every stress period in which ``TEMPERATURE PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_TEMPERATURE is specified, then temperatures are printed for the last time step of each stress period."
+      "keyword to indicate that the list of UZF cell temperatures will be printed to the listing file for every stress period in which ``TEMPERATURE PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_TEMPERATURE is specified, then temperatures are printed for the last time step of each stress period.": [
+        "gwe-uze"
+      ],
+      "keyword to indicate that the list of lake temperature will be printed to the listing file for every stress period in which ``TEMPERATURE PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_TEMPERATURE is specified, then temperature are printed for the last time step of each stress period.": [
+        "gwe-lke"
+      ],
+      "keyword to indicate that the list of reach temperatures will be printed to the listing file for every stress period in which ``TEMPERATURE PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_TEMPERATURE is specified, then temperatures are printed for the last time step of each stress period.": [
+        "gwe-sfe"
+      ],
+      "keyword to indicate that the list of well temperature will be printed to the listing file for every stress period in which ``TEMPERATURE PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_TEMPERATURE is specified, then temperature are printed for the last time step of each stress period.": [
+        "gwe-mwe"
+      ]
     }
   },
   "profile_option": {
     "options": {
-      "sim-nam": "is a flag that controls performance profiling and reporting.  NONE disables profiling. SUMMARY means to measure and print a coarse performance profile. DETAIL means collect and print information with the highest resolution available. NONE is default if PROFILE\\_OPTION is not specified."
+      "is a flag that controls performance profiling and reporting.  NONE disables profiling. SUMMARY means to measure and print a coarse performance profile. DETAIL means collect and print information with the highest resolution available. NONE is default if PROFILE\\_OPTION is not specified.": [
+        "sim-nam"
+      ]
     }
   },
   "qoutflow": {
     "options": {
-      "chf-oc": "keyword to specify that record corresponds to qoutflow.",
-      "olf-oc": "keyword to specify that record corresponds to qoutflow.",
-      "swf-oc": "keyword to specify that record corresponds to qoutflow."
+      "keyword to specify that record corresponds to qoutflow.": [
+        "chf-oc",
+        "olf-oc",
+        "swf-oc"
+      ]
     }
   },
   "rainfall": {
     "period": {
-      "gwe-lke": "real or character value that defines the rainfall temperature for the lake. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      "gwe-sfe": "real or character value that defines the rainfall temperature $(e.g.,\\:^{\\circ}C\\:or\\:^{\\circ}F)$ for the reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      "gwf-lak": "real or character value that defines the rainfall rate $(LT^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      "gwf-sfr": "real or character value that defines the  volumetric rate per unit area of water added by precipitation directly on the streamflow routing reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, rainfall  rates are zero for each reach.",
-      "gwt-lkt": "real or character value that defines the rainfall solute concentration $(ML^{-3})$ for the lake. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      "gwt-sft": "real or character value that defines the rainfall solute concentration $(ML^{-3})$ for the reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+      "real or character value that defines the  volumetric rate per unit area of water added by precipitation directly on the streamflow routing reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, rainfall  rates are zero for each reach.": [
+        "gwf-sfr"
+      ],
+      "real or character value that defines the rainfall rate $(LT^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+        "gwf-lak"
+      ],
+      "real or character value that defines the rainfall solute concentration $(ML^{-3})$ for the lake. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+        "gwt-lkt"
+      ],
+      "real or character value that defines the rainfall solute concentration $(ML^{-3})$ for the reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+        "gwt-sft"
+      ],
+      "real or character value that defines the rainfall temperature $(e.g.,\\:^{\\circ}C\\:or\\:^{\\circ}F)$ for the reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+        "gwe-sfe"
+      ],
+      "real or character value that defines the rainfall temperature for the lake. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+        "gwe-lke"
+      ]
     }
   },
   "rate": {
     "period": {
-      "gwe-mwe": "real or character value that defines the injection temperature $(e.g.,\\:^{\\circ}C\\:or\\:^{\\circ}F)$ for the well. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      "gwf-evta": "is the maximum ET flux rate ($LT^{-1}$).",
-      "gwf-lak": "real or character value that defines the extraction rate for the lake outflow. A positive value indicates inflow and a negative value indicates outflow from the lake. RATE only applies to outlets associated with active lakes (STATUS is ACTIVE). A specified RATE is only applied if COUTTYPE for the OUTLETNO is SPECIFIED. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, the RATE for each SPECIFIED lake outlet is zero.",
-      "gwf-maw": "is the volumetric pumping rate for the multi-aquifer well. A positive value indicates recharge and a negative value indicates discharge (pumping). RATE only applies to active (STATUS is ACTIVE) multi-aquifer wells. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, the RATE for each multi-aquifer well is zero.",
-      "gwt-mwt": "real or character value that defines the injection solute concentration $(ML^{-3})$ for the well. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+      "is the maximum ET flux rate ($LT^{-1}$).": [
+        "gwf-evta"
+      ],
+      "is the volumetric pumping rate for the multi-aquifer well. A positive value indicates recharge and a negative value indicates discharge (pumping). RATE only applies to active (STATUS is ACTIVE) multi-aquifer wells. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, the RATE for each multi-aquifer well is zero.": [
+        "gwf-maw"
+      ],
+      "real or character value that defines the extraction rate for the lake outflow. A positive value indicates inflow and a negative value indicates outflow from the lake. RATE only applies to outlets associated with active lakes (STATUS is ACTIVE). A specified RATE is only applied if COUTTYPE for the OUTLETNO is SPECIFIED. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, the RATE for each SPECIFIED lake outlet is zero.": [
+        "gwf-lak"
+      ],
+      "real or character value that defines the injection solute concentration $(ML^{-3})$ for the well. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+        "gwt-mwt"
+      ],
+      "real or character value that defines the injection temperature $(e.g.,\\:^{\\circ}C\\:or\\:^{\\circ}F)$ for the well. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+        "gwe-mwe"
+      ]
     }
   },
   "rate_scaling": {
     "period": {
-      "gwf-maw": "activate rate scaling.  If RATE\\_SCALING is specified, both PUMP\\_ELEVATION and SCALING\\_LENGTH must be specified. RATE\\_SCALING cannot be used with HEAD\\_LIMIT.  RATE\\_SCALING can be used for extraction or injection wells.  For extraction wells, the extraction rate will start to decrease once the head in the well lowers to a level equal to the pump elevation plus the scaling length.  If the head in the well drops below the pump elevation, then the extraction rate is calculated to be zero.  For an injection well, the injection rate will begin to decrease once the head in the well rises above the specified pump elevation.  If the head in the well rises above the pump elevation plus the scaling length, then the injection rate will be set to zero."
+      "activate rate scaling.  If RATE\\_SCALING is specified, both PUMP\\_ELEVATION and SCALING\\_LENGTH must be specified. RATE\\_SCALING cannot be used with HEAD\\_LIMIT.  RATE\\_SCALING can be used for extraction or injection wells.  For extraction wells, the extraction rate will start to decrease once the head in the well lowers to a level equal to the pump elevation plus the scaling length.  If the head in the well drops below the pump elevation, then the extraction rate is calculated to be zero.  For an injection well, the injection rate will begin to decrease once the head in the well rises above the specified pump elevation.  If the head in the well rises above the pump elevation plus the scaling length, then the injection rate will be set to zero.": [
+        "gwf-maw"
+      ]
     }
   },
   "readasarrays": {
     "options": {
-      "gwf-evta": "indicates that array-based input will be used for the Evapotranspiration Package.  This keyword must be specified to use array-based input.  When READASARRAYS is specified, values must be provided for every cell within a model layer, even those cells that have an IDOMAIN value less than one.  Values assigned to cells with IDOMAIN values less than one are not used and have no effect on simulation results.",
-      "gwf-rcha": "indicates that array-based input will be used for the Recharge Package.  This keyword must be specified to use array-based input.  When READASARRAYS is specified, values must be provided for every cell within a model layer, even those cells that have an IDOMAIN value less than one.  Values assigned to cells with IDOMAIN values less than one are not used and have no effect on simulation results. ",
-      "utl-spca": "indicates that array-based input will be used for the SPC Package.  This keyword must be specified to use array-based input.  When READASARRAYS is specified, values must be provided for every cell within a model layer, even those cells that have an IDOMAIN value less than one.  Values assigned to cells with IDOMAIN values less than one are not used and have no effect on simulation results."
+      "indicates that array-based input will be used for the Evapotranspiration Package.  This keyword must be specified to use array-based input.  When READASARRAYS is specified, values must be provided for every cell within a model layer, even those cells that have an IDOMAIN value less than one.  Values assigned to cells with IDOMAIN values less than one are not used and have no effect on simulation results.": [
+        "gwf-evta"
+      ],
+      "indicates that array-based input will be used for the Recharge Package.  This keyword must be specified to use array-based input.  When READASARRAYS is specified, values must be provided for every cell within a model layer, even those cells that have an IDOMAIN value less than one.  Values assigned to cells with IDOMAIN values less than one are not used and have no effect on simulation results. ": [
+        "gwf-rcha"
+      ],
+      "indicates that array-based input will be used for the SPC Package.  This keyword must be specified to use array-based input.  When READASARRAYS is specified, values must be provided for every cell within a model layer, even those cells that have an IDOMAIN value less than one.  Values assigned to cells with IDOMAIN values less than one are not used and have no effect on simulation results.": [
+        "utl-spca"
+      ]
     }
   },
   "recharge": {
     "period": {
-      "gwf-rcha": "is the recharge flux rate ($LT^{-1}$).  This rate is multiplied inside the program by the surface area of the cell to calculate the volumetric recharge rate. The recharge array may be defined by a time-array series (see the ``Using Time-Array Series in a Package'' section)."
+      "is the recharge flux rate ($LT^{-1}$).  This rate is multiplied inside the program by the surface area of the cell to calculate the volumetric recharge rate. The recharge array may be defined by a time-array series (see the ``Using Time-Array Series in a Package'' section).": [
+        "gwf-rcha"
+      ]
     }
   },
   "relaxation_factor": {
     "linear": {
-      "sln-ims": "optional real value that defines the relaxation factor used by the incomplete LU factorization preconditioners (MILU(0) and MILUT). RELAXATION\\_FACTOR is unitless and should be greater than or equal to 0.0 and less than or equal to 1.0. RELAXATION\\_FACTOR values of about 1.0 are commonly used, and experience suggests that convergence can be optimized in some cases with relax values of 0.97. A RELAXATION\\_FACTOR value of 0.0 will result in either ILU(0) or ILUT preconditioning (depending on the value specified for PRECONDITIONER\\_LEVELS and/or PRECONDITIONER\\_DROP\\_TOLERANCE). By default,  RELAXATION\\_FACTOR is zero."
+      "optional real value that defines the relaxation factor used by the incomplete LU factorization preconditioners (MILU(0) and MILUT). RELAXATION\\_FACTOR is unitless and should be greater than or equal to 0.0 and less than or equal to 1.0. RELAXATION\\_FACTOR values of about 1.0 are commonly used, and experience suggests that convergence can be optimized in some cases with relax values of 0.97. A RELAXATION\\_FACTOR value of 0.0 will result in either ILU(0) or ILUT preconditioning (depending on the value specified for PRECONDITIONER\\_LEVELS and/or PRECONDITIONER\\_DROP\\_TOLERANCE). By default,  RELAXATION\\_FACTOR is zero.": [
+        "sln-ims"
+      ]
     }
   },
   "release_time_frequency": {
     "options": {
-      "prt-prp": "real number indicating the time frequency at which to release particles. This option can be used to schedule releases at a regular interval for the duration of the simulation, starting at the simulation start time. The release schedule is the union of this option, the RELEASETIMES block, and PERIOD block RELEASESETTING selections. If none of these are provided, a single release time is configured at the beginning of the first time step of the simulation's first stress period."
+      "real number indicating the time frequency at which to release particles. This option can be used to schedule releases at a regular interval for the duration of the simulation, starting at the simulation start time. The release schedule is the union of this option, the RELEASETIMES block, and PERIOD block RELEASESETTING selections. If none of these are provided, a single release time is configured at the beginning of the first time step of the simulation's first stress period.": [
+        "prt-prp"
+      ]
     }
   },
   "release_time_tolerance": {
     "options": {
-      "prt-prp": "real number indicating the tolerance within which to consider consecutive release times coincident. Coincident release times will be merged into a single release time. The default is $\\epsilon \\times 10^{11}$, where $\\epsilon$ is machine precision."
+      "real number indicating the tolerance within which to consider consecutive release times coincident. Coincident release times will be merged into a single release time. The default is $\\epsilon \\times 10^{11}$, where $\\epsilon$ is machine precision.": [
+        "prt-prp"
+      ]
     }
   },
   "reordering_method": {
     "linear": {
-      "sln-ims": "an optional keyword that defines the matrix reordering approach used. By default, matrix reordering is not applied.  NONE - original ordering.  RCM - reverse Cuthill McKee ordering.  MD - minimum degree ordering."
+      "an optional keyword that defines the matrix reordering approach used. By default, matrix reordering is not applied.  NONE - original ordering.  RCM - reverse Cuthill McKee ordering.  MD - minimum degree ordering.": [
+        "sln-ims"
+      ]
     }
   },
   "retfactor": {
     "griddata": {
-      "prt-mip": "is a real value by which velocity is divided within a given cell.  RETFACTOR can be used to account for solute retardation, i.e., the apparent effect of linear sorption on the velocity of particles that track solute advection.  RETFACTOR may be assigned any real value.  A RETFACTOR value greater than 1 represents particle retardation (slowing), and a value of 1 represents no retardation.  The effect of specifying a RETFACTOR value for each cell is the same as the effect of directly multiplying the POROSITY in each cell by the proposed RETFACTOR value for each cell.  RETFACTOR allows conceptual isolation of effects such as retardation from the effect of porosity.  The default value is 1."
+      "is a real value by which velocity is divided within a given cell.  RETFACTOR can be used to account for solute retardation, i.e., the apparent effect of linear sorption on the velocity of particles that track solute advection.  RETFACTOR may be assigned any real value.  A RETFACTOR value greater than 1 represents particle retardation (slowing), and a value of 1 represents no retardation.  The effect of specifying a RETFACTOR value for each cell is the same as the effect of directly multiplying the POROSITY in each cell by the proposed RETFACTOR value for each cell.  RETFACTOR allows conceptual isolation of effects such as retardation from the effect of porosity.  The default value is 1.": [
+        "prt-mip"
+      ]
     }
   },
   "rewet": {
     "options": {
-      "gwf-npf": "activates model rewetting.  Rewetting is off by default."
+      "activates model rewetting.  Rewetting is off by default.": [
+        "gwf-npf"
+      ]
     }
   },
   "rhs": {
     "options": {
-      "gwf-npf": "If the RHS keyword is also included, then the XT3D additional terms will be added to the right-hand side.  If the RHS keyword is excluded, then the XT3D terms will be put into the coefficient matrix."
+      "If the RHS keyword is also included, then the XT3D additional terms will be added to the right-hand side.  If the RHS keyword is excluded, then the XT3D terms will be put into the coefficient matrix.": [
+        "gwf-npf"
+      ]
     }
   },
   "rough": {
     "period": {
-      "gwf-lak": "real value that defines the roughness coefficient for the lake outlet. Any value can be specified if COUTTYPE is not MANNING. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+      "real value that defines the roughness coefficient for the lake outlet. Any value can be specified if COUTTYPE is not MANNING. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+        "gwf-lak"
+      ]
     }
   },
   "runoff": {
     "period": {
-      "gwe-sfe": "real or character value that defines the temperature of runoff $(e.g.,\\:^{\\circ}C\\:or\\:^{\\circ}F)$ for the reach.  Users are free to use whatever temperature scale they want, which might include negative temperatures.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      "gwf-lak": "real or character value that defines the runoff rate $(L^3 T^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      "gwf-sfr": "real or character value that defines the volumetric rate of diffuse overland runoff that enters the streamflow routing reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. If the volumetric runoff rate for a reach is negative and exceeds inflows to the reach (upstream and specified inflows, and rainfall but excluding groundwater leakage into the reach) the volumetric runoff rate is limited to inflows to the reach and the volumetric evaporation rate for the reach is set to zero. By default, runoff rates are zero for each reach.",
-      "gwt-lkt": "real or character value that defines the concentration of runoff $(ML^{-3})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      "gwt-sft": "real or character value that defines the concentration of runoff $(ML^{-3})$ for the reach. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+      "real or character value that defines the concentration of runoff $(ML^{-3})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+        "gwt-lkt"
+      ],
+      "real or character value that defines the concentration of runoff $(ML^{-3})$ for the reach. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+        "gwt-sft"
+      ],
+      "real or character value that defines the runoff rate $(L^3 T^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+        "gwf-lak"
+      ],
+      "real or character value that defines the temperature of runoff $(e.g.,\\:^{\\circ}C\\:or\\:^{\\circ}F)$ for the reach.  Users are free to use whatever temperature scale they want, which might include negative temperatures.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+        "gwe-sfe"
+      ],
+      "real or character value that defines the volumetric rate of diffuse overland runoff that enters the streamflow routing reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. If the volumetric runoff rate for a reach is negative and exceeds inflows to the reach (upstream and specified inflows, and rainfall but excluding groundwater leakage into the reach) the volumetric runoff rate is limited to inflows to the reach and the volumetric evaporation rate for the reach is set to zero. By default, runoff rates are zero for each reach.": [
+        "gwf-sfr"
+      ]
     }
   },
   "save": {
     "period": {
-      "chf-oc": "keyword to indicate that information will be saved this stress period.",
-      "gwe-oc": "keyword to indicate that information will be saved this stress period.",
-      "gwf-oc": "keyword to indicate that information will be saved this stress period.",
-      "gwt-oc": "keyword to indicate that information will be saved this stress period.",
-      "olf-oc": "keyword to indicate that information will be saved this stress period.",
-      "prt-oc": "keyword to indicate that information will be saved this stress period.",
-      "swf-oc": "keyword to indicate that information will be saved this stress period."
+      "keyword to indicate that information will be saved this stress period.": [
+        "chf-oc",
+        "gwe-oc",
+        "gwf-oc",
+        "gwt-oc",
+        "olf-oc",
+        "prt-oc",
+        "swf-oc"
+      ]
     }
   },
   "save_flows": {
     "options": {
-      "chf-cdb": "keyword to indicate that critical depth boundary flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "chf-chd": "keyword to indicate that constant-head flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "chf-dfw": "keyword to indicate that budget flow terms will be written to the file specified with ``BUDGET SAVE FILE'' in Output Control.",
-      "chf-evp": "keyword to indicate that evaporation flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "chf-flw": "keyword to indicate that inflow flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "chf-nam": "keyword to indicate that all model package flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "chf-pcp": "keyword to indicate that precipitation flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "chf-sto": "keyword to indicate that cell-by-cell flow terms will be written to the file specified with ``BUDGET SAVE FILE'' in Output Control.",
-      "chf-zdg": "keyword to indicate that zero-depth-gradient boundary flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "exg-gwegwe": "keyword to indicate that cell-by-cell flow terms will be written to the budget file for each model provided that the Output Control for the models are set up with the ``BUDGET SAVE FILE'' option.",
-      "exg-gwfgwf": "keyword to indicate that cell-by-cell flow terms will be written to the budget file for each model provided that the Output Control for the models are set up with the ``BUDGET SAVE FILE'' option.",
-      "exg-gwtgwt": "keyword to indicate that cell-by-cell flow terms will be written to the budget file for each model provided that the Output Control for the models are set up with the ``BUDGET SAVE FILE'' option.",
-      "gwe-ctp": "keyword to indicate that constant temperature flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "gwe-esl": "keyword to indicate that energy source loading flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "gwe-est": "keyword to indicate that EST flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "gwe-fmi": "keyword to indicate that FMI flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "gwe-lke": "keyword to indicate that lake flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "gwe-mve": "keyword to indicate that lake flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "gwe-mwe": "keyword to indicate that well flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "gwe-nam": "keyword to indicate that all model package flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "gwe-sfe": "keyword to indicate that reach flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "gwe-ssm": "keyword to indicate that SSM flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "gwe-uze": "keyword to indicate that unsaturated zone flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "gwf-api": "keyword to indicate that api boundary flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "gwf-chd": "keyword to indicate that constant-head flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "gwf-csub": "keyword to indicate that cell-by-cell flow terms will be written to the file specified with ``BUDGET SAVE FILE'' in Output Control.",
-      "gwf-drn": "keyword to indicate that drain flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "gwf-evt": "keyword to indicate that evapotranspiration flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "gwf-evta": "keyword to indicate that evapotranspiration flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "gwf-ghb": "keyword to indicate that general-head boundary flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "gwf-lak": "keyword to indicate that lake flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "gwf-maw": "keyword to indicate that multi-aquifer well flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "gwf-nam": "keyword to indicate that all model package flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "gwf-npf": "keyword to indicate that budget flow terms will be written to the file specified with ``BUDGET SAVE FILE'' in Output Control.",
-      "gwf-rch": "keyword to indicate that recharge flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "gwf-rcha": "keyword to indicate that recharge flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "gwf-riv": "keyword to indicate that river flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "gwf-sfr": "keyword to indicate that stream reach flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "gwf-sto": "keyword to indicate that cell-by-cell flow terms will be written to the file specified with ``BUDGET SAVE FILE'' in Output Control.",
-      "gwf-uzf": "keyword to indicate that UZF flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "gwf-wel": "keyword to indicate that well flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "gwt-api": "keyword to indicate that api boundary flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "gwt-cnc": "keyword to indicate that constant concentration flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "gwt-fmi": "keyword to indicate that FMI flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "gwt-ist": "keyword to indicate that IST flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "gwt-lkt": "keyword to indicate that lake flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "gwt-mst": "keyword to indicate that MST flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "gwt-mvt": "keyword to indicate that lake flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "gwt-mwt": "keyword to indicate that well flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "gwt-nam": "keyword to indicate that all model package flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "gwt-sft": "keyword to indicate that reach flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "gwt-src": "keyword to indicate that mass source flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "gwt-ssm": "keyword to indicate that SSM flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "gwt-uzt": "keyword to indicate that unsaturated zone flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "olf-cdb": "keyword to indicate that critical depth boundary flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "olf-chd": "keyword to indicate that constant-head flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "olf-dfw": "keyword to indicate that budget flow terms will be written to the file specified with ``BUDGET SAVE FILE'' in Output Control.",
-      "olf-evp": "keyword to indicate that evaporation flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "olf-flw": "keyword to indicate that inflow flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "olf-nam": "keyword to indicate that all model package flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "olf-pcp": "keyword to indicate that precipitation flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "olf-sto": "keyword to indicate that cell-by-cell flow terms will be written to the file specified with ``BUDGET SAVE FILE'' in Output Control.",
-      "olf-zdg": "keyword to indicate that zero-depth-gradient boundary flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "prt-fmi": "keyword to indicate that FMI flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "prt-nam": "keyword to indicate that all model package flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "swf-cdb": "keyword to indicate that critical depth boundary flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "swf-chd": "keyword to indicate that constant-head flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "swf-dfw": "keyword to indicate that budget flow terms will be written to the file specified with ``BUDGET SAVE FILE'' in Output Control.",
-      "swf-evp": "keyword to indicate that evaporation flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "swf-flw": "keyword to indicate that inflow flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "swf-nam": "keyword to indicate that all model package flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "swf-pcp": "keyword to indicate that precipitation flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      "swf-sto": "keyword to indicate that cell-by-cell flow terms will be written to the file specified with ``BUDGET SAVE FILE'' in Output Control.",
-      "swf-zdg": "keyword to indicate that zero-depth-gradient boundary flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control."
+      "keyword to indicate that EST flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+        "gwe-est"
+      ],
+      "keyword to indicate that FMI flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+        "gwe-fmi",
+        "gwt-fmi",
+        "prt-fmi"
+      ],
+      "keyword to indicate that IST flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+        "gwt-ist"
+      ],
+      "keyword to indicate that MST flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+        "gwt-mst"
+      ],
+      "keyword to indicate that SSM flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+        "gwe-ssm",
+        "gwt-ssm"
+      ],
+      "keyword to indicate that UZF flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+        "gwf-uzf"
+      ],
+      "keyword to indicate that all model package flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+        "chf-nam",
+        "gwe-nam",
+        "gwf-nam",
+        "gwt-nam",
+        "olf-nam",
+        "prt-nam",
+        "swf-nam"
+      ],
+      "keyword to indicate that api boundary flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+        "gwf-api",
+        "gwt-api"
+      ],
+      "keyword to indicate that budget flow terms will be written to the file specified with ``BUDGET SAVE FILE'' in Output Control.": [
+        "chf-dfw",
+        "gwf-npf",
+        "olf-dfw",
+        "swf-dfw"
+      ],
+      "keyword to indicate that cell-by-cell flow terms will be written to the budget file for each model provided that the Output Control for the models are set up with the ``BUDGET SAVE FILE'' option.": [
+        "exg-gwegwe",
+        "exg-gwfgwf",
+        "exg-gwtgwt"
+      ],
+      "keyword to indicate that cell-by-cell flow terms will be written to the file specified with ``BUDGET SAVE FILE'' in Output Control.": [
+        "chf-sto",
+        "gwf-csub",
+        "gwf-sto",
+        "olf-sto",
+        "swf-sto"
+      ],
+      "keyword to indicate that constant concentration flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+        "gwt-cnc"
+      ],
+      "keyword to indicate that constant temperature flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+        "gwe-ctp"
+      ],
+      "keyword to indicate that constant-head flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+        "chf-chd",
+        "gwf-chd",
+        "olf-chd",
+        "swf-chd"
+      ],
+      "keyword to indicate that critical depth boundary flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+        "chf-cdb",
+        "olf-cdb",
+        "swf-cdb"
+      ],
+      "keyword to indicate that drain flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+        "gwf-drn"
+      ],
+      "keyword to indicate that energy source loading flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+        "gwe-esl"
+      ],
+      "keyword to indicate that evaporation flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+        "chf-evp",
+        "olf-evp",
+        "swf-evp"
+      ],
+      "keyword to indicate that evapotranspiration flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+        "gwf-evt",
+        "gwf-evta"
+      ],
+      "keyword to indicate that general-head boundary flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+        "gwf-ghb"
+      ],
+      "keyword to indicate that inflow flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+        "chf-flw",
+        "olf-flw",
+        "swf-flw"
+      ],
+      "keyword to indicate that lake flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+        "gwe-lke",
+        "gwe-mve",
+        "gwf-lak",
+        "gwt-lkt",
+        "gwt-mvt"
+      ],
+      "keyword to indicate that mass source flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+        "gwt-src"
+      ],
+      "keyword to indicate that multi-aquifer well flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+        "gwf-maw"
+      ],
+      "keyword to indicate that precipitation flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+        "chf-pcp",
+        "olf-pcp",
+        "swf-pcp"
+      ],
+      "keyword to indicate that reach flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+        "gwe-sfe",
+        "gwt-sft"
+      ],
+      "keyword to indicate that recharge flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+        "gwf-rch",
+        "gwf-rcha"
+      ],
+      "keyword to indicate that river flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+        "gwf-riv"
+      ],
+      "keyword to indicate that stream reach flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+        "gwf-sfr"
+      ],
+      "keyword to indicate that unsaturated zone flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+        "gwe-uze",
+        "gwt-uzt"
+      ],
+      "keyword to indicate that well flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+        "gwe-mwe",
+        "gwf-wel",
+        "gwt-mwt"
+      ],
+      "keyword to indicate that zero-depth-gradient boundary flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+        "chf-zdg",
+        "olf-zdg",
+        "swf-zdg"
+      ]
     }
   },
   "save_saturation": {
     "options": {
-      "gwf-npf": "keyword to indicate that cell saturation will be written to the budget file, which is specified with ``BUDGET SAVE FILE'' in Output Control.  Saturation will be saved to the budget file as an auxiliary variable saved with the DATA-SAT text label.  Saturation is a cell variable that ranges from zero to one and can be used by post processing programs to determine how much of a cell volume is saturated.  If ICELLTYPE is 0, then saturation is always one."
+      "keyword to indicate that cell saturation will be written to the budget file, which is specified with ``BUDGET SAVE FILE'' in Output Control.  Saturation will be saved to the budget file as an auxiliary variable saved with the DATA-SAT text label.  Saturation is a cell variable that ranges from zero to one and can be used by post processing programs to determine how much of a cell volume is saturated.  If ICELLTYPE is 0, then saturation is always one.": [
+        "gwf-npf"
+      ]
     }
   },
   "save_specific_discharge": {
     "options": {
-      "gwf-npf": "keyword to indicate that x, y, and z components of specific discharge will be calculated at cell centers and written to the budget file, which is specified with ``BUDGET SAVE FILE'' in Output Control.  If this option is activated, then additional information may be required in the discretization packages and the GWF Exchange package (if GWF models are coupled).  Specifically, ANGLDEGX must be specified in the CONNECTIONDATA block of the DISU Package; ANGLDEGX must also be specified for the GWF Exchange as an auxiliary variable."
+      "keyword to indicate that x, y, and z components of specific discharge will be calculated at cell centers and written to the budget file, which is specified with ``BUDGET SAVE FILE'' in Output Control.  If this option is activated, then additional information may be required in the discretization packages and the GWF Exchange package (if GWF models are coupled).  Specifically, ANGLDEGX must be specified in the CONNECTIONDATA block of the DISU Package; ANGLDEGX must also be specified for the GWF Exchange as an auxiliary variable.": [
+        "gwf-npf"
+      ]
     }
   },
   "save_velocity": {
     "options": {
-      "chf-dfw": "keyword to indicate that x, y, and z components of velocity will be calculated at cell centers and written to the budget file, which is specified with ``BUDGET SAVE FILE'' in Output Control.  If this option is activated, then additional information may be required in the discretization packages and the GWF Exchange package (if GWF models are coupled).  Specifically, ANGLDEGX must be specified in the CONNECTIONDATA block of the DISU Package; ANGLDEGX must also be specified for the GWF Exchange as an auxiliary variable.",
-      "olf-dfw": "keyword to indicate that x, y, and z components of velocity will be calculated at cell centers and written to the budget file, which is specified with ``BUDGET SAVE FILE'' in Output Control.  If this option is activated, then additional information may be required in the discretization packages and the GWF Exchange package (if GWF models are coupled).  Specifically, ANGLDEGX must be specified in the CONNECTIONDATA block of the DISU Package; ANGLDEGX must also be specified for the GWF Exchange as an auxiliary variable.",
-      "swf-dfw": "keyword to indicate that x, y, and z components of velocity will be calculated at cell centers and written to the budget file, which is specified with ``BUDGET SAVE FILE'' in Output Control.  If this option is activated, then additional information may be required in the discretization packages and the GWF Exchange package (if GWF models are coupled).  Specifically, ANGLDEGX must be specified in the CONNECTIONDATA block of the DISU Package; ANGLDEGX must also be specified for the GWF Exchange as an auxiliary variable."
+      "keyword to indicate that x, y, and z components of velocity will be calculated at cell centers and written to the budget file, which is specified with ``BUDGET SAVE FILE'' in Output Control.  If this option is activated, then additional information may be required in the discretization packages and the GWF Exchange package (if GWF models are coupled).  Specifically, ANGLDEGX must be specified in the CONNECTIONDATA block of the DISU Package; ANGLDEGX must also be specified for the GWF Exchange as an auxiliary variable.": [
+        "chf-dfw",
+        "olf-dfw",
+        "swf-dfw"
+      ]
     }
   },
   "scaling_method": {
     "linear": {
-      "sln-ims": "an optional keyword that defines the matrix scaling approach used. By default, matrix scaling is not applied.  NONE - no matrix scaling applied.  DIAGONAL - symmetric matrix scaling using the POLCG preconditioner scaling method in Hill (1992).  L2NORM - symmetric matrix scaling using the L2 norm."
+      "an optional keyword that defines the matrix scaling approach used. By default, matrix scaling is not applied.  NONE - no matrix scaling applied.  DIAGONAL - symmetric matrix scaling using the POLCG preconditioner scaling method in Hill (1992).  L2NORM - symmetric matrix scaling using the L2 norm.": [
+        "sln-ims"
+      ]
     }
   },
   "scheme": {
     "options": {
-      "gwe-adv": "scheme used to solve the advection term.  Can be upstream, central, or TVD.  If not specified, upstream weighting is the default weighting scheme.",
-      "gwt-adv": "scheme used to solve the advection term.  Can be upstream, central, or TVD.  If not specified, upstream weighting is the default weighting scheme."
+      "scheme used to solve the advection term.  Can be upstream, central, or TVD.  If not specified, upstream weighting is the default weighting scheme.": [
+        "gwe-adv",
+        "gwt-adv"
+      ]
     }
   },
   "sfac": {
     "attributes": {
-      "utl-tas": "xxx"
+      "xxx": [
+        "utl-tas"
+      ]
     }
   },
   "sfacs": {
     "attributes": {
-      "utl-ts": "xxx"
+      "xxx": [
+        "utl-ts"
+      ]
     }
   },
   "sgm": {
     "griddata": {
-      "gwf-csub": "is the specific gravity of moist or unsaturated sediments.  If not specified, then a default value of 1.7 is assigned."
+      "is the specific gravity of moist or unsaturated sediments.  If not specified, then a default value of 1.7 is assigned.": [
+        "gwf-csub"
+      ]
     }
   },
   "sgs": {
     "griddata": {
-      "gwf-csub": "is the specific gravity of saturated sediments. If not specified, then a default value of 2.0 is assigned."
+      "is the specific gravity of saturated sediments. If not specified, then a default value of 2.0 is assigned.": [
+        "gwf-csub"
+      ]
     }
   },
   "shuffle": {
     "options": {
-      "utl-ncf": "is the keyword used to turn on the netcdf variable shuffle filter when the deflate option is also set. The shuffle filter has the effect of storing the first byte of all of a variable's values in a chunk contiguously, followed by all the second bytes, etc. This can be an optimization for compression with certain types of data."
+      "is the keyword used to turn on the netcdf variable shuffle filter when the deflate option is also set. The shuffle filter has the effect of storing the first byte of all of a variable's values in a chunk contiguously, followed by all the second bytes, etc. This can be an optimization for compression with certain types of data.": [
+        "utl-ncf"
+      ]
     }
   },
   "shut_off": {
     "period": {
-      "gwf-maw": "keyword for activating well shut off capability.  Subsequent values define the minimum and maximum pumping rate that a well must exceed to shutoff or reactivate a well, respectively, during a stress period. SHUT\\_OFF is only applied to injection wells (RATE$<0$) and if HEAD\\_LIMIT is specified (not set to `OFF').  If HEAD\\_LIMIT is specified, SHUT\\_OFF can be deactivated by specifying a minimum value equal to zero. The SHUT\\_OFF option is based on the SHUT\\_OFF functionality available in the MNW2~\\citep{konikow2009} package for MODFLOW-2005. The SHUT\\_OFF option has been included to facilitate backward compatibility with previous versions of MODFLOW but use of the RATE\\_SCALING option instead of the SHUT\\_OFF option is recommended. By default, SHUT\\_OFF is not used."
+      "keyword for activating well shut off capability.  Subsequent values define the minimum and maximum pumping rate that a well must exceed to shutoff or reactivate a well, respectively, during a stress period. SHUT\\_OFF is only applied to injection wells (RATE$<0$) and if HEAD\\_LIMIT is specified (not set to `OFF').  If HEAD\\_LIMIT is specified, SHUT\\_OFF can be deactivated by specifying a minimum value equal to zero. The SHUT\\_OFF option is based on the SHUT\\_OFF functionality available in the MNW2~\\citep{konikow2009} package for MODFLOW-2005. The SHUT\\_OFF option has been included to facilitate backward compatibility with previous versions of MODFLOW but use of the RATE\\_SCALING option instead of the SHUT\\_OFF option is recommended. By default, SHUT\\_OFF is not used.": [
+        "gwf-maw"
+      ]
     }
   },
   "shutdown_kappa": {
     "options": {
-      "gwf-maw": "value that defines the weight applied to discharge rate for wells that limit the water level in a discharging well (defined using the HEAD\\_LIMIT keyword in the stress period data). SHUTDOWN\\_KAPPA is used to control discharge rate oscillations when the flow rate from the aquifer is less than the specified flow rate from the aquifer to the well. Values range between 0.0 and 1.0, and larger values increase the weight applied to the well discharge rate. The HEAD\\_LIMIT option has been included to facilitate backward compatibility with previous versions of MODFLOW but use of the RATE\\_SCALING option instead of the HEAD\\_LIMIT option is recommended. By default, SHUTDOWN\\_KAPPA is 0.0001."
+      "value that defines the weight applied to discharge rate for wells that limit the water level in a discharging well (defined using the HEAD\\_LIMIT keyword in the stress period data). SHUTDOWN\\_KAPPA is used to control discharge rate oscillations when the flow rate from the aquifer is less than the specified flow rate from the aquifer to the well. Values range between 0.0 and 1.0, and larger values increase the weight applied to the well discharge rate. The HEAD\\_LIMIT option has been included to facilitate backward compatibility with previous versions of MODFLOW but use of the RATE\\_SCALING option instead of the HEAD\\_LIMIT option is recommended. By default, SHUTDOWN\\_KAPPA is 0.0001.": [
+        "gwf-maw"
+      ]
     }
   },
   "shutdown_theta": {
     "options": {
-      "gwf-maw": "value that defines the weight applied to discharge rate for wells that limit the water level in a discharging well (defined using the HEAD\\_LIMIT keyword in the stress period data). SHUTDOWN\\_THETA is used to control discharge rate oscillations when the flow rate from the aquifer is less than the specified flow rate from the aquifer to the well. Values range between 0.0 and 1.0, and larger values increase the weight (decrease under-relaxation) applied to the well discharge rate. The HEAD\\_LIMIT option has been included to facilitate backward compatibility with previous versions of MODFLOW but use of the RATE\\_SCALING option instead of the HEAD\\_LIMIT option is recommended. By default, SHUTDOWN\\_THETA is 0.7."
+      "value that defines the weight applied to discharge rate for wells that limit the water level in a discharging well (defined using the HEAD\\_LIMIT keyword in the stress period data). SHUTDOWN\\_THETA is used to control discharge rate oscillations when the flow rate from the aquifer is less than the specified flow rate from the aquifer to the well. Values range between 0.0 and 1.0, and larger values increase the weight (decrease under-relaxation) applied to the well discharge rate. The HEAD\\_LIMIT option has been included to facilitate backward compatibility with previous versions of MODFLOW but use of the RATE\\_SCALING option instead of the HEAD\\_LIMIT option is recommended. By default, SHUTDOWN\\_THETA is 0.7.": [
+        "gwf-maw"
+      ]
     }
   },
   "simulate_et": {
     "options": {
-      "gwf-uzf": "keyword specifying that ET in the unsaturated (UZF) and saturated zones (GWF) will be simulated. ET can be simulated in the UZF cell and not the GWF cell by omitting keywords LINEAR\\_GWET and SQUARE\\_GWET."
+      "keyword specifying that ET in the unsaturated (UZF) and saturated zones (GWF) will be simulated. ET can be simulated in the UZF cell and not the GWF cell by omitting keywords LINEAR\\_GWET and SQUARE\\_GWET.": [
+        "gwf-uzf"
+      ]
     }
   },
   "simulate_gwseep": {
     "options": {
-      "gwf-uzf": "keyword specifying that groundwater discharge (GWSEEP) to land surface will be simulated. Groundwater discharge is nonzero when groundwater head is greater than land surface.  This option is no longer recommended; a better approach is to use the Drain Package with discharge scaling as a way to handle seepage to land surface.  The Drain Package with discharge scaling is described in Chapter 3 of the Supplemental Technical Information. "
+      "keyword specifying that groundwater discharge (GWSEEP) to land surface will be simulated. Groundwater discharge is nonzero when groundwater head is greater than land surface.  This option is no longer recommended; a better approach is to use the Drain Package with discharge scaling as a way to handle seepage to land surface.  The Drain Package with discharge scaling is described in Chapter 3 of the Supplemental Technical Information. ": [
+        "gwf-uzf"
+      ]
     }
   },
   "slope": {
     "period": {
-      "gwf-lak": "real or character value that defines the bed slope for the lake outlet. A specified SLOPE value is only used for active lakes if COUTTYPE for lake outlet OUTLETNO is MANNING. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+      "real or character value that defines the bed slope for the lake outlet. A specified SLOPE value is only used for active lakes if COUTTYPE for lake outlet OUTLETNO is MANNING. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+        "gwf-lak"
+      ]
     }
   },
   "solutiongroup": {
     "solutiongroup": {
-      "sim-nam": "is the list of solution types and models in the solution."
+      "is the list of solution types and models in the solution.": [
+        "sim-nam"
+      ]
     }
   },
   "sorbate": {
     "options": {
-      "gwt-ist": "keyword to specify that record corresponds to immobile sorbate concentration.",
-      "gwt-mst": "keyword to specify that record corresponds to sorbate concentration."
+      "keyword to specify that record corresponds to immobile sorbate concentration.": [
+        "gwt-ist"
+      ],
+      "keyword to specify that record corresponds to sorbate concentration.": [
+        "gwt-mst"
+      ]
     }
   },
   "sorption": {
     "options": {
-      "gwt-ist": "is a text keyword to indicate that sorption will be activated.  Valid sorption options include LINEAR, FREUNDLICH, and LANGMUIR.  Use of this keyword requires that BULK\\_DENSITY and DISTCOEF are specified in the GRIDDATA block.  If sorption is specified as FREUNDLICH or LANGMUIR then SP2 is also required in the GRIDDATA block.  The sorption option must be consistent with the sorption option specified in the MST Package or the program will terminate with an error.",
-      "gwt-mst": "is a text keyword to indicate that sorption will be activated.  Valid sorption options include LINEAR, FREUNDLICH, and LANGMUIR.  Use of this keyword requires that BULK\\_DENSITY and DISTCOEF are specified in the GRIDDATA block.  If sorption is specified as FREUNDLICH or LANGMUIR then SP2 is also required in the GRIDDATA block."
+      "is a text keyword to indicate that sorption will be activated.  Valid sorption options include LINEAR, FREUNDLICH, and LANGMUIR.  Use of this keyword requires that BULK\\_DENSITY and DISTCOEF are specified in the GRIDDATA block.  If sorption is specified as FREUNDLICH or LANGMUIR then SP2 is also required in the GRIDDATA block.": [
+        "gwt-mst"
+      ],
+      "is a text keyword to indicate that sorption will be activated.  Valid sorption options include LINEAR, FREUNDLICH, and LANGMUIR.  Use of this keyword requires that BULK\\_DENSITY and DISTCOEF are specified in the GRIDDATA block.  If sorption is specified as FREUNDLICH or LANGMUIR then SP2 is also required in the GRIDDATA block.  The sorption option must be consistent with the sorption option specified in the MST Package or the program will terminate with an error.": [
+        "gwt-ist"
+      ]
     }
   },
   "sp2": {
     "griddata": {
-      "gwt-ist": "is the exponent for the Freundlich isotherm and the sorption capacity for the Langmuir isotherm.  sp2 is not required unless the SORPTION keyword is specified in the options block and sorption is specified as FREUNDLICH or LANGMUIR. If the SORPTION keyword is not specified in the options block, or if sorption is specified as LINEAR, sp2 will have no effect on simulation results. ",
-      "gwt-mst": "is the exponent for the Freundlich isotherm and the sorption capacity for the Langmuir isotherm.  sp2 is not required unless the SORPTION keyword is specified in the options block.  If the SORPTION keyword is not specified in the options block, sp2 will have no effect on simulation results. "
+      "is the exponent for the Freundlich isotherm and the sorption capacity for the Langmuir isotherm.  sp2 is not required unless the SORPTION keyword is specified in the options block and sorption is specified as FREUNDLICH or LANGMUIR. If the SORPTION keyword is not specified in the options block, or if sorption is specified as LINEAR, sp2 will have no effect on simulation results. ": [
+        "gwt-ist"
+      ],
+      "is the exponent for the Freundlich isotherm and the sorption capacity for the Langmuir isotherm.  sp2 is not required unless the SORPTION keyword is specified in the options block.  If the SORPTION keyword is not specified in the options block, sp2 will have no effect on simulation results. ": [
+        "gwt-mst"
+      ]
     }
   },
   "specified_initial_delay_head": {
     "options": {
-      "gwf-csub": "keyword to indicate that absolute initial delay bed head will be specified for interbeds defined in the PACKAGEDATA block. If SPECIFIED\\_INITIAL\\_DELAY\\_HEAD and SPECIFIED\\_INITIAL\\_INTERBED\\_STATE are not specified then delay bed head values specified in the PACKAGEDATA block are relative to simulated values if the first stress period is steady-state or initial GWF heads if the first stress period is transient."
+      "keyword to indicate that absolute initial delay bed head will be specified for interbeds defined in the PACKAGEDATA block. If SPECIFIED\\_INITIAL\\_DELAY\\_HEAD and SPECIFIED\\_INITIAL\\_INTERBED\\_STATE are not specified then delay bed head values specified in the PACKAGEDATA block are relative to simulated values if the first stress period is steady-state or initial GWF heads if the first stress period is transient.": [
+        "gwf-csub"
+      ]
     }
   },
   "specified_initial_interbed_state": {
     "options": {
-      "gwf-csub": "keyword to indicate that absolute preconsolidation stresses (heads) and delay bed heads will be specified for interbeds defined in the PACKAGEDATA block. The SPECIFIED\\_INITIAL\\_INTERBED\\_STATE option is equivalent to specifying the SPECIFIED\\_INITIAL\\_PRECONSOLITATION\\_STRESS and SPECIFIED\\_INITIAL\\_DELAY\\_HEAD. If SPECIFIED\\_INITIAL\\_INTERBED\\_STATE is not specified then preconsolidation stress (head) and delay bed head values specified in the PACKAGEDATA block are relative to simulated values of the first stress period if steady-state or initial stresses and GWF heads if the first stress period is transient."
+      "keyword to indicate that absolute preconsolidation stresses (heads) and delay bed heads will be specified for interbeds defined in the PACKAGEDATA block. The SPECIFIED\\_INITIAL\\_INTERBED\\_STATE option is equivalent to specifying the SPECIFIED\\_INITIAL\\_PRECONSOLITATION\\_STRESS and SPECIFIED\\_INITIAL\\_DELAY\\_HEAD. If SPECIFIED\\_INITIAL\\_INTERBED\\_STATE is not specified then preconsolidation stress (head) and delay bed head values specified in the PACKAGEDATA block are relative to simulated values of the first stress period if steady-state or initial stresses and GWF heads if the first stress period is transient.": [
+        "gwf-csub"
+      ]
     }
   },
   "specified_initial_preconsolidation_stress": {
     "options": {
-      "gwf-csub": "keyword to indicate that absolute preconsolidation stresses (heads) will be specified for interbeds defined in the PACKAGEDATA block. If SPECIFIED\\_INITIAL\\_PRECONSOLITATION\\_STRESS and SPECIFIED\\_INITIAL\\_INTERBED\\_STATE are not specified then preconsolidation stress (head) values specified in the PACKAGEDATA block are relative to simulated values if the first stress period is steady-state or initial stresses (heads) if the first stress period is transient."
+      "keyword to indicate that absolute preconsolidation stresses (heads) will be specified for interbeds defined in the PACKAGEDATA block. If SPECIFIED\\_INITIAL\\_PRECONSOLITATION\\_STRESS and SPECIFIED\\_INITIAL\\_INTERBED\\_STATE are not specified then preconsolidation stress (head) values specified in the PACKAGEDATA block are relative to simulated values if the first stress period is steady-state or initial stresses (heads) if the first stress period is transient.": [
+        "gwf-csub"
+      ]
     }
   },
   "square_gwet": {
     "options": {
-      "gwf-uzf": "keyword specifying that groundwater ET will be simulated by assuming a constant ET rate for groundwater levels between land surface (TOP) and land surface minus the ET extinction depth (TOP-EXTDP). Groundwater ET is smoothly reduced from the PET rate to zero over a nominal interval at TOP-EXTDP."
+      "keyword specifying that groundwater ET will be simulated by assuming a constant ET rate for groundwater levels between land surface (TOP) and land surface minus the ET extinction depth (TOP-EXTDP). Groundwater ET is smoothly reduced from the PET rate to zero over a nominal interval at TOP-EXTDP.": [
+        "gwf-uzf"
+      ]
     }
   },
   "ss": {
     "griddata": {
-      "gwf-sto": "is specific storage (or the storage coefficient if STORAGECOEFFICIENT is specified as an option). Specific storage values must be greater than or equal to 0. If the CSUB Package is included in the GWF model, specific storage must be zero for every cell."
+      "is specific storage (or the storage coefficient if STORAGECOEFFICIENT is specified as an option). Specific storage values must be greater than or equal to 0. If the CSUB Package is included in the GWF model, specific storage must be zero for every cell.": [
+        "gwf-sto"
+      ]
     },
     "period": {
-      "utl-tvs": "is the new value to be assigned as the cell's specific storage (or storage coefficient if the STORAGECOEFFICIENT STO package option is specified) from the start of the specified stress period, as per SS in the STO package.  Specific storage values must be greater than or equal to 0.  If the OPTIONS block includes a TS6 entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+      "is the new value to be assigned as the cell's specific storage (or storage coefficient if the STORAGECOEFFICIENT STO package option is specified) from the start of the specified stress period, as per SS in the STO package.  Specific storage values must be greater than or equal to 0.  If the OPTIONS block includes a TS6 entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+        "utl-tvs"
+      ]
     }
   },
   "ss_confined_only": {
     "options": {
-      "gwf-sto": "keyword to indicate that compressible storage is only calculated for a convertible cell (ICONVERT>0) when the cell is under confined conditions (head greater than or equal to the top of the cell). This option has no effect on cells that are marked as being always confined (ICONVERT=0).  This option is identical to the approach used to calculate storage changes under confined conditions in MODFLOW-2005."
+      "keyword to indicate that compressible storage is only calculated for a convertible cell (ICONVERT>0) when the cell is under confined conditions (head greater than or equal to the top of the cell). This option has no effect on cells that are marked as being always confined (ICONVERT=0).  This option is identical to the approach used to calculate storage changes under confined conditions in MODFLOW-2005.": [
+        "gwf-sto"
+      ]
     }
   },
   "stage": {
     "options": {
-      "chf-oc": "keyword to specify that record corresponds to stage.",
-      "gwf-lak": "keyword to specify that record corresponds to stage.",
-      "gwf-sfr": "keyword to specify that record corresponds to stage.",
-      "olf-oc": "keyword to specify that record corresponds to stage.",
-      "swf-oc": "keyword to specify that record corresponds to stage."
+      "keyword to specify that record corresponds to stage.": [
+        "chf-oc",
+        "gwf-lak",
+        "gwf-sfr",
+        "olf-oc",
+        "swf-oc"
+      ]
     },
     "period": {
-      "gwf-lak": "real or character value that defines the stage for the lake. The specified STAGE is only applied if the lake is a constant stage lake. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      "gwf-sfr": "real or character value that defines the stage for the reach. The specified STAGE is only applied if the reach uses the simple routing option. If STAGE is not specified for reaches that use the simple routing option, the specified stage is set to the top of the reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+      "real or character value that defines the stage for the lake. The specified STAGE is only applied if the lake is a constant stage lake. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+        "gwf-lak"
+      ],
+      "real or character value that defines the stage for the reach. The specified STAGE is only applied if the reach uses the simple routing option. If STAGE is not specified for reaches that use the simple routing option, the specified stage is set to the top of the reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+        "gwf-sfr"
+      ]
     }
   },
   "start_date_time": {
     "options": {
-      "sim-tdis": "is the starting date and time of the simulation.  This is a text string that is used as a label within the simulation list file.  The value has no effect on the simulation.  The recommended format for the starting date and time is described at https://www.w3.org/TR/NOTE-datetime."
+      "is the starting date and time of the simulation.  This is a text string that is used as a label within the simulation list file.  The value has no effect on the simulation.  The recommended format for the starting date and time is described at https://www.w3.org/TR/NOTE-datetime.": [
+        "sim-tdis"
+      ]
     }
   },
   "status": {
     "period": {
-      "gwe-lke": "keyword option to define lake status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that temperature will be calculated for the lake.  If a lake is inactive, then there will be no energy fluxes into or out of the lake and the inactive value will be written for the lake temperature.  If a lake is constant, then the temperature for the lake will be fixed at the user specified value.",
-      "gwe-mwe": "keyword option to define well status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that temperature will be calculated for the well.  If a well is inactive, then there will be no solute mass fluxes into or out of the well and the inactive value will be written for the well temperature.  If a well is constant, then the temperature for the well will be fixed at the user specified value.",
-      "gwe-sfe": "keyword option to define reach status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that temperature will be calculated for the reach.  If a reach is inactive, then there will be no energy fluxes into or out of the reach and the inactive value will be written for the reach temperature.  If a reach is constant, then the temperature for the reach will be fixed at the user specified value.",
-      "gwe-uze": "keyword option to define UZF cell status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that temperature will be calculated for the UZF cell.  If a UZF cell is inactive, then there will be no energy fluxes into or out of the UZF cell and the inactive value will be written for the UZF cell temperature.  If a UZF cell is constant, then the temperature for the UZF cell will be fixed at the user specified value.",
-      "gwf-lak": "keyword option to define lake status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE.",
-      "gwf-maw": "keyword option to define well status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE.",
-      "gwf-sfr": "keyword option to define stream reach status.  STATUS can be ACTIVE, INACTIVE, or SIMPLE. The SIMPLE STATUS option simulates streamflow using a user-specified stage for a reach or a stage set to the top of the reach (depth = 0). In cases where the simulated leakage calculated using the specified stage exceeds the sum of inflows to the reach, the stage is set to the top of the reach and leakage is set equal to the sum of inflows. Upstream fractions should be changed using the UPSTREAM\\_FRACTION SFRSETTING if the status for one or more reaches is changed to ACTIVE or INACTIVE. For example, if one of two downstream connections for a reach is inactivated, the upstream fraction for the active and inactive downstream reach should be changed to 1.0 and 0.0, respectively, to ensure that the active reach receives all of the downstream outflow from the upstream reach. By default, STATUS is ACTIVE.",
-      "gwt-lkt": "keyword option to define lake status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that concentration will be calculated for the lake.  If a lake is inactive, then there will be no solute mass fluxes into or out of the lake and the inactive value will be written for the lake concentration.  If a lake is constant, then the concentration for the lake will be fixed at the user specified value.",
-      "gwt-mwt": "keyword option to define well status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that concentration will be calculated for the well.  If a well is inactive, then there will be no solute mass fluxes into or out of the well and the inactive value will be written for the well concentration.  If a well is constant, then the concentration for the well will be fixed at the user specified value.",
-      "gwt-sft": "keyword option to define reach status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that concentration will be calculated for the reach.  If a reach is inactive, then there will be no solute mass fluxes into or out of the reach and the inactive value will be written for the reach concentration.  If a reach is constant, then the concentration for the reach will be fixed at the user specified value.",
-      "gwt-uzt": "keyword option to define UZF cell status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that concentration will be calculated for the UZF cell.  If a UZF cell is inactive, then there will be no solute mass fluxes into or out of the UZF cell and the inactive value will be written for the UZF cell concentration.  If a UZF cell is constant, then the concentration for the UZF cell will be fixed at the user specified value."
+      "keyword option to define UZF cell status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that concentration will be calculated for the UZF cell.  If a UZF cell is inactive, then there will be no solute mass fluxes into or out of the UZF cell and the inactive value will be written for the UZF cell concentration.  If a UZF cell is constant, then the concentration for the UZF cell will be fixed at the user specified value.": [
+        "gwt-uzt"
+      ],
+      "keyword option to define UZF cell status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that temperature will be calculated for the UZF cell.  If a UZF cell is inactive, then there will be no energy fluxes into or out of the UZF cell and the inactive value will be written for the UZF cell temperature.  If a UZF cell is constant, then the temperature for the UZF cell will be fixed at the user specified value.": [
+        "gwe-uze"
+      ],
+      "keyword option to define lake status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that concentration will be calculated for the lake.  If a lake is inactive, then there will be no solute mass fluxes into or out of the lake and the inactive value will be written for the lake concentration.  If a lake is constant, then the concentration for the lake will be fixed at the user specified value.": [
+        "gwt-lkt"
+      ],
+      "keyword option to define lake status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that temperature will be calculated for the lake.  If a lake is inactive, then there will be no energy fluxes into or out of the lake and the inactive value will be written for the lake temperature.  If a lake is constant, then the temperature for the lake will be fixed at the user specified value.": [
+        "gwe-lke"
+      ],
+      "keyword option to define lake status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE.": [
+        "gwf-lak"
+      ],
+      "keyword option to define reach status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that concentration will be calculated for the reach.  If a reach is inactive, then there will be no solute mass fluxes into or out of the reach and the inactive value will be written for the reach concentration.  If a reach is constant, then the concentration for the reach will be fixed at the user specified value.": [
+        "gwt-sft"
+      ],
+      "keyword option to define reach status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that temperature will be calculated for the reach.  If a reach is inactive, then there will be no energy fluxes into or out of the reach and the inactive value will be written for the reach temperature.  If a reach is constant, then the temperature for the reach will be fixed at the user specified value.": [
+        "gwe-sfe"
+      ],
+      "keyword option to define stream reach status.  STATUS can be ACTIVE, INACTIVE, or SIMPLE. The SIMPLE STATUS option simulates streamflow using a user-specified stage for a reach or a stage set to the top of the reach (depth = 0). In cases where the simulated leakage calculated using the specified stage exceeds the sum of inflows to the reach, the stage is set to the top of the reach and leakage is set equal to the sum of inflows. Upstream fractions should be changed using the UPSTREAM\\_FRACTION SFRSETTING if the status for one or more reaches is changed to ACTIVE or INACTIVE. For example, if one of two downstream connections for a reach is inactivated, the upstream fraction for the active and inactive downstream reach should be changed to 1.0 and 0.0, respectively, to ensure that the active reach receives all of the downstream outflow from the upstream reach. By default, STATUS is ACTIVE.": [
+        "gwf-sfr"
+      ],
+      "keyword option to define well status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that concentration will be calculated for the well.  If a well is inactive, then there will be no solute mass fluxes into or out of the well and the inactive value will be written for the well concentration.  If a well is constant, then the concentration for the well will be fixed at the user specified value.": [
+        "gwt-mwt"
+      ],
+      "keyword option to define well status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that temperature will be calculated for the well.  If a well is inactive, then there will be no solute mass fluxes into or out of the well and the inactive value will be written for the well temperature.  If a well is constant, then the temperature for the well will be fixed at the user specified value.": [
+        "gwe-mwe"
+      ],
+      "keyword option to define well status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE.": [
+        "gwf-maw"
+      ]
     }
   },
   "steady-state": {
     "period": {
-      "chf-sto": "keyword to indicate that stress period IPER is steady-state. Steady-state conditions will apply until the TRANSIENT keyword is specified in a subsequent BEGIN PERIOD block.",
-      "gwf-sto": "keyword to indicate that stress period IPER is steady-state. Steady-state conditions will apply until the TRANSIENT keyword is specified in a subsequent BEGIN PERIOD block. If the CSUB Package is included in the GWF model, only the first and last stress period can be steady-state.",
-      "olf-sto": "keyword to indicate that stress period IPER is steady-state. Steady-state conditions will apply until the TRANSIENT keyword is specified in a subsequent BEGIN PERIOD block.",
-      "swf-sto": "keyword to indicate that stress period IPER is steady-state. Steady-state conditions will apply until the TRANSIENT keyword is specified in a subsequent BEGIN PERIOD block."
+      "keyword to indicate that stress period IPER is steady-state. Steady-state conditions will apply until the TRANSIENT keyword is specified in a subsequent BEGIN PERIOD block.": [
+        "chf-sto",
+        "olf-sto",
+        "swf-sto"
+      ],
+      "keyword to indicate that stress period IPER is steady-state. Steady-state conditions will apply until the TRANSIENT keyword is specified in a subsequent BEGIN PERIOD block. If the CSUB Package is included in the GWF model, only the first and last stress period can be steady-state.": [
+        "gwf-sto"
+      ]
     }
   },
   "steps": {
     "period": {
-      "chf-oc": "save for each step specified in STEPS. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
-      "gwe-oc": "save for each step specified in STEPS. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
-      "gwf-oc": "save for each step specified in STEPS. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
-      "gwt-oc": "save for each step specified in STEPS. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
-      "olf-oc": "save for each step specified in STEPS. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
-      "prt-oc": "save for each step specified in STEPS. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
-      "prt-prp": "release at the start of each step specified in STEPS. This option may be used in conjunction with other RELEASESETTING options.",
-      "swf-oc": "save for each step specified in STEPS. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps."
+      "release at the start of each step specified in STEPS. This option may be used in conjunction with other RELEASESETTING options.": [
+        "prt-prp"
+      ],
+      "save for each step specified in STEPS. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.": [
+        "chf-oc",
+        "gwe-oc",
+        "gwf-oc",
+        "gwt-oc",
+        "olf-oc",
+        "prt-oc",
+        "swf-oc"
+      ]
     }
   },
   "stop_at_weak_sink": {
     "options": {
-      "prt-prp": "is a text keyword to indicate that a particle is to terminate when it enters a cell that is a weak sink.  By default, particles are allowed to pass though cells that are weak sinks."
+      "is a text keyword to indicate that a particle is to terminate when it enters a cell that is a weak sink.  By default, particles are allowed to pass though cells that are weak sinks.": [
+        "prt-prp"
+      ]
     }
   },
   "stoptime": {
     "options": {
-      "prt-prp": "real value defining the maximum simulation time to which particles in the package can be tracked.  Particles that have not terminated earlier due to another termination condition will terminate when simulation time STOPTIME is reached.  If the last stress period in the simulation consists of more than one time step, particles will not be tracked past the ending time of the last stress period, regardless of STOPTIME.  If the EXTEND\\_TRACKING option is enabled and the last stress period in the simulation is steady-state, the simulation ending time will not limit the time to which particles can be tracked, but STOPTIME and STOPTRAVELTIME will continue to apply.  If STOPTIME and STOPTRAVELTIME are both provided, particles will be stopped if either is reached."
+      "real value defining the maximum simulation time to which particles in the package can be tracked.  Particles that have not terminated earlier due to another termination condition will terminate when simulation time STOPTIME is reached.  If the last stress period in the simulation consists of more than one time step, particles will not be tracked past the ending time of the last stress period, regardless of STOPTIME.  If the EXTEND\\_TRACKING option is enabled and the last stress period in the simulation is steady-state, the simulation ending time will not limit the time to which particles can be tracked, but STOPTIME and STOPTRAVELTIME will continue to apply.  If STOPTIME and STOPTRAVELTIME are both provided, particles will be stopped if either is reached.": [
+        "prt-prp"
+      ]
     }
   },
   "stoptraveltime": {
     "options": {
-      "prt-prp": "real value defining the maximum travel time over which particles in the model can be tracked.  Particles that have not terminated earlier due to another termination condition will terminate when their travel time reaches STOPTRAVELTIME.  If the last stress period in the simulation consists of more than one time step, particles will not be tracked past the ending time of the last stress period, regardless of STOPTRAVELTIME.  If the EXTEND\\_TRACKING option is enabled and the last stress period in the simulation is steady-state, the simulation ending time will not limit the time to which particles can be tracked, but STOPTIME and STOPTRAVELTIME will continue to apply.  If STOPTIME and STOPTRAVELTIME are both provided, particles will be stopped if either is reached."
+      "real value defining the maximum travel time over which particles in the model can be tracked.  Particles that have not terminated earlier due to another termination condition will terminate when their travel time reaches STOPTRAVELTIME.  If the last stress period in the simulation consists of more than one time step, particles will not be tracked past the ending time of the last stress period, regardless of STOPTRAVELTIME.  If the EXTEND\\_TRACKING option is enabled and the last stress period in the simulation is steady-state, the simulation ending time will not limit the time to which particles can be tracked, but STOPTIME and STOPTRAVELTIME will continue to apply.  If STOPTIME and STOPTRAVELTIME are both provided, particles will be stopped if either is reached.": [
+        "prt-prp"
+      ]
     }
   },
   "storage": {
     "options": {
-      "gwf-sfr": "keyword that activates storage contributions to the stream-flow routing package continuity equation."
+      "keyword that activates storage contributions to the stream-flow routing package continuity equation.": [
+        "gwf-sfr"
+      ]
     }
   },
   "storagecoefficient": {
     "options": {
-      "gwf-sto": "keyword to indicate that the SS array is read as storage coefficient rather than specific storage."
+      "keyword to indicate that the SS array is read as storage coefficient rather than specific storage.": [
+        "gwf-sto"
+      ]
     }
   },
   "strain_csv_coarse": {
     "options": {
-      "gwf-csub": "keyword to specify the record that corresponds to final coarse-grained material strain output."
+      "keyword to specify the record that corresponds to final coarse-grained material strain output.": [
+        "gwf-csub"
+      ]
     }
   },
   "strain_csv_interbed": {
     "options": {
-      "gwf-csub": "keyword to specify the record that corresponds to final interbed strain output."
+      "keyword to specify the record that corresponds to final interbed strain output.": [
+        "gwf-csub"
+      ]
     }
   },
   "strt": {
     "griddata": {
-      "chf-ic": "is the initial (starting) stage---that is, stage at the beginning of the CHF Model simulation.  STRT must be specified for all CHF Model simulations. One value is read for every model reach.",
-      "gwe-ic": "is the initial (starting) temperature---that is, the temperature at the beginning of the GWE Model simulation.  STRT must be specified for all GWE Model simulations. One value is read for every model cell.",
-      "gwf-ic": "is the initial (starting) head---that is, head at the beginning of the GWF Model simulation.  STRT must be specified for all simulations, including steady-state simulations. One value is read for every model cell. For simulations in which the first stress period is steady state, the values used for STRT generally do not affect the simulation (exceptions may occur if cells go dry and (or) rewet). The execution time, however, will be less if STRT includes hydraulic heads that are close to the steady-state solution.  A head value lower than the cell bottom can be provided if a cell should start as dry.",
-      "gwt-ic": "is the initial (starting) concentration---that is, concentration at the beginning of the GWT Model simulation.  STRT must be specified for all GWT Model simulations. One value is read for every model cell.",
-      "olf-ic": "is the initial (starting) stage---that is, stage at the beginning of the OLF Model simulation.  STRT must be specified for all OLF Model simulations. One value is read for every model reach.",
-      "swf-ic": "is the initial (starting) stage---that is, stage at the beginning of the SWF Model simulation.  STRT must be specified for all SWF Model simulations. One value is read for every model reach."
+      "is the initial (starting) concentration---that is, concentration at the beginning of the GWT Model simulation.  STRT must be specified for all GWT Model simulations. One value is read for every model cell.": [
+        "gwt-ic"
+      ],
+      "is the initial (starting) head---that is, head at the beginning of the GWF Model simulation.  STRT must be specified for all simulations, including steady-state simulations. One value is read for every model cell. For simulations in which the first stress period is steady state, the values used for STRT generally do not affect the simulation (exceptions may occur if cells go dry and (or) rewet). The execution time, however, will be less if STRT includes hydraulic heads that are close to the steady-state solution.  A head value lower than the cell bottom can be provided if a cell should start as dry.": [
+        "gwf-ic"
+      ],
+      "is the initial (starting) stage---that is, stage at the beginning of the CHF Model simulation.  STRT must be specified for all CHF Model simulations. One value is read for every model reach.": [
+        "chf-ic"
+      ],
+      "is the initial (starting) stage---that is, stage at the beginning of the OLF Model simulation.  STRT must be specified for all OLF Model simulations. One value is read for every model reach.": [
+        "olf-ic"
+      ],
+      "is the initial (starting) stage---that is, stage at the beginning of the SWF Model simulation.  STRT must be specified for all SWF Model simulations. One value is read for every model reach.": [
+        "swf-ic"
+      ],
+      "is the initial (starting) temperature---that is, the temperature at the beginning of the GWE Model simulation.  STRT must be specified for all GWE Model simulations. One value is read for every model cell.": [
+        "gwe-ic"
+      ]
     }
   },
   "surf_rate_specified": {
     "options": {
-      "gwf-evt": "indicates that the proportion of the evapotranspiration rate at the ET surface will be specified as PETM0 in list input."
+      "indicates that the proportion of the evapotranspiration rate at the ET surface will be specified as PETM0 in list input.": [
+        "gwf-evt"
+      ]
     }
   },
   "surface": {
     "period": {
-      "gwf-evta": "is the elevation of the ET surface ($L$)."
+      "is the elevation of the ET surface ($L$).": [
+        "gwf-evta"
+      ]
     }
   },
   "surfdep": {
     "options": {
-      "gwf-lak": "real value that defines the surface depression depth for VERTICAL lake-GWF connections. If specified, SURFDEP must be greater than or equal to zero. If SURFDEP is not specified, a default value of zero is used for all vertical lake-GWF connections."
+      "real value that defines the surface depression depth for VERTICAL lake-GWF connections. If specified, SURFDEP must be greater than or equal to zero. If SURFDEP is not specified, a default value of zero is used for all vertical lake-GWF connections.": [
+        "gwf-lak"
+      ]
     }
   },
   "sy": {
     "griddata": {
-      "gwf-sto": "is specific yield. Specific yield values must be greater than or equal to 0. Specific yield does not have to be specified if there are no convertible cells (ICONVERT=0 in every cell)."
+      "is specific yield. Specific yield values must be greater than or equal to 0. Specific yield does not have to be specified if there are no convertible cells (ICONVERT=0 in every cell).": [
+        "gwf-sto"
+      ]
     },
     "period": {
-      "utl-tvs": "is the new value to be assigned as the cell's specific yield from the start of the specified stress period, as per SY in the STO package.  Specific yield values must be greater than or equal to 0.  If the OPTIONS block includes a TS6 entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+      "is the new value to be assigned as the cell's specific yield from the start of the specified stress period, as per SY in the STO package.  Specific yield values must be greater than or equal to 0.  If the OPTIONS block includes a TS6 entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+        "utl-tvs"
+      ]
     }
   },
   "tab6": {
     "crosssections": {
-      "gwf-sfr": "keyword to specify that record corresponds to a cross-section table file."
+      "keyword to specify that record corresponds to a cross-section table file.": [
+        "gwf-sfr"
+      ]
     },
     "period": {
-      "gwf-sfr": "keyword to specify that record corresponds to a cross-section table file."
+      "keyword to specify that record corresponds to a cross-section table file.": [
+        "gwf-sfr"
+      ]
     },
     "tables": {
-      "gwf-lak": "keyword to specify that record corresponds to a table file."
+      "keyword to specify that record corresponds to a table file.": [
+        "gwf-lak"
+      ]
     }
   },
   "tas6": {
     "options": {
-      "gwf-evta": "keyword to specify that record corresponds to a time-array-series file.",
-      "gwf-rcha": "keyword to specify that record corresponds to a time-array-series file.",
-      "utl-spca": "keyword to specify that record corresponds to a time-array-series file."
+      "keyword to specify that record corresponds to a time-array-series file.": [
+        "gwf-evta",
+        "gwf-rcha",
+        "utl-spca"
+      ]
     }
   },
   "tdis6": {
     "timing": {
-      "sim-nam": "is the name of the Temporal Discretization (TDIS) Input File."
+      "is the name of the Temporal Discretization (TDIS) Input File.": [
+        "sim-nam"
+      ]
     }
   },
   "temperature": {
     "options": {
-      "gwe-lke": "keyword to specify that record corresponds to temperature.",
-      "gwe-mwe": "keyword to specify that record corresponds to temperature.",
-      "gwe-oc": "keyword to specify that record corresponds to temperature.",
-      "gwe-sfe": "keyword to specify that record corresponds to temperature.",
-      "gwe-uze": "keyword to specify that record corresponds to temperature."
+      "keyword to specify that record corresponds to temperature.": [
+        "gwe-lke",
+        "gwe-mwe",
+        "gwe-oc",
+        "gwe-sfe",
+        "gwe-uze"
+      ]
     },
     "period": {
-      "gwe-lke": "real or character value that defines the temperature for the lake. The specified TEMPERATURE is only applied if the lake is a constant temperature lake. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      "gwe-mwe": "real or character value that defines the temperature for the well. The specified TEMPERATURE is only applied if the well is a constant temperature well. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      "gwe-sfe": "real or character value that defines the temperature for the reach. The specified TEMPERATURE is only applied if the reach is a constant temperature reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      "gwe-uze": "real or character value that defines the temperature for the unsaturated zone flow cell. The specified TEMPERATURE is only applied if the unsaturated zone flow cell is a constant temperature cell. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      "utl-spc": "is the user-supplied boundary temperature. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, the TEMPERATURE for each boundary feature is zero.",
-      "utl-spca": "is the temperature of the associated Recharge or Evapotranspiration stress package.  The temperature array may be defined by a time-array series (see the \"Using Time-Array Series in a Package\" section)."
+      "is the temperature of the associated Recharge or Evapotranspiration stress package.  The temperature array may be defined by a time-array series (see the \"Using Time-Array Series in a Package\" section).": [
+        "utl-spca"
+      ],
+      "is the user-supplied boundary temperature. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, the TEMPERATURE for each boundary feature is zero.": [
+        "utl-spc"
+      ],
+      "real or character value that defines the temperature for the lake. The specified TEMPERATURE is only applied if the lake is a constant temperature lake. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+        "gwe-lke"
+      ],
+      "real or character value that defines the temperature for the reach. The specified TEMPERATURE is only applied if the reach is a constant temperature reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+        "gwe-sfe"
+      ],
+      "real or character value that defines the temperature for the unsaturated zone flow cell. The specified TEMPERATURE is only applied if the unsaturated zone flow cell is a constant temperature cell. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+        "gwe-uze"
+      ],
+      "real or character value that defines the temperature for the well. The specified TEMPERATURE is only applied if the well is a constant temperature well. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+        "gwe-mwe"
+      ]
     }
   },
   "temperature_species_name": {
     "options": {
-      "gwf-vsc": "string used to identify the auxspeciesname in PACKAGEDATA that corresponds to the temperature species.  There can be only one occurrence of this temperature species name in the PACKAGEDATA block or the program will terminate with an error.  This value has no effect if viscosity does not depend on temperature."
+      "string used to identify the auxspeciesname in PACKAGEDATA that corresponds to the temperature species.  There can be only one occurrence of this temperature species name in the PACKAGEDATA block or the program will terminate with an error.  This value has no effect if viscosity does not depend on temperature.": [
+        "gwf-vsc"
+      ]
     }
   },
   "thermal_a2": {
     "options": {
-      "gwf-vsc": "is an empirical parameter specified by the user for calculating viscosity using a nonlinear formulation.  If A2 is not specified, a default value of 10.0 is assigned (Voss, 1984). "
+      "is an empirical parameter specified by the user for calculating viscosity using a nonlinear formulation.  If A2 is not specified, a default value of 10.0 is assigned (Voss, 1984). ": [
+        "gwf-vsc"
+      ]
     }
   },
   "thermal_a3": {
     "options": {
-      "gwf-vsc": "is an empirical parameter specified by the user for calculating viscosity using a nonlinear formulation.  If A3 is not specified, a default value of 248.37 is assigned (Voss, 1984). "
+      "is an empirical parameter specified by the user for calculating viscosity using a nonlinear formulation.  If A3 is not specified, a default value of 248.37 is assigned (Voss, 1984). ": [
+        "gwf-vsc"
+      ]
     }
   },
   "thermal_a4": {
     "options": {
-      "gwf-vsc": "is an empirical parameter specified by the user for calculating viscosity using a nonlinear formulation.  If A4 is not specified, a default value of 133.15 is assigned (Voss, 1984). "
+      "is an empirical parameter specified by the user for calculating viscosity using a nonlinear formulation.  If A4 is not specified, a default value of 133.15 is assigned (Voss, 1984). ": [
+        "gwf-vsc"
+      ]
     }
   },
   "thermal_formulation": {
     "options": {
-      "gwf-vsc": "may be used for specifying which viscosity formulation to use for the temperature species. Can be either LINEAR or NONLINEAR. The LINEAR viscosity formulation is the default."
+      "may be used for specifying which viscosity formulation to use for the temperature species. Can be either LINEAR or NONLINEAR. The LINEAR viscosity formulation is the default.": [
+        "gwf-vsc"
+      ]
     }
   },
   "thickstrt": {
     "options": {
-      "gwf-npf": "indicates that cells having a negative ICELLTYPE are confined, and their cell thickness for conductance calculations will be computed as STRT-BOT rather than TOP-BOT.  This option should be used with caution as it only affects conductance calculations in the NPF Package."
+      "indicates that cells having a negative ICELLTYPE are confined, and their cell thickness for conductance calculations will be computed as STRT-BOT rather than TOP-BOT.  This option should be used with caution as it only affects conductance calculations in the NPF Package.": [
+        "gwf-npf"
+      ]
     }
   },
   "time_conversion": {
     "options": {
-      "chf-dfw": "real value that is used to convert user-specified Manning's roughness coefficients from seconds to model time units. TIME\\_CONVERSION should be set to 1.0, 60.0, 3,600.0, 86,400.0, and 31,557,600.0 when using time units (TIME\\_UNITS) of seconds, minutes, hours, days, or years in the simulation, respectively. TIME\\_CONVERSION does not need to be specified if TIME\\_UNITS are seconds.",
-      "gwf-lak": "real value that is used to convert user-specified Manning's roughness coefficients or gravitational acceleration used to calculate outlet flows from seconds to model time units. TIME\\_CONVERSION should be set to 1.0, 60.0, 3,600.0, 86,400.0, and 31,557,600.0 when using time units (TIME\\_UNITS) of seconds, minutes, hours, days, or years in the simulation, respectively. CONVTIME does not need to be specified if no lake outlets are specified or TIME\\_UNITS are seconds.",
-      "gwf-sfr": "real value that is used to convert user-specified Manning's roughness coefficients from seconds to model time units. TIME\\_CONVERSION should be set to 1.0, 60.0, 3,600.0, 86,400.0, and 31,557,600.0 when using time units (TIME\\_UNITS) of seconds, minutes, hours, days, or years in the simulation, respectively. TIME\\_CONVERSION does not need to be specified if TIME\\_UNITS are seconds.",
-      "olf-dfw": "real value that is used to convert user-specified Manning's roughness coefficients from seconds to model time units. TIME\\_CONVERSION should be set to 1.0, 60.0, 3,600.0, 86,400.0, and 31,557,600.0 when using time units (TIME\\_UNITS) of seconds, minutes, hours, days, or years in the simulation, respectively. TIME\\_CONVERSION does not need to be specified if TIME\\_UNITS are seconds.",
-      "swf-dfw": "real value that is used to convert user-specified Manning's roughness coefficients from seconds to model time units. TIME\\_CONVERSION should be set to 1.0, 60.0, 3,600.0, 86,400.0, and 31,557,600.0 when using time units (TIME\\_UNITS) of seconds, minutes, hours, days, or years in the simulation, respectively. TIME\\_CONVERSION does not need to be specified if TIME\\_UNITS are seconds."
+      "real value that is used to convert user-specified Manning's roughness coefficients from seconds to model time units. TIME\\_CONVERSION should be set to 1.0, 60.0, 3,600.0, 86,400.0, and 31,557,600.0 when using time units (TIME\\_UNITS) of seconds, minutes, hours, days, or years in the simulation, respectively. TIME\\_CONVERSION does not need to be specified if TIME\\_UNITS are seconds.": [
+        "chf-dfw",
+        "gwf-sfr",
+        "olf-dfw",
+        "swf-dfw"
+      ],
+      "real value that is used to convert user-specified Manning's roughness coefficients or gravitational acceleration used to calculate outlet flows from seconds to model time units. TIME\\_CONVERSION should be set to 1.0, 60.0, 3,600.0, 86,400.0, and 31,557,600.0 when using time units (TIME\\_UNITS) of seconds, minutes, hours, days, or years in the simulation, respectively. CONVTIME does not need to be specified if no lake outlets are specified or TIME\\_UNITS are seconds.": [
+        "gwf-lak"
+      ]
     }
   },
   "time_units": {
     "options": {
-      "sim-tdis": "is the time units of the simulation.  This is a text string that is used as a label within model output files.  Values for time\\_units may be ``unknown'',  ``seconds'', ``minutes'', ``hours'', ``days'', or ``years''.  The default time unit is ``unknown''."
+      "is the time units of the simulation.  This is a text string that is used as a label within model output files.  Values for time\\_units may be ``unknown'',  ``seconds'', ``minutes'', ``hours'', ``days'', or ``years''.  The default time unit is ``unknown''.": [
+        "sim-tdis"
+      ]
     }
   },
   "timeseries": {
     "timeseries": {
-      "utl-ts": "xxx"
+      "xxx": [
+        "utl-ts"
+      ]
     }
   },
   "top": {
     "griddata": {
-      "gwe-dis": "is the top elevation for each cell in the top model layer.",
-      "gwe-disu": "is the top elevation for each cell in the model grid.",
-      "gwe-disv": "is the top elevation for each cell in the top model layer.",
-      "gwf-dis": "is the top elevation for each cell in the top model layer.",
-      "gwf-disu": "is the top elevation for each cell in the model grid.",
-      "gwf-disv": "is the top elevation for each cell in the top model layer.",
-      "gwt-dis": "is the top elevation for each cell in the top model layer.",
-      "gwt-disu": "is the top elevation for each cell in the model grid.",
-      "gwt-disv": "is the top elevation for each cell in the top model layer.",
-      "prt-dis": "is the top elevation for each cell in the top model layer.",
-      "prt-disv": "is the top elevation for each cell in the top model layer."
+      "is the top elevation for each cell in the model grid.": [
+        "gwe-disu",
+        "gwf-disu",
+        "gwt-disu"
+      ],
+      "is the top elevation for each cell in the top model layer.": [
+        "gwe-dis",
+        "gwe-disv",
+        "gwf-dis",
+        "gwf-disv",
+        "gwt-dis",
+        "gwt-disv",
+        "prt-dis",
+        "prt-disv"
+      ]
     }
   },
   "track": {
     "options": {
-      "prt-oc": "keyword to specify that record corresponds to a binary track file.  Each PRT Model's OC Package may have only one binary track output file.",
-      "prt-prp": "keyword to specify that record corresponds to a binary track output file.  Each PRP Package may have a distinct binary track output file."
+      "keyword to specify that record corresponds to a binary track file.  Each PRT Model's OC Package may have only one binary track output file.": [
+        "prt-oc"
+      ],
+      "keyword to specify that record corresponds to a binary track output file.  Each PRP Package may have a distinct binary track output file.": [
+        "prt-prp"
+      ]
     }
   },
   "track_exit": {
     "options": {
-      "prt-oc": "keyword to indicate that particle tracking output is to be written when a particle exits a feature (a model, cell, or subcell)"
+      "keyword to indicate that particle tracking output is to be written when a particle exits a feature (a model, cell, or subcell)": [
+        "prt-oc"
+      ]
     }
   },
   "track_release": {
     "options": {
-      "prt-oc": "keyword to indicate that particle tracking output is to be written when a particle is released"
+      "keyword to indicate that particle tracking output is to be written when a particle is released": [
+        "prt-oc"
+      ]
     }
   },
   "track_terminate": {
     "options": {
-      "prt-oc": "keyword to indicate that particle tracking output is to be written when a particle terminates for any reason"
+      "keyword to indicate that particle tracking output is to be written when a particle terminates for any reason": [
+        "prt-oc"
+      ]
     }
   },
   "track_timestep": {
     "options": {
-      "prt-oc": "keyword to indicate that particle tracking output is to be written at the end of each time step"
+      "keyword to indicate that particle tracking output is to be written at the end of each time step": [
+        "prt-oc"
+      ]
     }
   },
   "track_usertime": {
     "options": {
-      "prt-oc": "keyword to indicate that particle tracking output is to be written at user-specified times, provided as double precision values in the TRACKTIMES block."
+      "keyword to indicate that particle tracking output is to be written at user-specified times, provided as double precision values in the TRACKTIMES block.": [
+        "prt-oc"
+      ]
     }
   },
   "track_weaksink": {
     "options": {
-      "prt-oc": "keyword to indicate that particle tracking output is to be written when a particle exits a weak sink (a cell which removes some but not all inflow from adjacent cells)"
+      "keyword to indicate that particle tracking output is to be written when a particle exits a weak sink (a cell which removes some but not all inflow from adjacent cells)": [
+        "prt-oc"
+      ]
     }
   },
   "trackcsv": {
     "options": {
-      "prt-oc": "keyword to specify that record corresponds to a CSV track file.  Each PRT Model's OC Package may have only one CSV track file.",
-      "prt-prp": "keyword to specify that record corresponds to a CSV track output file.  Each PRP Package may have a distinct CSV track output file."
+      "keyword to specify that record corresponds to a CSV track file.  Each PRT Model's OC Package may have only one CSV track file.": [
+        "prt-oc"
+      ],
+      "keyword to specify that record corresponds to a CSV track output file.  Each PRP Package may have a distinct CSV track output file.": [
+        "prt-prp"
+      ]
     }
   },
   "transient": {
     "period": {
-      "chf-sto": "keyword to indicate that stress period IPER is transient. Transient conditions will apply until the STEADY-STATE keyword is specified in a subsequent BEGIN PERIOD block.",
-      "gwf-sto": "keyword to indicate that stress period IPER is transient. Transient conditions will apply until the STEADY-STATE keyword is specified in a subsequent BEGIN PERIOD block.",
-      "olf-sto": "keyword to indicate that stress period IPER is transient. Transient conditions will apply until the STEADY-STATE keyword is specified in a subsequent BEGIN PERIOD block.",
-      "swf-sto": "keyword to indicate that stress period IPER is transient. Transient conditions will apply until the STEADY-STATE keyword is specified in a subsequent BEGIN PERIOD block."
+      "keyword to indicate that stress period IPER is transient. Transient conditions will apply until the STEADY-STATE keyword is specified in a subsequent BEGIN PERIOD block.": [
+        "chf-sto",
+        "gwf-sto",
+        "olf-sto",
+        "swf-sto"
+      ]
     }
   },
   "ts6": {
     "options": {
-      "chf-chd": "keyword to specify that record corresponds to a time-series file.",
-      "chf-evp": "keyword to specify that record corresponds to a time-series file.",
-      "chf-flw": "keyword to specify that record corresponds to a time-series file.",
-      "chf-pcp": "keyword to specify that record corresponds to a time-series file.",
-      "chf-zdg": "keyword to specify that record corresponds to a time-series file.",
-      "gwe-ctp": "keyword to specify that record corresponds to a time-series file.",
-      "gwe-esl": "keyword to specify that record corresponds to a time-series file.",
-      "gwe-lke": "keyword to specify that record corresponds to a time-series file.",
-      "gwe-mwe": "keyword to specify that record corresponds to a time-series file.",
-      "gwe-sfe": "keyword to specify that record corresponds to a time-series file.",
-      "gwe-uze": "keyword to specify that record corresponds to a time-series file.",
-      "gwf-chd": "keyword to specify that record corresponds to a time-series file.",
-      "gwf-csub": "keyword to specify that record corresponds to a time-series file.",
-      "gwf-drn": "keyword to specify that record corresponds to a time-series file.",
-      "gwf-evt": "keyword to specify that record corresponds to a time-series file.",
-      "gwf-ghb": "keyword to specify that record corresponds to a time-series file.",
-      "gwf-lak": "keyword to specify that record corresponds to a time-series file.",
-      "gwf-maw": "keyword to specify that record corresponds to a time-series file.",
-      "gwf-rch": "keyword to specify that record corresponds to a time-series file.",
-      "gwf-riv": "keyword to specify that record corresponds to a time-series file.",
-      "gwf-sfr": "keyword to specify that record corresponds to a time-series file.",
-      "gwf-uzf": "keyword to specify that record corresponds to a time-series file.",
-      "gwf-wel": "keyword to specify that record corresponds to a time-series file.",
-      "gwt-cnc": "keyword to specify that record corresponds to a time-series file.",
-      "gwt-lkt": "keyword to specify that record corresponds to a time-series file.",
-      "gwt-mwt": "keyword to specify that record corresponds to a time-series file.",
-      "gwt-sft": "keyword to specify that record corresponds to a time-series file.",
-      "gwt-src": "keyword to specify that record corresponds to a time-series file.",
-      "gwt-uzt": "keyword to specify that record corresponds to a time-series file.",
-      "olf-chd": "keyword to specify that record corresponds to a time-series file.",
-      "olf-evp": "keyword to specify that record corresponds to a time-series file.",
-      "olf-flw": "keyword to specify that record corresponds to a time-series file.",
-      "olf-pcp": "keyword to specify that record corresponds to a time-series file.",
-      "olf-zdg": "keyword to specify that record corresponds to a time-series file.",
-      "swf-chd": "keyword to specify that record corresponds to a time-series file.",
-      "swf-evp": "keyword to specify that record corresponds to a time-series file.",
-      "swf-flw": "keyword to specify that record corresponds to a time-series file.",
-      "swf-pcp": "keyword to specify that record corresponds to a time-series file.",
-      "swf-zdg": "keyword to specify that record corresponds to a time-series file.",
-      "utl-spc": "keyword to specify that record corresponds to a time-series file.",
-      "utl-tvk": "keyword to specify that record corresponds to a time-series file.",
-      "utl-tvs": "keyword to specify that record corresponds to a time-series file."
+      "keyword to specify that record corresponds to a time-series file.": [
+        "chf-chd",
+        "chf-evp",
+        "chf-flw",
+        "chf-pcp",
+        "chf-zdg",
+        "gwe-ctp",
+        "gwe-esl",
+        "gwe-lke",
+        "gwe-mwe",
+        "gwe-sfe",
+        "gwe-uze",
+        "gwf-chd",
+        "gwf-csub",
+        "gwf-drn",
+        "gwf-evt",
+        "gwf-ghb",
+        "gwf-lak",
+        "gwf-maw",
+        "gwf-rch",
+        "gwf-riv",
+        "gwf-sfr",
+        "gwf-uzf",
+        "gwf-wel",
+        "gwt-cnc",
+        "gwt-lkt",
+        "gwt-mwt",
+        "gwt-sft",
+        "gwt-src",
+        "gwt-uzt",
+        "olf-chd",
+        "olf-evp",
+        "olf-flw",
+        "olf-pcp",
+        "olf-zdg",
+        "swf-chd",
+        "swf-evp",
+        "swf-flw",
+        "swf-pcp",
+        "swf-zdg",
+        "utl-spc",
+        "utl-tvk",
+        "utl-tvs"
+      ]
     }
   },
   "tvk6": {
     "options": {
-      "gwf-npf": "keyword to specify that record corresponds to a time-varying hydraulic conductivity (TVK) file.  The behavior of TVK and a description of the input file is provided separately."
+      "keyword to specify that record corresponds to a time-varying hydraulic conductivity (TVK) file.  The behavior of TVK and a description of the input file is provided separately.": [
+        "gwf-npf"
+      ]
     }
   },
   "tvs6": {
     "options": {
-      "gwf-sto": "keyword to specify that record corresponds to a time-varying storage (TVS) file.  The behavior of TVS and a description of the input file is provided separately."
+      "keyword to specify that record corresponds to a time-varying storage (TVS) file.  The behavior of TVS and a description of the input file is provided separately.": [
+        "gwf-sto"
+      ]
     }
   },
   "under_relaxation": {
     "nonlinear": {
-      "sln-ims": "is an optional keyword that defines the nonlinear under-relaxation schemes used. Under-relaxation is also known as dampening, and is used to reduce the size of the calculated dependent variable before proceeding to the next outer iteration.  Under-relaxation can be an effective tool for highly nonlinear models when there are large and often counteracting changes in the calculated dependent variable between successive outer iterations.  By default under-relaxation is not used.  NONE - under-relaxation is not used (default). SIMPLE - Simple under-relaxation scheme with a fixed relaxation factor (UNDER\\_RELAXATION\\_GAMMA) is used.  COOLEY - Cooley under-relaxation scheme is used.  DBD - delta-bar-delta under-relaxation is used.  Note that the under-relaxation schemes are often used in conjunction with problems that use the Newton-Raphson formulation, however, experience has indicated that they also work well for non-Newton problems, such as those with the wet/dry options of MODFLOW 6."
+      "is an optional keyword that defines the nonlinear under-relaxation schemes used. Under-relaxation is also known as dampening, and is used to reduce the size of the calculated dependent variable before proceeding to the next outer iteration.  Under-relaxation can be an effective tool for highly nonlinear models when there are large and often counteracting changes in the calculated dependent variable between successive outer iterations.  By default under-relaxation is not used.  NONE - under-relaxation is not used (default). SIMPLE - Simple under-relaxation scheme with a fixed relaxation factor (UNDER\\_RELAXATION\\_GAMMA) is used.  COOLEY - Cooley under-relaxation scheme is used.  DBD - delta-bar-delta under-relaxation is used.  Note that the under-relaxation schemes are often used in conjunction with problems that use the Newton-Raphson formulation, however, experience has indicated that they also work well for non-Newton problems, such as those with the wet/dry options of MODFLOW 6.": [
+        "sln-ims"
+      ]
     },
     "options": {
-      "chf-nam": "keyword that indicates whether the surface water stage in a reach will be under-relaxed when water levels fall below the bottom of the model below any given cell. By default, Newton-Raphson UNDER\\_RELAXATION is not applied.",
-      "gwf-nam": "keyword that indicates whether the groundwater head in a cell will be under-relaxed when water levels fall below the bottom of the model below any given cell. By default, Newton-Raphson UNDER\\_RELAXATION is not applied.",
-      "olf-nam": "keyword that indicates whether the surface water stage in a reach will be under-relaxed when water levels fall below the bottom of the model below any given cell. By default, Newton-Raphson UNDER\\_RELAXATION is not applied.",
-      "swf-nam": "keyword that indicates whether the surface water stage in a reach will be under-relaxed when water levels fall below the bottom of the model below any given cell. By default, Newton-Raphson UNDER\\_RELAXATION is not applied."
+      "keyword that indicates whether the groundwater head in a cell will be under-relaxed when water levels fall below the bottom of the model below any given cell. By default, Newton-Raphson UNDER\\_RELAXATION is not applied.": [
+        "gwf-nam"
+      ],
+      "keyword that indicates whether the surface water stage in a reach will be under-relaxed when water levels fall below the bottom of the model below any given cell. By default, Newton-Raphson UNDER\\_RELAXATION is not applied.": [
+        "chf-nam",
+        "olf-nam",
+        "swf-nam"
+      ]
     }
   },
   "under_relaxation_gamma": {
     "nonlinear": {
-      "sln-ims": "real value defining either the relaxation factor for the SIMPLE scheme or the history or memory term factor of the Cooley and delta-bar-delta algorithms. For the SIMPLE scheme, a value of one indicates that there is no under-relaxation and the full head change is applied.  This value can be gradually reduced from one as a way to improve convergence; for well behaved problems, using a value less than one can increase the number of outer iterations required for convergence and needlessly increase run times.  UNDER\\_RELAXATION\\_GAMMA must be greater than zero for the SIMPLE scheme or the program will terminate with an error.  For the Cooley and delta-bar-delta schemes, UNDER\\_RELAXATION\\_GAMMA is a memory term that can range between zero and one. When UNDER\\_RELAXATION\\_GAMMA is zero, only the most recent history (previous iteration value) is maintained. As UNDER\\_RELAXATION\\_GAMMA is increased, past history of iteration changes has greater influence on the memory term. The memory term is maintained as an exponential average of past changes. Retaining some past history can overcome granular behavior in the calculated function surface and therefore helps to overcome cyclic patterns of non-convergence. The value usually ranges from 0.1 to 0.3; a value of 0.2 works well for most problems. UNDER\\_RELAXATION\\_GAMMA only needs to be specified if UNDER\\_RELAXATION is not NONE."
+      "real value defining either the relaxation factor for the SIMPLE scheme or the history or memory term factor of the Cooley and delta-bar-delta algorithms. For the SIMPLE scheme, a value of one indicates that there is no under-relaxation and the full head change is applied.  This value can be gradually reduced from one as a way to improve convergence; for well behaved problems, using a value less than one can increase the number of outer iterations required for convergence and needlessly increase run times.  UNDER\\_RELAXATION\\_GAMMA must be greater than zero for the SIMPLE scheme or the program will terminate with an error.  For the Cooley and delta-bar-delta schemes, UNDER\\_RELAXATION\\_GAMMA is a memory term that can range between zero and one. When UNDER\\_RELAXATION\\_GAMMA is zero, only the most recent history (previous iteration value) is maintained. As UNDER\\_RELAXATION\\_GAMMA is increased, past history of iteration changes has greater influence on the memory term. The memory term is maintained as an exponential average of past changes. Retaining some past history can overcome granular behavior in the calculated function surface and therefore helps to overcome cyclic patterns of non-convergence. The value usually ranges from 0.1 to 0.3; a value of 0.2 works well for most problems. UNDER\\_RELAXATION\\_GAMMA only needs to be specified if UNDER\\_RELAXATION is not NONE.": [
+        "sln-ims"
+      ]
     }
   },
   "under_relaxation_kappa": {
     "nonlinear": {
-      "sln-ims": "real value defining the increment for the learning rate (under-relaxation term) of the delta-bar-delta algorithm. The value of UNDER\\_RELAXATION\\_kappa is between zero and one. If the change in the dependent-variable (for example, head) is of the same sign to that of the previous iteration, the under-relaxation term is increased by an increment of UNDER\\_RELAXATION\\_KAPPA. The value usually ranges from 0.03 to 0.3; a value of 0.1 works well for most problems. UNDER\\_RELAXATION\\_KAPPA only needs to be specified if UNDER\\_RELAXATION is DBD."
+      "real value defining the increment for the learning rate (under-relaxation term) of the delta-bar-delta algorithm. The value of UNDER\\_RELAXATION\\_kappa is between zero and one. If the change in the dependent-variable (for example, head) is of the same sign to that of the previous iteration, the under-relaxation term is increased by an increment of UNDER\\_RELAXATION\\_KAPPA. The value usually ranges from 0.03 to 0.3; a value of 0.1 works well for most problems. UNDER\\_RELAXATION\\_KAPPA only needs to be specified if UNDER\\_RELAXATION is DBD.": [
+        "sln-ims"
+      ]
     }
   },
   "under_relaxation_momentum": {
     "nonlinear": {
-      "sln-ims": "real value defining the fraction of past history changes that is added as a momentum term to the step change for a nonlinear iteration. The value of UNDER\\_RELAXATION\\_MOMENTUM is between zero and one. A large momentum term should only be used when small learning rates are expected. Small amounts of the momentum term help convergence. The value usually ranges from 0.0001 to 0.1; a value of 0.001 works well for most problems. UNDER\\_RELAXATION\\_MOMENTUM only needs to be specified if UNDER\\_RELAXATION is DBD."
+      "real value defining the fraction of past history changes that is added as a momentum term to the step change for a nonlinear iteration. The value of UNDER\\_RELAXATION\\_MOMENTUM is between zero and one. A large momentum term should only be used when small learning rates are expected. Small amounts of the momentum term help convergence. The value usually ranges from 0.0001 to 0.1; a value of 0.001 works well for most problems. UNDER\\_RELAXATION\\_MOMENTUM only needs to be specified if UNDER\\_RELAXATION is DBD.": [
+        "sln-ims"
+      ]
     }
   },
   "under_relaxation_theta": {
     "nonlinear": {
-      "sln-ims": "real value defining the reduction factor for the learning rate (under-relaxation term) of the delta-bar-delta algorithm. The value of UNDER\\_RELAXATION\\_THETA is between zero and one. If the change in the dependent-variable (for example, head) is of opposite sign to that of the previous iteration, the under-relaxation term is reduced by a factor of UNDER\\_RELAXATION\\_THETA. The value usually ranges from 0.3 to 0.9; a value of 0.7 works well for most problems. UNDER\\_RELAXATION\\_THETA only needs to be specified if UNDER\\_RELAXATION is DBD."
+      "real value defining the reduction factor for the learning rate (under-relaxation term) of the delta-bar-delta algorithm. The value of UNDER\\_RELAXATION\\_THETA is between zero and one. If the change in the dependent-variable (for example, head) is of opposite sign to that of the previous iteration, the under-relaxation term is reduced by a factor of UNDER\\_RELAXATION\\_THETA. The value usually ranges from 0.3 to 0.9; a value of 0.7 works well for most problems. UNDER\\_RELAXATION\\_THETA only needs to be specified if UNDER\\_RELAXATION is DBD.": [
+        "sln-ims"
+      ]
     }
   },
   "unit_conversion": {
     "options": {
-      "gwf-sfr": "real value that is used to convert user-specified Manning's roughness coefficients from seconds per meters$^{1/3}$ to model length and time units. A constant of 1.486 is used for flow units of cubic feet per second, and a constant of 1.0 is used for units of cubic meters per second. The constant must be multiplied by 86,400 when using time units of days in the simulation."
+      "real value that is used to convert user-specified Manning's roughness coefficients from seconds per meters$^{1/3}$ to model length and time units. A constant of 1.486 is used for flow units of cubic feet per second, and a constant of 1.0 is used for units of cubic meters per second. The constant must be multiplied by 86,400 when using time units of days in the simulation.": [
+        "gwf-sfr"
+      ]
     }
   },
   "unsat_etae": {
     "options": {
-      "gwf-uzf": "keyword specifying that ET in the unsaturated zone will be simulated using a capillary pressure based formulation. Capillary pressure is calculated using the Brooks-Corey retention function."
+      "keyword specifying that ET in the unsaturated zone will be simulated using a capillary pressure based formulation. Capillary pressure is calculated using the Brooks-Corey retention function.": [
+        "gwf-uzf"
+      ]
     }
   },
   "unsat_etwc": {
     "options": {
-      "gwf-uzf": "keyword specifying that ET in the unsaturated zone will be simulated as a function of the specified PET rate while the water content (THETA) is greater than the ET extinction water content (EXTWC)."
+      "keyword specifying that ET in the unsaturated zone will be simulated as a function of the specified PET rate while the water content (THETA) is greater than the ET extinction water content (EXTWC).": [
+        "gwf-uzf"
+      ]
     }
   },
   "update_material_properties": {
     "options": {
-      "gwf-csub": "keyword to indicate that the thickness and void ratio of coarse-grained and interbed sediments (delay and no-delay) will vary during the simulation. If not specified, the thickness and void ratio of coarse-grained and interbed sediments will not vary during the simulation."
+      "keyword to indicate that the thickness and void ratio of coarse-grained and interbed sediments (delay and no-delay) will vary during the simulation. If not specified, the thickness and void ratio of coarse-grained and interbed sediments will not vary during the simulation.": [
+        "gwf-csub"
+      ]
     }
   },
   "upstream_fraction": {
     "period": {
-      "gwf-sfr": "real value that defines the fraction of upstream flow (USTRF) from each upstream reach that is applied as upstream inflow to the reach. The sum of all USTRF values for all reaches connected to the same upstream reach must be equal to one."
+      "real value that defines the fraction of upstream flow (USTRF) from each upstream reach that is applied as upstream inflow to the reach. The sum of all USTRF values for all reaches connected to the same upstream reach must be equal to one.": [
+        "gwf-sfr"
+      ]
     }
   },
   "uzet": {
     "period": {
-      "gwe-uze": "real or character value that states what fraction of the simulated unsaturated zone evapotranspiration is associated with evaporation.  The evaporative losses from the unsaturated zone moisture content will have an evaporative cooling effect on the GWE cell from which the evaporation originated. If this value is larger than 1, then it will be reset to 1.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      "gwt-uzt": "real or character value that defines the concentration of unsaturated zone evapotranspiration water $(ML^{-3})$ for the UZF cell. If this concentration value is larger than the simulated concentration in the UZF cell, then the unsaturated zone ET water will be removed at the same concentration as the UZF cell.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+      "real or character value that defines the concentration of unsaturated zone evapotranspiration water $(ML^{-3})$ for the UZF cell. If this concentration value is larger than the simulated concentration in the UZF cell, then the unsaturated zone ET water will be removed at the same concentration as the UZF cell.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+        "gwt-uzt"
+      ],
+      "real or character value that states what fraction of the simulated unsaturated zone evapotranspiration is associated with evaporation.  The evaporative losses from the unsaturated zone moisture content will have an evaporative cooling effect on the GWE cell from which the evaporation originated. If this value is larger than 1, then it will be reset to 1.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+        "gwe-uze"
+      ]
     }
   },
   "variablecv": {
     "options": {
-      "exg-gwfgwf": "keyword to indicate that the vertical conductance will be calculated using the saturated thickness and properties of the overlying cell and the thickness and properties of the underlying cell.  If the DEWATERED keyword is also specified, then the vertical conductance is calculated using only the saturated thickness and properties of the overlying cell if the head in the underlying cell is below its top.  If these keywords are not specified, then the default condition is to calculate the vertical conductance at the start of the simulation using the initial head and the cell properties.  The vertical conductance remains constant for the entire simulation.",
-      "gwf-npf": "keyword to indicate that the vertical conductance will be calculated using the saturated thickness and properties of the overlying cell and the thickness and properties of the underlying cell.  If the DEWATERED keyword is also specified, then the vertical conductance is calculated using only the saturated thickness and properties of the overlying cell if the head in the underlying cell is below its top.  If these keywords are not specified, then the default condition is to calculate the vertical conductance at the start of the simulation using the initial head and the cell properties.  The vertical conductance remains constant for the entire simulation."
+      "keyword to indicate that the vertical conductance will be calculated using the saturated thickness and properties of the overlying cell and the thickness and properties of the underlying cell.  If the DEWATERED keyword is also specified, then the vertical conductance is calculated using only the saturated thickness and properties of the overlying cell if the head in the underlying cell is below its top.  If these keywords are not specified, then the default condition is to calculate the vertical conductance at the start of the simulation using the initial head and the cell properties.  The vertical conductance remains constant for the entire simulation.": [
+        "exg-gwfgwf",
+        "gwf-npf"
+      ]
     }
   },
   "vertical_offset_tolerance": {
     "options": {
-      "gwe-disu": "checks are performed to ensure that the top of a cell is not higher than the bottom of an overlying cell.  This option can be used to specify the tolerance that is used for checking.  If top of a cell is above the bottom of an overlying cell by a value less than this tolerance, then the program will not terminate with an error.  The default value is zero.  This option should generally not be used.",
-      "gwf-disu": "checks are performed to ensure that the top of a cell is not higher than the bottom of an overlying cell.  This option can be used to specify the tolerance that is used for checking.  If top of a cell is above the bottom of an overlying cell by a value less than this tolerance, then the program will not terminate with an error.  The default value is zero.  This option should generally not be used.",
-      "gwt-disu": "checks are performed to ensure that the top of a cell is not higher than the bottom of an overlying cell.  This option can be used to specify the tolerance that is used for checking.  If top of a cell is above the bottom of an overlying cell by a value less than this tolerance, then the program will not terminate with an error.  The default value is zero.  This option should generally not be used."
+      "checks are performed to ensure that the top of a cell is not higher than the bottom of an overlying cell.  This option can be used to specify the tolerance that is used for checking.  If top of a cell is above the bottom of an overlying cell by a value less than this tolerance, then the program will not terminate with an error.  The default value is zero.  This option should generally not be used.": [
+        "gwe-disu",
+        "gwf-disu",
+        "gwt-disu"
+      ]
     }
   },
   "viscosity": {
     "options": {
-      "gwf-vsc": "keyword to specify that record corresponds to viscosity."
+      "keyword to specify that record corresponds to viscosity.": [
+        "gwf-vsc"
+      ]
     }
   },
   "viscref": {
     "options": {
-      "gwf-vsc": "fluid reference viscosity used in the equation of state.  This value is set to 1.0 if not specified as an option."
+      "fluid reference viscosity used in the equation of state.  This value is set to 1.0 if not specified as an option.": [
+        "gwf-vsc"
+      ]
     }
   },
   "volfrac": {
     "griddata": {
-      "gwt-ist": "fraction of the cell volume that consists of this immobile domain.  The sum of all immobile domain volume fractions must be less than one."
+      "fraction of the cell volume that consists of this immobile domain.  The sum of all immobile domain volume fractions must be less than one.": [
+        "gwt-ist"
+      ]
     }
   },
   "water_content": {
     "options": {
-      "gwf-uzf": "keyword to specify that record corresponds to unsaturated zone water contents."
+      "keyword to specify that record corresponds to unsaturated zone water contents.": [
+        "gwf-uzf"
+      ]
     }
   },
   "well_head": {
     "period": {
-      "gwf-maw": "is the head in the multi-aquifer well. WELL\\_HEAD is only applied to constant head (STATUS is CONSTANT) and inactive (STATUS is INACTIVE) multi-aquifer wells. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. The program will terminate with an error if WELL\\_HEAD is less than the bottom of the well."
+      "is the head in the multi-aquifer well. WELL\\_HEAD is only applied to constant head (STATUS is CONSTANT) and inactive (STATUS is INACTIVE) multi-aquifer wells. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. The program will terminate with an error if WELL\\_HEAD is less than the bottom of the well.": [
+        "gwf-maw"
+      ]
     }
   },
   "wetdry": {
     "griddata": {
-      "gwf-npf": "is a combination of the wetting threshold and a flag to indicate which neighboring cells can cause a cell to become wet. If WETDRY $<$ 0, only a cell below a dry cell can cause the cell to become wet. If WETDRY $>$ 0, the cell below a dry cell and horizontally adjacent cells can cause a cell to become wet. If WETDRY is 0, the cell cannot be wetted. The absolute value of WETDRY is the wetting threshold. When the sum of BOT and the absolute value of WETDRY at a dry cell is equaled or exceeded by the head at an adjacent cell, the cell is wetted.  WETDRY must be specified if ``REWET'' is specified in the OPTIONS block.  If ``REWET'' is not specified in the options block, then WETDRY can be entered, and memory will be allocated for it, even though it is not used."
+      "is a combination of the wetting threshold and a flag to indicate which neighboring cells can cause a cell to become wet. If WETDRY $<$ 0, only a cell below a dry cell can cause the cell to become wet. If WETDRY $>$ 0, the cell below a dry cell and horizontally adjacent cells can cause a cell to become wet. If WETDRY is 0, the cell cannot be wetted. The absolute value of WETDRY is the wetting threshold. When the sum of BOT and the absolute value of WETDRY at a dry cell is equaled or exceeded by the head at an adjacent cell, the cell is wetted.  WETDRY must be specified if ``REWET'' is specified in the OPTIONS block.  If ``REWET'' is not specified in the options block, then WETDRY can be entered, and memory will be allocated for it, even though it is not used.": [
+        "gwf-npf"
+      ]
     }
   },
   "wetfct": {
     "options": {
-      "gwf-npf": "is a keyword and factor that is included in the calculation of the head that is initially established at a cell when that cell is converted from dry to wet."
+      "is a keyword and factor that is included in the calculation of the head that is initially established at a cell when that cell is converted from dry to wet.": [
+        "gwf-npf"
+      ]
     }
   },
   "width": {
     "griddata": {
-      "chf-disv1d": "real value that defines the width for each one-dimensional cell. WIDTH must be greater than zero.  If the Cross Section (CXS) Package is used, then the WIDTH value will be multiplied by the specified cross section x-fraction values.",
-      "olf-disv1d": "real value that defines the width for each one-dimensional cell. WIDTH must be greater than zero.  If the Cross Section (CXS) Package is used, then the WIDTH value will be multiplied by the specified cross section x-fraction values.",
-      "swf-disv1d": "real value that defines the width for each one-dimensional cell. WIDTH must be greater than zero.  If the Cross Section (CXS) Package is used, then the WIDTH value will be multiplied by the specified cross section x-fraction values."
+      "real value that defines the width for each one-dimensional cell. WIDTH must be greater than zero.  If the Cross Section (CXS) Package is used, then the WIDTH value will be multiplied by the specified cross section x-fraction values.": [
+        "chf-disv1d",
+        "olf-disv1d",
+        "swf-disv1d"
+      ]
     },
     "options": {
-      "chf-oc": "width for writing each number.",
-      "gwe-oc": "width for writing each number.",
-      "gwf-oc": "width for writing each number.",
-      "gwt-ist": "width for writing each number.",
-      "gwt-oc": "width for writing each number.",
-      "olf-oc": "width for writing each number.",
-      "swf-oc": "width for writing each number."
+      "width for writing each number.": [
+        "chf-oc",
+        "gwe-oc",
+        "gwf-oc",
+        "gwt-ist",
+        "gwt-oc",
+        "olf-oc",
+        "swf-oc"
+      ]
     },
     "period": {
-      "gwf-lak": "real or character value that defines the width of the lake outlet. A specified WIDTH value is only used for active lakes if COUTTYPE for lake outlet OUTLETNO is not SPECIFIED. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+      "real or character value that defines the width of the lake outlet. A specified WIDTH value is only used for active lakes if COUTTYPE for lake outlet OUTLETNO is not SPECIFIED. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+        "gwf-lak"
+      ]
     }
   },
   "withdrawal": {
     "period": {
-      "gwf-lak": "real or character value that defines the maximum withdrawal rate $(L^3 T^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+      "real or character value that defines the maximum withdrawal rate $(L^3 T^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+        "gwf-lak"
+      ]
     }
   },
   "wkt": {
     "options": {
-      "utl-ncf": "is the coordinate reference system (CRS) well-known text (WKT) string."
+      "is the coordinate reference system (CRS) well-known text (WKT) string.": [
+        "utl-ncf"
+      ]
     }
   },
   "xorigin": {
     "options": {
-      "chf-disv1d": "x-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      "gwe-dis": "x-position of the lower-left corner of the model grid.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      "gwe-disu": "x-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      "gwe-disv": "x-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      "gwf-dis": "x-position of the lower-left corner of the model grid.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      "gwf-disu": "x-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      "gwf-disv": "x-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      "gwt-dis": "x-position of the lower-left corner of the model grid.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      "gwt-disu": "x-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      "gwt-disv": "x-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      "olf-dis2d": "x-position of the lower-left corner of the model grid.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      "olf-disv1d": "x-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      "olf-disv2d": "x-position of the lower-left corner of the model grid.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      "prt-dis": "x-position of the lower-left corner of the model grid.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      "prt-disv": "x-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      "swf-dis2d": "x-position of the lower-left corner of the model grid.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      "swf-disv1d": "x-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      "swf-disv2d": "x-position of the lower-left corner of the model grid.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space."
+      "x-position of the lower-left corner of the model grid.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.": [
+        "gwe-dis",
+        "gwf-dis",
+        "gwt-dis",
+        "olf-dis2d",
+        "olf-disv2d",
+        "prt-dis",
+        "swf-dis2d",
+        "swf-disv2d"
+      ],
+      "x-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.": [
+        "chf-disv1d",
+        "gwe-disu",
+        "gwe-disv",
+        "gwf-disu",
+        "gwf-disv",
+        "gwt-disu",
+        "gwt-disv",
+        "olf-disv1d",
+        "prt-disv",
+        "swf-disv1d"
+      ]
     }
   },
   "xt3d": {
     "options": {
-      "exg-gwfgwf": "keyword that activates the XT3D formulation between the cells connected with this GWF-GWF Exchange.",
-      "gwf-npf": "keyword indicating that the XT3D formulation will be used.  If the RHS keyword is also included, then the XT3D additional terms will be added to the right-hand side.  If the RHS keyword is excluded, then the XT3D terms will be put into the coefficient matrix.  Use of XT3D will substantially increase the computational effort, but will result in improved accuracy for anisotropic conductivity fields and for unstructured grids in which the CVFD requirement is violated.  XT3D requires additional information about the shapes of grid cells.  If XT3D is active and the DISU Package is used, then the user will need to provide in the DISU Package the angldegx array in the CONNECTIONDATA block and the VERTICES and CELL2D blocks."
+      "keyword indicating that the XT3D formulation will be used.  If the RHS keyword is also included, then the XT3D additional terms will be added to the right-hand side.  If the RHS keyword is excluded, then the XT3D terms will be put into the coefficient matrix.  Use of XT3D will substantially increase the computational effort, but will result in improved accuracy for anisotropic conductivity fields and for unstructured grids in which the CVFD requirement is violated.  XT3D requires additional information about the shapes of grid cells.  If XT3D is active and the DISU Package is used, then the user will need to provide in the DISU Package the angldegx array in the CONNECTIONDATA block and the VERTICES and CELL2D blocks.": [
+        "gwf-npf"
+      ],
+      "keyword that activates the XT3D formulation between the cells connected with this GWF-GWF Exchange.": [
+        "exg-gwfgwf"
+      ]
     }
   },
   "xt3d_off": {
     "options": {
-      "gwe-cnd": "deactivate the xt3d method and use the faster and less accurate approximation.  This option may provide a fast and accurate solution under some circumstances, such as when flow aligns with the model grid, there is no mechanical dispersion, or when the longitudinal and transverse dispersivities are equal.  This option may also be used to assess the computational demand of the XT3D approach by noting the run time differences with and without this option on.",
-      "gwt-dsp": "deactivate the xt3d method and use the faster and less accurate approximation.  This option may provide a fast and accurate solution under some circumstances, such as when flow aligns with the model grid, there is no mechanical dispersion, or when the longitudinal and transverse dispersivities are equal.  This option may also be used to assess the computational demand of the XT3D approach by noting the run time differences with and without this option on."
+      "deactivate the xt3d method and use the faster and less accurate approximation.  This option may provide a fast and accurate solution under some circumstances, such as when flow aligns with the model grid, there is no mechanical dispersion, or when the longitudinal and transverse dispersivities are equal.  This option may also be used to assess the computational demand of the XT3D approach by noting the run time differences with and without this option on.": [
+        "gwe-cnd",
+        "gwt-dsp"
+      ]
     }
   },
   "xt3d_rhs": {
     "options": {
-      "gwe-cnd": "add xt3d terms to right-hand side, when possible.  This option uses less memory, but may require more iterations.",
-      "gwt-dsp": "add xt3d terms to right-hand side, when possible.  This option uses less memory, but may require more iterations."
+      "add xt3d terms to right-hand side, when possible.  This option uses less memory, but may require more iterations.": [
+        "gwe-cnd",
+        "gwt-dsp"
+      ]
     }
   },
   "xt3doptions": {
     "options": {
-      "gwf-npf": "none"
+      "none": [
+        "gwf-npf"
+      ]
     }
   },
   "yorigin": {
     "options": {
-      "chf-disv1d": "y-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      "gwe-dis": "y-position of the lower-left corner of the model grid.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      "gwe-disu": "y-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      "gwe-disv": "y-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      "gwf-dis": "y-position of the lower-left corner of the model grid.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      "gwf-disu": "y-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      "gwf-disv": "y-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      "gwt-dis": "y-position of the lower-left corner of the model grid.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      "gwt-disu": "y-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      "gwt-disv": "y-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      "olf-dis2d": "y-position of the lower-left corner of the model grid.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      "olf-disv1d": "y-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      "olf-disv2d": "y-position of the lower-left corner of the model grid.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      "prt-dis": "y-position of the lower-left corner of the model grid.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      "prt-disv": "y-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      "swf-dis2d": "y-position of the lower-left corner of the model grid.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      "swf-disv1d": "y-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      "swf-disv2d": "y-position of the lower-left corner of the model grid.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space."
+      "y-position of the lower-left corner of the model grid.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.": [
+        "gwe-dis",
+        "gwf-dis",
+        "gwt-dis",
+        "olf-dis2d",
+        "olf-disv2d",
+        "prt-dis",
+        "swf-dis2d",
+        "swf-disv2d"
+      ],
+      "y-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.": [
+        "chf-disv1d",
+        "gwe-disu",
+        "gwe-disv",
+        "gwf-disu",
+        "gwf-disv",
+        "gwt-disu",
+        "gwt-disv",
+        "olf-disv1d",
+        "prt-disv",
+        "swf-disv1d"
+      ]
     }
   },
   "zdisplacement": {
     "options": {
-      "gwf-csub": "keyword to specify that record corresponds to the z-displacement binary file."
+      "keyword to specify that record corresponds to the z-displacement binary file.": [
+        "gwf-csub"
+      ]
     }
   },
   "zero_order_decay": {
     "options": {
-      "gwt-ist": "is a text keyword to indicate that zero-order decay will occur.  Use of this keyword requires that DECAY and DECAY\\_SORBED (if sorption is active) are specified in the GRIDDATA block.",
-      "gwt-mst": "is a text keyword to indicate that zero-order decay will occur.  Use of this keyword requires that DECAY and DECAY\\_SORBED (if sorption is active) are specified in the GRIDDATA block."
+      "is a text keyword to indicate that zero-order decay will occur.  Use of this keyword requires that DECAY and DECAY\\_SORBED (if sorption is active) are specified in the GRIDDATA block.": [
+        "gwt-ist",
+        "gwt-mst"
+      ]
     }
   },
   "zero_order_decay_solid": {
     "options": {
-      "gwe-est": "is a text keyword to indicate that zero-order decay will occur in the solid phase. That is, decay occurs in the solid and is a rate per mass (not volume) of solid only.  Use of this keyword requires that DECAY\\_SOLID is specified in the GRIDDATA block."
+      "is a text keyword to indicate that zero-order decay will occur in the solid phase. That is, decay occurs in the solid and is a rate per mass (not volume) of solid only.  Use of this keyword requires that DECAY\\_SOLID is specified in the GRIDDATA block.": [
+        "gwe-est"
+      ]
     }
   },
   "zero_order_decay_water": {
     "options": {
-      "gwe-est": "is a text keyword to indicate that zero-order decay will occur in the aqueous phase. That is, decay occurs in the water and is a rate per volume of water only, not per volume of aquifer (i.e., grid cell).  Use of this keyword requires that DECAY\\_WATER is specified in the GRIDDATA block."
+      "is a text keyword to indicate that zero-order decay will occur in the aqueous phase. That is, decay occurs in the water and is a rate per volume of water only, not per volume of aquifer (i.e., grid cell).  Use of this keyword requires that DECAY\\_WATER is specified in the GRIDDATA block.": [
+        "gwe-est"
+      ]
     }
   },
   "zetaim": {
     "griddata": {
-      "gwt-ist": "mass transfer rate coefficient between the mobile and immobile domains, in dimensions of per time."
+      "mass transfer rate coefficient between the mobile and immobile domains, in dimensions of per time.": [
+        "gwt-ist"
+      ]
     }
   }
 }

--- a/src/providers/hover.json
+++ b/src/providers/hover.json
@@ -33,7 +33,7 @@
   },
   "alternative_cell_averaging": {
     "options": {
-      "is a text keyword to indicate that an alternative method will be used for calculating the conductance for horizontal cell connections.  The text value for ALTERNATIVE\\_CELL\\_AVERAGING can be ``LOGARITHMIC'', ``AMT-LMK'', or ``AMT-HMK''.  ``AMT-LMK'' signifies that the conductance will be calculated using arithmetic-mean thickness and logarithmic-mean hydraulic conductivity.  ``AMT-HMK'' signifies that the conductance will be calculated using arithmetic-mean thickness and harmonic-mean hydraulic conductivity. If the user does not specify a value for ALTERNATIVE\\_CELL\\_AVERAGING, then the harmonic-mean method will be used.  This option cannot be used if the XT3D option is invoked.": [
+      "is a text keyword to indicate that an alternative method will be used for calculating the conductance for horizontal cell connections.  The text value for ALTERNATIVE\\_CELL\\_AVERAGING can be `LOGARITHMIC`, `AMT-LMK`, or `AMT-HMK`.  `AMT-LMK` signifies that the conductance will be calculated using arithmetic-mean thickness and logarithmic-mean hydraulic conductivity.  `AMT-HMK` signifies that the conductance will be calculated using arithmetic-mean thickness and harmonic-mean hydraulic conductivity. If the user does not specify a value for ALTERNATIVE\\_CELL\\_AVERAGING, then the harmonic-mean method will be used.  This option cannot be used if the XT3D option is invoked.": [
         "gwf-npf"
       ]
     }
@@ -159,7 +159,7 @@
   },
   "auto_flow_reduce": {
     "options": {
-      "keyword and real value that defines the fraction of the cell thickness used as an interval for smoothly adjusting negative pumping rates to 0 in cells with head values less than or equal to the bottom of the cell. Negative pumping rates are adjusted to 0 or a smaller negative value when the head in the cell is equal to or less than the calculated interval above the cell bottom. AUTO\\_FLOW\\_REDUCE is set to 0.1 if the specified value is less than or equal to zero. By default, negative pumping rates are not reduced during a simulation.  This AUTO\\_FLOW\\_REDUCE option only applies to wells in model cells that are marked as ``convertible'' (ICELLTYPE /= 0) in the Node Property Flow (NPF) input file. Reduction in flow will not occur for wells in cells marked as confined (ICELLTYPE = 0).": [
+      "keyword and real value that defines the fraction of the cell thickness used as an interval for smoothly adjusting negative pumping rates to 0 in cells with head values less than or equal to the bottom of the cell. Negative pumping rates are adjusted to 0 or a smaller negative value when the head in the cell is equal to or less than the calculated interval above the cell bottom. AUTO\\_FLOW\\_REDUCE is set to 0.1 if the specified value is less than or equal to zero. By default, negative pumping rates are not reduced during a simulation.  This AUTO\\_FLOW\\_REDUCE option only applies to wells in model cells that are marked as `convertible` (ICELLTYPE /= 0) in the Node Property Flow (NPF) input file. Reduction in flow will not occur for wells in cells marked as confined (ICELLTYPE = 0).": [
         "gwf-wel"
       ]
     }
@@ -190,13 +190,13 @@
   },
   "auxiliary": {
     "options": {
-      "an array of auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided. Most auxiliary variables will not be used by the GWE-GWE Exchange, but they will be available for use by other parts of the program.  If an auxiliary variable with the name ``ANGLDEGX'' is found, then this information will be used as the angle (provided in degrees) between the connection face normal and the x axis, where a value of zero indicates that a normal vector points directly along the positive x axis.  The connection face normal is a normal vector on the cell face shared between the cell in model 1 and the cell in model 2 pointing away from the model 1 cell.  Additional information on ``ANGLDEGX'' is provided in the description of the DISU Package.  If an auxiliary variable with the name ``CDIST'' is found, then this information will be used as the straight-line connection distance, including the vertical component, between the two cell centers.  Both ANGLDEGX and CDIST are required if specific discharge is calculated for either of the groundwater models.": [
+      "an array of auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided. Most auxiliary variables will not be used by the GWE-GWE Exchange, but they will be available for use by other parts of the program.  If an auxiliary variable with the name `ANGLDEGX` is found, then this information will be used as the angle (provided in degrees) between the connection face normal and the x axis, where a value of zero indicates that a normal vector points directly along the positive x axis.  The connection face normal is a normal vector on the cell face shared between the cell in model 1 and the cell in model 2 pointing away from the model 1 cell.  Additional information on `ANGLDEGX` is provided in the description of the DISU Package.  If an auxiliary variable with the name `CDIST` is found, then this information will be used as the straight-line connection distance, including the vertical component, between the two cell centers.  Both ANGLDEGX and CDIST are required if specific discharge is calculated for either of the groundwater models.": [
         "exg-gwegwe"
       ],
-      "an array of auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided. Most auxiliary variables will not be used by the GWF-GWF Exchange, but they will be available for use by other parts of the program.  If an auxiliary variable with the name ``ANGLDEGX'' is found, then this information will be used as the angle (provided in degrees) between the connection face normal and the x axis, where a value of zero indicates that a normal vector points directly along the positive x axis.  The connection face normal is a normal vector on the cell face shared between the cell in model 1 and the cell in model 2 pointing away from the model 1 cell.  Additional information on ``ANGLDEGX'' and when it is required is provided in the description of the DISU Package.  If an auxiliary variable with the name ``CDIST'' is found, then this information will be used in the calculation of specific discharge within model cells connected by the exchange.  For a horizontal connection, CDIST should be specified as the horizontal distance between the cell centers, and should not include the vertical component.  For vertical connections, CDIST should be specified as the difference in elevation between the two cell centers.  Both ANGLDEGX and CDIST are required if specific discharge is calculated for either of the groundwater models.": [
+      "an array of auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided. Most auxiliary variables will not be used by the GWF-GWF Exchange, but they will be available for use by other parts of the program.  If an auxiliary variable with the name `ANGLDEGX` is found, then this information will be used as the angle (provided in degrees) between the connection face normal and the x axis, where a value of zero indicates that a normal vector points directly along the positive x axis.  The connection face normal is a normal vector on the cell face shared between the cell in model 1 and the cell in model 2 pointing away from the model 1 cell.  Additional information on `ANGLDEGX` and when it is required is provided in the description of the DISU Package.  If an auxiliary variable with the name `CDIST` is found, then this information will be used in the calculation of specific discharge within model cells connected by the exchange.  For a horizontal connection, CDIST should be specified as the horizontal distance between the cell centers, and should not include the vertical component.  For vertical connections, CDIST should be specified as the difference in elevation between the two cell centers.  Both ANGLDEGX and CDIST are required if specific discharge is calculated for either of the groundwater models.": [
         "exg-gwfgwf"
       ],
-      "an array of auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided. Most auxiliary variables will not be used by the GWT-GWT Exchange, but they will be available for use by other parts of the program.  If an auxiliary variable with the name ``ANGLDEGX'' is found, then this information will be used as the angle (provided in degrees) between the connection face normal and the x axis, where a value of zero indicates that a normal vector points directly along the positive x axis.  The connection face normal is a normal vector on the cell face shared between the cell in model 1 and the cell in model 2 pointing away from the model 1 cell.  Additional information on ``ANGLDEGX'' is provided in the description of the DISU Package.  ANGLDEGX must be specified if dispersion is simulated in the connected GWT models.": [
+      "an array of auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided. Most auxiliary variables will not be used by the GWT-GWT Exchange, but they will be available for use by other parts of the program.  If an auxiliary variable with the name `ANGLDEGX` is found, then this information will be used as the angle (provided in degrees) between the connection face normal and the x axis, where a value of zero indicates that a normal vector points directly along the positive x axis.  The connection face normal is a normal vector on the cell face shared between the cell in model 1 and the cell in model 2 pointing away from the model 1 cell.  Additional information on `ANGLDEGX` is provided in the description of the DISU Package.  ANGLDEGX must be specified if dispersion is simulated in the connected GWT models.": [
         "exg-gwtgwt"
       ],
       "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.": [
@@ -351,7 +351,7 @@
   },
   "bedk": {
     "period": {
-      "real or character value that defines the hydraulic conductivity of the reach streambed. BEDK can be any positive value if the reach is not connected to an underlying GWF cell. Otherwise, BEDK must be greater than zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+      "real or character value that defines the hydraulic conductivity of the reach streambed. BEDK can be any positive value if the reach is not connected to an underlying GWF cell. Otherwise, BEDK must be greater than zero. If the Options block includes a TIMESERIESFILE entry (see the `Time-Variable Input` section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
         "gwf-sfr"
       ]
     }
@@ -583,7 +583,7 @@
   },
   "cell_averaging": {
     "options": {
-      "is a keyword and text keyword to indicate the method that will be used for calculating the conductance for horizontal cell connections.  The text value for CELL\\_AVERAGING can be ``HARMONIC'', ``LOGARITHMIC'', or ``AMT-LMK'', which means ``arithmetic-mean thickness and logarithmic-mean hydraulic conductivity''. If the user does not specify a value for CELL\\_AVERAGING, then the harmonic-mean method will be used.": [
+      "is a keyword and text keyword to indicate the method that will be used for calculating the conductance for horizontal cell connections.  The text value for CELL\\_AVERAGING can be `HARMONIC`, `LOGARITHMIC`, or `AMT-LMK`, which means `arithmetic-mean thickness and logarithmic-mean hydraulic conductivity`. If the user does not specify a value for CELL\\_AVERAGING, then the harmonic-mean method will be used.": [
         "exg-gwfgwf"
       ]
     }
@@ -762,22 +762,22 @@
       ]
     },
     "period": {
-      "is the boundary concentration. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, the CONCENTRATION for each boundary feature is zero.": [
+      "is the boundary concentration. If the Options block includes a TIMESERIESFILE entry (see the `Time-Variable Input` section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, the CONCENTRATION for each boundary feature is zero.": [
         "utl-spc"
       ],
       "is the concentration of the associated Recharge or Evapotranspiration stress package.  The concentration array may be defined by a time-array series (see the \"Using Time-Array Series in a Package\" section).": [
         "utl-spca"
       ],
-      "real or character value that defines the concentration for the lake. The specified CONCENTRATION is only applied if the lake is a constant concentration lake. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+      "real or character value that defines the concentration for the lake. The specified CONCENTRATION is only applied if the lake is a constant concentration lake. If the Options block includes a TIMESERIESFILE entry (see the `Time-Variable Input` section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
         "gwt-lkt"
       ],
-      "real or character value that defines the concentration for the reach. The specified CONCENTRATION is only applied if the reach is a constant concentration reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+      "real or character value that defines the concentration for the reach. The specified CONCENTRATION is only applied if the reach is a constant concentration reach. If the Options block includes a TIMESERIESFILE entry (see the `Time-Variable Input` section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
         "gwt-sft"
       ],
-      "real or character value that defines the concentration for the unsaturated zone flow cell. The specified CONCENTRATION is only applied if the unsaturated zone flow cell is a constant concentration cell. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+      "real or character value that defines the concentration for the unsaturated zone flow cell. The specified CONCENTRATION is only applied if the unsaturated zone flow cell is a constant concentration cell. If the Options block includes a TIMESERIESFILE entry (see the `Time-Variable Input` section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
         "gwt-uzt"
       ],
-      "real or character value that defines the concentration for the well. The specified CONCENTRATION is only applied if the well is a constant concentration well. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+      "real or character value that defines the concentration for the well. The specified CONCENTRATION is only applied if the well is a constant concentration well. If the Options block includes a TIMESERIESFILE entry (see the `Time-Variable Input` section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
         "gwt-mwt"
       ]
     }
@@ -1066,7 +1066,7 @@
   },
   "dry_tracking_method": {
     "options": {
-      "is a string indicating how particles should behave in dry-but-active cells (as can occur with the Newton formulation).  The value can be ``DROP'', ``STOP'', or ``STAY''.  The default is ``DROP'', which passes particles vertically and instantaneously to the water table. ``STOP'' causes particles to terminate. ``STAY'' causes particles to remain stationary but active.": [
+      "is a string indicating how particles should behave in dry-but-active cells (as can occur with the Newton formulation).  The value can be `DROP`, `STOP`, or `STAY`.  The default is `DROP`, which passes particles vertically and instantaneously to the water table. `STOP` causes particles to terminate. `STAY` causes particles to remain stationary but active.": [
         "prt-prp"
       ]
     }
@@ -1094,16 +1094,16 @@
   },
   "evaporation": {
     "period": {
-      "real or character value that defines the concentration of evaporated water $(ML^{-3})$ for the lake. If this concentration value is larger than the simulated concentration in the lake, then the evaporated water will be removed at the same concentration as the lake.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+      "real or character value that defines the concentration of evaporated water $(ML^{-3})$ for the lake. If this concentration value is larger than the simulated concentration in the lake, then the evaporated water will be removed at the same concentration as the lake.  If the Options block includes a TIMESERIESFILE entry (see the `Time-Variable Input` section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
         "gwt-lkt"
       ],
-      "real or character value that defines the concentration of evaporated water $(ML^{-3})$ for the reach. If this concentration value is larger than the simulated concentration in the reach, then the evaporated water will be removed at the same concentration as the reach.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+      "real or character value that defines the concentration of evaporated water $(ML^{-3})$ for the reach. If this concentration value is larger than the simulated concentration in the reach, then the evaporated water will be removed at the same concentration as the reach.  If the Options block includes a TIMESERIESFILE entry (see the `Time-Variable Input` section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
         "gwt-sft"
       ],
-      "real or character value that defines the maximum evaporation rate $(LT^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+      "real or character value that defines the maximum evaporation rate $(LT^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the `Time-Variable Input` section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
         "gwf-lak"
       ],
-      "real or character value that defines the volumetric rate per unit area of water subtracted by evaporation from the streamflow routing reach. A positive evaporation rate should be provided. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. If the volumetric evaporation rate for a reach exceeds the sources of water to the reach (upstream and specified inflows, rainfall, and runoff but excluding groundwater leakage into the reach) the volumetric evaporation rate is limited to the sources of water to the reach. By default, evaporation rates are zero for each reach.": [
+      "real or character value that defines the volumetric rate per unit area of water subtracted by evaporation from the streamflow routing reach. A positive evaporation rate should be provided. If the Options block includes a TIMESERIESFILE entry (see the `Time-Variable Input` section), values can be obtained from a time series by entering the time-series name in place of a numeric value. If the volumetric evaporation rate for a reach exceeds the sources of water to the reach (upstream and specified inflows, rainfall, and runoff but excluding groundwater leakage into the reach) the volumetric evaporation rate is limited to the sources of water to the reach. By default, evaporation rates are zero for each reach.": [
         "gwf-sfr"
       ],
       "use of the EVAPORATION keyword is allowed in the LKE package; however, the specified value is not currently used in LKE calculations.  Instead, the latent heat of evaporation is multiplied by the simulated evaporation rate for determining the thermal energy lost from a stream reach.": [
@@ -1203,10 +1203,10 @@
   },
   "ext-inflow": {
     "period": {
-      "real or character value that defines the concentration of external inflow $(ML^{-3})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+      "real or character value that defines the concentration of external inflow $(ML^{-3})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the `Time-Variable Input` section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
         "gwt-lkt"
       ],
-      "real or character value that defines the temperature of external inflow for the lake.  Users are free to use whatever temperature scale they want, which might include negative temperatures.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+      "real or character value that defines the temperature of external inflow for the lake.  Users are free to use whatever temperature scale they want, which might include negative temperatures.  If the Options block includes a TIMESERIESFILE entry (see the `Time-Variable Input` section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
         "gwe-lke"
       ]
     }
@@ -1627,7 +1627,7 @@
         "gwf-disu",
         "gwt-disu"
       ],
-      "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1 or greater, the cell exists in the simulation.  If the IDOMAIN value for a cell is -1, the cell does not exist in the simulation.  Furthermore, the first existing cell above will be connected to the first existing cell below.  This type of cell is referred to as a ``vertical pass through'' cell.": [
+      "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1 or greater, the cell exists in the simulation.  If the IDOMAIN value for a cell is -1, the cell does not exist in the simulation.  Furthermore, the first existing cell above will be connected to the first existing cell below.  This type of cell is referred to as a `vertical pass through` cell.": [
         "gwf-dis",
         "gwf-disv",
         "olf-disv2d",
@@ -1638,7 +1638,7 @@
         "olf-disv1d",
         "swf-disv1d"
       ],
-      "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1, the cell exists in the simulation.  If the IDOMAIN value for a cell is -1, the cell does not exist in the simulation.  Furthermore, the first existing cell above will be connected to the first existing cell below.  This type of cell is referred to as a ``vertical pass through'' cell.": [
+      "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1, the cell exists in the simulation.  If the IDOMAIN value for a cell is -1, the cell does not exist in the simulation.  Furthermore, the first existing cell above will be connected to the first existing cell below.  This type of cell is referred to as a `vertical pass through` cell.": [
         "gwe-dis",
         "gwe-disv",
         "gwt-dis",
@@ -1675,26 +1675,26 @@
   },
   "infiltration": {
     "period": {
-      "real or character value that defines the infiltration solute concentration $(ML^{-3})$ for the UZF cell. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+      "real or character value that defines the infiltration solute concentration $(ML^{-3})$ for the UZF cell. If the Options block includes a TIMESERIESFILE entry (see the `Time-Variable Input` section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
         "gwt-uzt"
       ],
-      "real or character value that defines the temperature of the infiltration $(e.g.,\\:^{\\circ}C\\:or\\:^{\\circ}F)$ for the UZF cell. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+      "real or character value that defines the temperature of the infiltration $(e.g.,\\:^{\\circ}C\\:or\\:^{\\circ}F)$ for the UZF cell. If the Options block includes a TIMESERIESFILE entry (see the `Time-Variable Input` section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
         "gwe-uze"
       ]
     }
   },
   "inflow": {
     "period": {
-      "real or character value that defines the concentration of inflow $(ML^{-3})$ for the reach. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+      "real or character value that defines the concentration of inflow $(ML^{-3})$ for the reach. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the `Time-Variable Input` section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
         "gwt-sft"
       ],
-      "real or character value that defines the temperature of inflow $(e.g.,\\:^{\\circ}C\\:or\\:^{\\circ}F)$ for the reach. Users are free to use whatever temperature scale they want, which might include negative temperatures.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+      "real or character value that defines the temperature of inflow $(e.g.,\\:^{\\circ}C\\:or\\:^{\\circ}F)$ for the reach. Users are free to use whatever temperature scale they want, which might include negative temperatures.  If the Options block includes a TIMESERIESFILE entry (see the `Time-Variable Input` section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
         "gwe-sfe"
       ],
-      "real or character value that defines the volumetric inflow rate $(L^3 T^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, inflow rates are zero for each lake.": [
+      "real or character value that defines the volumetric inflow rate $(L^3 T^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the `Time-Variable Input` section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, inflow rates are zero for each lake.": [
         "gwf-lak"
       ],
-      "real or character value that defines the volumetric inflow rate for the streamflow routing reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, inflow rates are zero for each reach.": [
+      "real or character value that defines the volumetric inflow rate for the streamflow routing reach. If the Options block includes a TIMESERIESFILE entry (see the `Time-Variable Input` section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, inflow rates are zero for each reach.": [
         "gwf-sfr"
       ]
     }
@@ -1736,7 +1736,7 @@
   },
   "invert": {
     "period": {
-      "real or character value that defines the invert elevation for the lake outlet. A specified INVERT value is only used for active lakes if COUTTYPE for lake outlet OUTLETNO is not SPECIFIED. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+      "real or character value that defines the invert elevation for the lake outlet. A specified INVERT value is only used for active lakes if COUTTYPE for lake outlet OUTLETNO is not SPECIFIED. If the Options block includes a TIMESERIESFILE entry (see the `Time-Variable Input` section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
         "gwf-lak"
       ]
     }
@@ -1789,7 +1789,7 @@
       ]
     },
     "period": {
-      "is the new value to be assigned as the cell's hydraulic conductivity from the start of the specified stress period, as per K in the NPF package.  If the OPTIONS block includes a TS6 entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+      "is the new value to be assigned as the cell's hydraulic conductivity from the start of the specified stress period, as per K in the NPF package.  If the OPTIONS block includes a TS6 entry (see the `Time-Variable Input` section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
         "utl-tvk"
       ]
     }
@@ -1801,7 +1801,7 @@
       ]
     },
     "period": {
-      "is the new value to be assigned as the cell's hydraulic conductivity of the second ellipsoid axis (or the ratio of K22/K if the K22OVERK NPF package option is specified) from the start of the specified stress period, as per K22 in the NPF package.  For an unrotated case this is the hydraulic conductivity in the y direction.  If the OPTIONS block includes a TS6 entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+      "is the new value to be assigned as the cell's hydraulic conductivity of the second ellipsoid axis (or the ratio of K22/K if the K22OVERK NPF package option is specified) from the start of the specified stress period, as per K22 in the NPF package.  For an unrotated case this is the hydraulic conductivity in the y direction.  If the OPTIONS block includes a TS6 entry (see the `Time-Variable Input` section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
         "utl-tvk"
       ]
     }
@@ -1820,7 +1820,7 @@
       ]
     },
     "period": {
-      "is the new value to be assigned as the cell's hydraulic conductivity of the third ellipsoid axis (or the ratio of K33/K if the K33OVERK NPF package option is specified) from the start of the specified stress period, as per K33 in the NPF package.  For an unrotated case, this is the vertical hydraulic conductivity.  If the OPTIONS block includes a TS6 entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+      "is the new value to be assigned as the cell's hydraulic conductivity of the third ellipsoid axis (or the ratio of K33/K if the K33OVERK NPF package option is specified) from the start of the specified stress period, as per K33 in the NPF package.  For an unrotated case, this is the vertical hydraulic conductivity.  If the OPTIONS block includes a TS6 entry (see the `Time-Variable Input` section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
         "utl-tvk"
       ]
     }
@@ -1898,7 +1898,7 @@
   },
   "length_units": {
     "options": {
-      "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.": [
+      "is the length units used for this model.  Values can be `FEET`, `METERS`, or `CENTIMETERS`.  If not specified, the default is `UNKNOWN`.": [
         "chf-disv1d",
         "gwe-dis",
         "gwe-disu",
@@ -1936,32 +1936,32 @@
   },
   "list": {
     "options": {
-      "is name of the listing file to create for this CHF model.  If not specified, then the name of the list file will be the basename of the CHF model name file and the '.lst' extension.  For example, if the CHF name file is called ``my.model.nam'' then the list file will be called ``my.model.lst''.": [
+      "is name of the listing file to create for this CHF model.  If not specified, then the name of the list file will be the basename of the CHF model name file and the '.lst' extension.  For example, if the CHF name file is called `my.model.nam` then the list file will be called `my.model.lst`.": [
         "chf-nam"
       ],
-      "is name of the listing file to create for this GWE model.  If not specified, then the name of the list file will be the basename of the GWE model name file and the ``.lst'' extension.  For example, if the GWE name file is called ``my.model.nam'' then the list file will be called ``my.model.lst''.": [
+      "is name of the listing file to create for this GWE model.  If not specified, then the name of the list file will be the basename of the GWE model name file and the `.lst` extension.  For example, if the GWE name file is called `my.model.nam` then the list file will be called `my.model.lst`.": [
         "gwe-nam"
       ],
-      "is name of the listing file to create for this GWF model.  If not specified, then the name of the list file will be the basename of the GWF model name file and the '.lst' extension.  For example, if the GWF name file is called ``my.model.nam'' then the list file will be called ``my.model.lst''.": [
+      "is name of the listing file to create for this GWF model.  If not specified, then the name of the list file will be the basename of the GWF model name file and the '.lst' extension.  For example, if the GWF name file is called `my.model.nam` then the list file will be called `my.model.lst`.": [
         "gwf-nam"
       ],
-      "is name of the listing file to create for this GWT model.  If not specified, then the name of the list file will be the basename of the GWT model name file and the '.lst' extension.  For example, if the GWT name file is called ``my.model.nam'' then the list file will be called ``my.model.lst''.": [
+      "is name of the listing file to create for this GWT model.  If not specified, then the name of the list file will be the basename of the GWT model name file and the '.lst' extension.  For example, if the GWT name file is called `my.model.nam` then the list file will be called `my.model.lst`.": [
         "gwt-nam"
       ],
-      "is name of the listing file to create for this OLF model.  If not specified, then the name of the list file will be the basename of the OLF model name file and the '.lst' extension.  For example, if the OLF name file is called ``my.model.nam'' then the list file will be called ``my.model.lst''.": [
+      "is name of the listing file to create for this OLF model.  If not specified, then the name of the list file will be the basename of the OLF model name file and the '.lst' extension.  For example, if the OLF name file is called `my.model.nam` then the list file will be called `my.model.lst`.": [
         "olf-nam"
       ],
-      "is name of the listing file to create for this PRT model.  If not specified, then the name of the list file will be the basename of the PRT model name file and the '.lst' extension.  For example, if the PRT name file is called ``my.model.nam'' then the list file will be called ``my.model.lst''.": [
+      "is name of the listing file to create for this PRT model.  If not specified, then the name of the list file will be the basename of the PRT model name file and the '.lst' extension.  For example, if the PRT name file is called `my.model.nam` then the list file will be called `my.model.lst`.": [
         "prt-nam"
       ],
-      "is name of the listing file to create for this SWF model.  If not specified, then the name of the list file will be the basename of the SWF model name file and the '.lst' extension.  For example, if the SWF name file is called ``my.model.nam'' then the list file will be called ``my.model.lst''.": [
+      "is name of the listing file to create for this SWF model.  If not specified, then the name of the list file will be the basename of the SWF model name file and the '.lst' extension.  For example, if the SWF name file is called `my.model.nam` then the list file will be called `my.model.lst`.": [
         "swf-nam"
       ]
     }
   },
   "local_z": {
     "options": {
-      "indicates that ``zrpt'' defines the local z coordinate of the release point within the cell, with value of 0 at the bottom and 1 at the top of the cell.  If the cell is partially saturated at release time, the top of the cell is considered to be the water table elevation (the head in the cell) rather than the top defined by the user.": [
+      "indicates that `zrpt` defines the local z coordinate of the release point within the cell, with value of 0 at the bottom and 1 at the top of the cell.  If the cell is partially saturated at release time, the top of the cell is considered to be the water table elevation (the head in the cell) rather than the top defined by the user.": [
         "prt-prp"
       ]
     }
@@ -1975,7 +1975,7 @@
   },
   "manning": {
     "period": {
-      "real or character value that defines the Manning's roughness coefficient for the reach. MANNING must be greater than zero.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+      "real or character value that defines the Manning's roughness coefficient for the reach. MANNING must be greater than zero.  If the Options block includes a TIMESERIESFILE entry (see the `Time-Variable Input` section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
         "gwf-sfr"
       ]
     }
@@ -2828,44 +2828,44 @@
   },
   "print_concentration": {
     "options": {
-      "keyword to indicate that the list of UZF cell concentration will be printed to the listing file for every stress period in which ``CONCENTRATION PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_CONCENTRATION is specified, then concentration are printed for the last time step of each stress period.": [
+      "keyword to indicate that the list of UZF cell concentration will be printed to the listing file for every stress period in which `CONCENTRATION PRINT` is specified in Output Control.  If there is no Output Control option and PRINT\\_CONCENTRATION is specified, then concentration are printed for the last time step of each stress period.": [
         "gwt-uzt"
       ],
-      "keyword to indicate that the list of lake concentration will be printed to the listing file for every stress period in which ``CONCENTRATION PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_CONCENTRATION is specified, then concentration are printed for the last time step of each stress period.": [
+      "keyword to indicate that the list of lake concentration will be printed to the listing file for every stress period in which `CONCENTRATION PRINT` is specified in Output Control.  If there is no Output Control option and PRINT\\_CONCENTRATION is specified, then concentration are printed for the last time step of each stress period.": [
         "gwt-lkt"
       ],
-      "keyword to indicate that the list of reach concentration will be printed to the listing file for every stress period in which ``CONCENTRATION PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_CONCENTRATION is specified, then concentration are printed for the last time step of each stress period.": [
+      "keyword to indicate that the list of reach concentration will be printed to the listing file for every stress period in which `CONCENTRATION PRINT` is specified in Output Control.  If there is no Output Control option and PRINT\\_CONCENTRATION is specified, then concentration are printed for the last time step of each stress period.": [
         "gwt-sft"
       ],
-      "keyword to indicate that the list of well concentration will be printed to the listing file for every stress period in which ``CONCENTRATION PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_CONCENTRATION is specified, then concentration are printed for the last time step of each stress period.": [
+      "keyword to indicate that the list of well concentration will be printed to the listing file for every stress period in which `CONCENTRATION PRINT` is specified in Output Control.  If there is no Output Control option and PRINT\\_CONCENTRATION is specified, then concentration are printed for the last time step of each stress period.": [
         "gwt-mwt"
       ]
     }
   },
   "print_flows": {
     "options": {
-      "keyword to indicate that calculated flows between cells will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control. If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.  This option can produce extremely large list files because all cell-by-cell flows are printed.  It should only be used with the DFW Package for models that have a small number of cells.": [
+      "keyword to indicate that calculated flows between cells will be printed to the listing file for every stress period time step in which `BUDGET PRINT` is specified in Output Control. If there is no Output Control option and `PRINT\\_FLOWS` is specified, then flow rates are printed for the last time step of each stress period.  This option can produce extremely large list files because all cell-by-cell flows are printed.  It should only be used with the DFW Package for models that have a small number of cells.": [
         "chf-dfw",
         "olf-dfw",
         "swf-dfw"
       ],
-      "keyword to indicate that calculated flows between cells will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control. If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.  This option can produce extremely large list files because all cell-by-cell flows are printed.  It should only be used with the NPF Package for models that have a small number of cells.": [
+      "keyword to indicate that calculated flows between cells will be printed to the listing file for every stress period time step in which `BUDGET PRINT` is specified in Output Control. If there is no Output Control option and `PRINT\\_FLOWS` is specified, then flow rates are printed for the last time step of each stress period.  This option can produce extremely large list files because all cell-by-cell flows are printed.  It should only be used with the NPF Package for models that have a small number of cells.": [
         "gwf-npf"
       ],
-      "keyword to indicate that the list of GNC flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.": [
+      "keyword to indicate that the list of GNC flow rates will be printed to the listing file for every stress period time step in which `BUDGET PRINT` is specified in Output Control.  If there is no Output Control option and `PRINT\\_FLOWS` is specified, then flow rates are printed for the last time step of each stress period.": [
         "gwf-gnc"
       ],
-      "keyword to indicate that the list of MVR flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.": [
+      "keyword to indicate that the list of MVR flow rates will be printed to the listing file for every stress period time step in which `BUDGET PRINT` is specified in Output Control.  If there is no Output Control option and `PRINT\\_FLOWS` is specified, then flow rates are printed for the last time step of each stress period.": [
         "gwf-mvr"
       ],
-      "keyword to indicate that the list of SSM flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.": [
+      "keyword to indicate that the list of SSM flow rates will be printed to the listing file for every stress period time step in which `BUDGET PRINT` is specified in Output Control.  If there is no Output Control option and `PRINT\\_FLOWS` is specified, then flow rates are printed for the last time step of each stress period.": [
         "gwe-ssm",
         "gwt-ssm"
       ],
-      "keyword to indicate that the list of UZF flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.": [
+      "keyword to indicate that the list of UZF flow rates will be printed to the listing file for every stress period time step in which `BUDGET PRINT` is specified in Output Control.  If there is no Output Control option and `PRINT\\_FLOWS` is specified, then flow rates are printed for the last time step of each stress period.": [
         "gwf-uzf"
       ],
-      "keyword to indicate that the list of all model package flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.": [
+      "keyword to indicate that the list of all model package flow rates will be printed to the listing file for every stress period time step in which `BUDGET PRINT` is specified in Output Control.  If there is no Output Control option and `PRINT\\_FLOWS` is specified, then flow rates are printed for the last time step of each stress period.": [
         "chf-nam",
         "gwe-nam",
         "gwf-nam",
@@ -2874,99 +2874,99 @@
         "prt-nam",
         "swf-nam"
       ],
-      "keyword to indicate that the list of api boundary flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.": [
+      "keyword to indicate that the list of api boundary flow rates will be printed to the listing file for every stress period time step in which `BUDGET PRINT` is specified in Output Control.  If there is no Output Control option and `PRINT\\_FLOWS` is specified, then flow rates are printed for the last time step of each stress period.": [
         "gwf-api",
         "gwt-api"
       ],
-      "keyword to indicate that the list of constant concentration flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.": [
+      "keyword to indicate that the list of constant concentration flow rates will be printed to the listing file for every stress period time step in which `BUDGET PRINT` is specified in Output Control.  If there is no Output Control option and `PRINT\\_FLOWS` is specified, then flow rates are printed for the last time step of each stress period.": [
         "gwt-cnc"
       ],
-      "keyword to indicate that the list of constant temperature flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.": [
+      "keyword to indicate that the list of constant temperature flow rates will be printed to the listing file for every stress period time step in which `BUDGET PRINT` is specified in Output Control.  If there is no Output Control option and `PRINT\\_FLOWS` is specified, then flow rates are printed for the last time step of each stress period.": [
         "gwe-ctp"
       ],
-      "keyword to indicate that the list of constant-head flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.": [
+      "keyword to indicate that the list of constant-head flow rates will be printed to the listing file for every stress period time step in which `BUDGET PRINT` is specified in Output Control.  If there is no Output Control option and `PRINT\\_FLOWS` is specified, then flow rates are printed for the last time step of each stress period.": [
         "chf-chd",
         "gwf-chd",
         "olf-chd",
         "swf-chd"
       ],
-      "keyword to indicate that the list of critical depth boundary flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.": [
+      "keyword to indicate that the list of critical depth boundary flow rates will be printed to the listing file for every stress period time step in which `BUDGET PRINT` is specified in Output Control.  If there is no Output Control option and `PRINT\\_FLOWS` is specified, then flow rates are printed for the last time step of each stress period.": [
         "chf-cdb",
         "olf-cdb",
         "swf-cdb"
       ],
-      "keyword to indicate that the list of drain flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.": [
+      "keyword to indicate that the list of drain flow rates will be printed to the listing file for every stress period time step in which `BUDGET PRINT` is specified in Output Control.  If there is no Output Control option and `PRINT\\_FLOWS` is specified, then flow rates are printed for the last time step of each stress period.": [
         "gwf-drn"
       ],
-      "keyword to indicate that the list of energy source loading flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.": [
+      "keyword to indicate that the list of energy source loading flow rates will be printed to the listing file for every stress period time step in which `BUDGET PRINT` is specified in Output Control.  If there is no Output Control option and `PRINT\\_FLOWS` is specified, then flow rates are printed for the last time step of each stress period.": [
         "gwe-esl"
       ],
-      "keyword to indicate that the list of evaporation flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.": [
+      "keyword to indicate that the list of evaporation flow rates will be printed to the listing file for every stress period time step in which `BUDGET PRINT` is specified in Output Control.  If there is no Output Control option and `PRINT\\_FLOWS` is specified, then flow rates are printed for the last time step of each stress period.": [
         "chf-evp",
         "olf-evp",
         "swf-evp"
       ],
-      "keyword to indicate that the list of evapotranspiration flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.": [
+      "keyword to indicate that the list of evapotranspiration flow rates will be printed to the listing file for every stress period time step in which `BUDGET PRINT` is specified in Output Control.  If there is no Output Control option and `PRINT\\_FLOWS` is specified, then flow rates are printed for the last time step of each stress period.": [
         "gwf-evt",
         "gwf-evta"
       ],
-      "keyword to indicate that the list of exchange flow rates will be printed to the listing file for every stress period in which ``SAVE BUDGET'' is specified in Output Control.": [
+      "keyword to indicate that the list of exchange flow rates will be printed to the listing file for every stress period in which `SAVE BUDGET` is specified in Output Control.": [
         "exg-chfgwf",
         "exg-gwegwe",
         "exg-gwfgwf",
         "exg-gwtgwt",
         "exg-olfgwf"
       ],
-      "keyword to indicate that the list of general-head boundary flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.": [
+      "keyword to indicate that the list of general-head boundary flow rates will be printed to the listing file for every stress period time step in which `BUDGET PRINT` is specified in Output Control.  If there is no Output Control option and `PRINT\\_FLOWS` is specified, then flow rates are printed for the last time step of each stress period.": [
         "gwf-ghb"
       ],
-      "keyword to indicate that the list of inflow flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.": [
+      "keyword to indicate that the list of inflow flow rates will be printed to the listing file for every stress period time step in which `BUDGET PRINT` is specified in Output Control.  If there is no Output Control option and `PRINT\\_FLOWS` is specified, then flow rates are printed for the last time step of each stress period.": [
         "chf-flw",
         "olf-flw",
         "swf-flw"
       ],
-      "keyword to indicate that the list of lake flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.": [
+      "keyword to indicate that the list of lake flow rates will be printed to the listing file for every stress period time step in which `BUDGET PRINT` is specified in Output Control.  If there is no Output Control option and `PRINT\\_FLOWS` is specified, then flow rates are printed for the last time step of each stress period.": [
         "gwe-lke",
         "gwe-mve",
         "gwf-lak",
         "gwt-lkt",
         "gwt-mvt"
       ],
-      "keyword to indicate that the list of mass source flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.": [
+      "keyword to indicate that the list of mass source flow rates will be printed to the listing file for every stress period time step in which `BUDGET PRINT` is specified in Output Control.  If there is no Output Control option and `PRINT\\_FLOWS` is specified, then flow rates are printed for the last time step of each stress period.": [
         "gwt-src"
       ],
-      "keyword to indicate that the list of multi-aquifer well flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.": [
+      "keyword to indicate that the list of multi-aquifer well flow rates will be printed to the listing file for every stress period time step in which `BUDGET PRINT` is specified in Output Control.  If there is no Output Control option and `PRINT\\_FLOWS` is specified, then flow rates are printed for the last time step of each stress period.": [
         "gwf-maw"
       ],
-      "keyword to indicate that the list of precipitation flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.": [
+      "keyword to indicate that the list of precipitation flow rates will be printed to the listing file for every stress period time step in which `BUDGET PRINT` is specified in Output Control.  If there is no Output Control option and `PRINT\\_FLOWS` is specified, then flow rates are printed for the last time step of each stress period.": [
         "chf-pcp",
         "olf-pcp",
         "swf-pcp"
       ],
-      "keyword to indicate that the list of reach flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.": [
+      "keyword to indicate that the list of reach flow rates will be printed to the listing file for every stress period time step in which `BUDGET PRINT` is specified in Output Control.  If there is no Output Control option and `PRINT\\_FLOWS` is specified, then flow rates are printed for the last time step of each stress period.": [
         "gwe-sfe",
         "gwt-sft"
       ],
-      "keyword to indicate that the list of recharge flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.": [
+      "keyword to indicate that the list of recharge flow rates will be printed to the listing file for every stress period time step in which `BUDGET PRINT` is specified in Output Control.  If there is no Output Control option and `PRINT\\_FLOWS` is specified, then flow rates are printed for the last time step of each stress period.": [
         "gwf-rch",
         "gwf-rcha"
       ],
-      "keyword to indicate that the list of river flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.": [
+      "keyword to indicate that the list of river flow rates will be printed to the listing file for every stress period time step in which `BUDGET PRINT` is specified in Output Control.  If there is no Output Control option and `PRINT\\_FLOWS` is specified, then flow rates are printed for the last time step of each stress period.": [
         "gwf-riv"
       ],
-      "keyword to indicate that the list of stream reach flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.": [
+      "keyword to indicate that the list of stream reach flow rates will be printed to the listing file for every stress period time step in which `BUDGET PRINT` is specified in Output Control.  If there is no Output Control option and `PRINT\\_FLOWS` is specified, then flow rates are printed for the last time step of each stress period.": [
         "gwf-sfr"
       ],
-      "keyword to indicate that the list of unsaturated zone flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.": [
+      "keyword to indicate that the list of unsaturated zone flow rates will be printed to the listing file for every stress period time step in which `BUDGET PRINT` is specified in Output Control.  If there is no Output Control option and `PRINT\\_FLOWS` is specified, then flow rates are printed for the last time step of each stress period.": [
         "gwe-uze",
         "gwt-uzt"
       ],
-      "keyword to indicate that the list of well flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.": [
+      "keyword to indicate that the list of well flow rates will be printed to the listing file for every stress period time step in which `BUDGET PRINT` is specified in Output Control.  If there is no Output Control option and `PRINT\\_FLOWS` is specified, then flow rates are printed for the last time step of each stress period.": [
         "gwe-mwe",
         "gwf-wel",
         "gwt-mwt"
       ],
-      "keyword to indicate that the list of zero-depth-gradient boundary flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.": [
+      "keyword to indicate that the list of zero-depth-gradient boundary flow rates will be printed to the listing file for every stress period time step in which `BUDGET PRINT` is specified in Output Control.  If there is no Output Control option and `PRINT\\_FLOWS` is specified, then flow rates are printed for the last time step of each stress period.": [
         "chf-zdg",
         "olf-zdg",
         "swf-zdg"
@@ -2988,7 +2988,7 @@
   },
   "print_head": {
     "options": {
-      "keyword to indicate that the list of multi-aquifer well heads will be printed to the listing file for every stress period in which ``HEAD PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_HEAD is specified, then heads are printed for the last time step of each stress period.": [
+      "keyword to indicate that the list of multi-aquifer well heads will be printed to the listing file for every stress period in which `HEAD PRINT` is specified in Output Control.  If there is no Output Control option and PRINT\\_HEAD is specified, then heads are printed for the last time step of each stress period.": [
         "gwf-maw"
       ]
     }
@@ -3150,10 +3150,10 @@
   },
   "print_stage": {
     "options": {
-      "keyword to indicate that the list of lake stages will be printed to the listing file for every stress period in which ``HEAD PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_STAGE is specified, then stages are printed for the last time step of each stress period.": [
+      "keyword to indicate that the list of lake stages will be printed to the listing file for every stress period in which `HEAD PRINT` is specified in Output Control.  If there is no Output Control option and PRINT\\_STAGE is specified, then stages are printed for the last time step of each stress period.": [
         "gwf-lak"
       ],
-      "keyword to indicate that the list of stream reach stages will be printed to the listing file for every stress period in which ``HEAD PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_STAGE is specified, then stages are printed for the last time step of each stress period.": [
+      "keyword to indicate that the list of stream reach stages will be printed to the listing file for every stress period in which `HEAD PRINT` is specified in Output Control.  If there is no Output Control option and PRINT\\_STAGE is specified, then stages are printed for the last time step of each stress period.": [
         "gwf-sfr"
       ]
     }
@@ -3167,16 +3167,16 @@
   },
   "print_temperature": {
     "options": {
-      "keyword to indicate that the list of UZF cell temperatures will be printed to the listing file for every stress period in which ``TEMPERATURE PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_TEMPERATURE is specified, then temperatures are printed for the last time step of each stress period.": [
+      "keyword to indicate that the list of UZF cell temperatures will be printed to the listing file for every stress period in which `TEMPERATURE PRINT` is specified in Output Control.  If there is no Output Control option and PRINT\\_TEMPERATURE is specified, then temperatures are printed for the last time step of each stress period.": [
         "gwe-uze"
       ],
-      "keyword to indicate that the list of lake temperature will be printed to the listing file for every stress period in which ``TEMPERATURE PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_TEMPERATURE is specified, then temperature are printed for the last time step of each stress period.": [
+      "keyword to indicate that the list of lake temperature will be printed to the listing file for every stress period in which `TEMPERATURE PRINT` is specified in Output Control.  If there is no Output Control option and PRINT\\_TEMPERATURE is specified, then temperature are printed for the last time step of each stress period.": [
         "gwe-lke"
       ],
-      "keyword to indicate that the list of reach temperatures will be printed to the listing file for every stress period in which ``TEMPERATURE PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_TEMPERATURE is specified, then temperatures are printed for the last time step of each stress period.": [
+      "keyword to indicate that the list of reach temperatures will be printed to the listing file for every stress period in which `TEMPERATURE PRINT` is specified in Output Control.  If there is no Output Control option and PRINT\\_TEMPERATURE is specified, then temperatures are printed for the last time step of each stress period.": [
         "gwe-sfe"
       ],
-      "keyword to indicate that the list of well temperature will be printed to the listing file for every stress period in which ``TEMPERATURE PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_TEMPERATURE is specified, then temperature are printed for the last time step of each stress period.": [
+      "keyword to indicate that the list of well temperature will be printed to the listing file for every stress period in which `TEMPERATURE PRINT` is specified in Output Control.  If there is no Output Control option and PRINT\\_TEMPERATURE is specified, then temperature are printed for the last time step of each stress period.": [
         "gwe-mwe"
       ]
     }
@@ -3199,22 +3199,22 @@
   },
   "rainfall": {
     "period": {
-      "real or character value that defines the  volumetric rate per unit area of water added by precipitation directly on the streamflow routing reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, rainfall  rates are zero for each reach.": [
+      "real or character value that defines the  volumetric rate per unit area of water added by precipitation directly on the streamflow routing reach. If the Options block includes a TIMESERIESFILE entry (see the `Time-Variable Input` section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, rainfall  rates are zero for each reach.": [
         "gwf-sfr"
       ],
-      "real or character value that defines the rainfall rate $(LT^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+      "real or character value that defines the rainfall rate $(LT^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the `Time-Variable Input` section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
         "gwf-lak"
       ],
-      "real or character value that defines the rainfall solute concentration $(ML^{-3})$ for the lake. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+      "real or character value that defines the rainfall solute concentration $(ML^{-3})$ for the lake. If the Options block includes a TIMESERIESFILE entry (see the `Time-Variable Input` section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
         "gwt-lkt"
       ],
-      "real or character value that defines the rainfall solute concentration $(ML^{-3})$ for the reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+      "real or character value that defines the rainfall solute concentration $(ML^{-3})$ for the reach. If the Options block includes a TIMESERIESFILE entry (see the `Time-Variable Input` section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
         "gwt-sft"
       ],
-      "real or character value that defines the rainfall temperature $(e.g.,\\:^{\\circ}C\\:or\\:^{\\circ}F)$ for the reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+      "real or character value that defines the rainfall temperature $(e.g.,\\:^{\\circ}C\\:or\\:^{\\circ}F)$ for the reach. If the Options block includes a TIMESERIESFILE entry (see the `Time-Variable Input` section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
         "gwe-sfe"
       ],
-      "real or character value that defines the rainfall temperature for the lake. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+      "real or character value that defines the rainfall temperature for the lake. If the Options block includes a TIMESERIESFILE entry (see the `Time-Variable Input` section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
         "gwe-lke"
       ]
     }
@@ -3224,16 +3224,16 @@
       "is the maximum ET flux rate ($LT^{-1}$).": [
         "gwf-evta"
       ],
-      "is the volumetric pumping rate for the multi-aquifer well. A positive value indicates recharge and a negative value indicates discharge (pumping). RATE only applies to active (STATUS is ACTIVE) multi-aquifer wells. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, the RATE for each multi-aquifer well is zero.": [
+      "is the volumetric pumping rate for the multi-aquifer well. A positive value indicates recharge and a negative value indicates discharge (pumping). RATE only applies to active (STATUS is ACTIVE) multi-aquifer wells. If the Options block includes a TIMESERIESFILE entry (see the `Time-Variable Input` section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, the RATE for each multi-aquifer well is zero.": [
         "gwf-maw"
       ],
-      "real or character value that defines the extraction rate for the lake outflow. A positive value indicates inflow and a negative value indicates outflow from the lake. RATE only applies to outlets associated with active lakes (STATUS is ACTIVE). A specified RATE is only applied if COUTTYPE for the OUTLETNO is SPECIFIED. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, the RATE for each SPECIFIED lake outlet is zero.": [
+      "real or character value that defines the extraction rate for the lake outflow. A positive value indicates inflow and a negative value indicates outflow from the lake. RATE only applies to outlets associated with active lakes (STATUS is ACTIVE). A specified RATE is only applied if COUTTYPE for the OUTLETNO is SPECIFIED. If the Options block includes a TIMESERIESFILE entry (see the `Time-Variable Input` section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, the RATE for each SPECIFIED lake outlet is zero.": [
         "gwf-lak"
       ],
-      "real or character value that defines the injection solute concentration $(ML^{-3})$ for the well. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+      "real or character value that defines the injection solute concentration $(ML^{-3})$ for the well. If the Options block includes a TIMESERIESFILE entry (see the `Time-Variable Input` section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
         "gwt-mwt"
       ],
-      "real or character value that defines the injection temperature $(e.g.,\\:^{\\circ}C\\:or\\:^{\\circ}F)$ for the well. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+      "real or character value that defines the injection temperature $(e.g.,\\:^{\\circ}C\\:or\\:^{\\circ}F)$ for the well. If the Options block includes a TIMESERIESFILE entry (see the `Time-Variable Input` section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
         "gwe-mwe"
       ]
     }
@@ -3260,7 +3260,7 @@
   },
   "recharge": {
     "period": {
-      "is the recharge flux rate ($LT^{-1}$).  This rate is multiplied inside the program by the surface area of the cell to calculate the volumetric recharge rate. The recharge array may be defined by a time-array series (see the ``Using Time-Array Series in a Package'' section).": [
+      "is the recharge flux rate ($LT^{-1}$).  This rate is multiplied inside the program by the surface area of the cell to calculate the volumetric recharge rate. The recharge array may be defined by a time-array series (see the `Using Time-Array Series in a Package` section).": [
         "gwf-rcha"
       ]
     }
@@ -3316,26 +3316,26 @@
   },
   "rough": {
     "period": {
-      "real value that defines the roughness coefficient for the lake outlet. Any value can be specified if COUTTYPE is not MANNING. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+      "real value that defines the roughness coefficient for the lake outlet. Any value can be specified if COUTTYPE is not MANNING. If the Options block includes a TIMESERIESFILE entry (see the `Time-Variable Input` section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
         "gwf-lak"
       ]
     }
   },
   "runoff": {
     "period": {
-      "real or character value that defines the concentration of runoff $(ML^{-3})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+      "real or character value that defines the concentration of runoff $(ML^{-3})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the `Time-Variable Input` section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
         "gwt-lkt"
       ],
-      "real or character value that defines the concentration of runoff $(ML^{-3})$ for the reach. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+      "real or character value that defines the concentration of runoff $(ML^{-3})$ for the reach. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the `Time-Variable Input` section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
         "gwt-sft"
       ],
-      "real or character value that defines the runoff rate $(L^3 T^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+      "real or character value that defines the runoff rate $(L^3 T^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the `Time-Variable Input` section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
         "gwf-lak"
       ],
-      "real or character value that defines the temperature of runoff $(e.g.,\\:^{\\circ}C\\:or\\:^{\\circ}F)$ for the reach.  Users are free to use whatever temperature scale they want, which might include negative temperatures.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+      "real or character value that defines the temperature of runoff $(e.g.,\\:^{\\circ}C\\:or\\:^{\\circ}F)$ for the reach.  Users are free to use whatever temperature scale they want, which might include negative temperatures.  If the Options block includes a TIMESERIESFILE entry (see the `Time-Variable Input` section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
         "gwe-sfe"
       ],
-      "real or character value that defines the volumetric rate of diffuse overland runoff that enters the streamflow routing reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. If the volumetric runoff rate for a reach is negative and exceeds inflows to the reach (upstream and specified inflows, and rainfall but excluding groundwater leakage into the reach) the volumetric runoff rate is limited to inflows to the reach and the volumetric evaporation rate for the reach is set to zero. By default, runoff rates are zero for each reach.": [
+      "real or character value that defines the volumetric rate of diffuse overland runoff that enters the streamflow routing reach. If the Options block includes a TIMESERIESFILE entry (see the `Time-Variable Input` section), values can be obtained from a time series by entering the time-series name in place of a numeric value. If the volumetric runoff rate for a reach is negative and exceeds inflows to the reach (upstream and specified inflows, and rainfall but excluding groundwater leakage into the reach) the volumetric runoff rate is limited to inflows to the reach and the volumetric evaporation rate for the reach is set to zero. By default, runoff rates are zero for each reach.": [
         "gwf-sfr"
       ]
     }
@@ -3355,28 +3355,28 @@
   },
   "save_flows": {
     "options": {
-      "keyword to indicate that EST flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+      "keyword to indicate that EST flow terms will be written to the file specified with `BUDGET FILEOUT` in Output Control.": [
         "gwe-est"
       ],
-      "keyword to indicate that FMI flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+      "keyword to indicate that FMI flow terms will be written to the file specified with `BUDGET FILEOUT` in Output Control.": [
         "gwe-fmi",
         "gwt-fmi",
         "prt-fmi"
       ],
-      "keyword to indicate that IST flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+      "keyword to indicate that IST flow terms will be written to the file specified with `BUDGET FILEOUT` in Output Control.": [
         "gwt-ist"
       ],
-      "keyword to indicate that MST flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+      "keyword to indicate that MST flow terms will be written to the file specified with `BUDGET FILEOUT` in Output Control.": [
         "gwt-mst"
       ],
-      "keyword to indicate that SSM flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+      "keyword to indicate that SSM flow terms will be written to the file specified with `BUDGET FILEOUT` in Output Control.": [
         "gwe-ssm",
         "gwt-ssm"
       ],
-      "keyword to indicate that UZF flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+      "keyword to indicate that UZF flow terms will be written to the file specified with `BUDGET FILEOUT` in Output Control.": [
         "gwf-uzf"
       ],
-      "keyword to indicate that all model package flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+      "keyword to indicate that all model package flow terms will be written to the file specified with `BUDGET FILEOUT` in Output Control.": [
         "chf-nam",
         "gwe-nam",
         "gwf-nam",
@@ -3385,110 +3385,110 @@
         "prt-nam",
         "swf-nam"
       ],
-      "keyword to indicate that api boundary flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+      "keyword to indicate that api boundary flow terms will be written to the file specified with `BUDGET FILEOUT` in Output Control.": [
         "gwf-api",
         "gwt-api"
       ],
-      "keyword to indicate that budget flow terms will be written to the file specified with ``BUDGET SAVE FILE'' in Output Control.": [
+      "keyword to indicate that budget flow terms will be written to the file specified with `BUDGET SAVE FILE` in Output Control.": [
         "chf-dfw",
         "gwf-npf",
         "olf-dfw",
         "swf-dfw"
       ],
-      "keyword to indicate that cell-by-cell flow terms will be written to the budget file for each model provided that the Output Control for the models are set up with the ``BUDGET SAVE FILE'' option.": [
+      "keyword to indicate that cell-by-cell flow terms will be written to the budget file for each model provided that the Output Control for the models are set up with the `BUDGET SAVE FILE` option.": [
         "exg-gwegwe",
         "exg-gwfgwf",
         "exg-gwtgwt"
       ],
-      "keyword to indicate that cell-by-cell flow terms will be written to the file specified with ``BUDGET SAVE FILE'' in Output Control.": [
+      "keyword to indicate that cell-by-cell flow terms will be written to the file specified with `BUDGET SAVE FILE` in Output Control.": [
         "chf-sto",
         "gwf-csub",
         "gwf-sto",
         "olf-sto",
         "swf-sto"
       ],
-      "keyword to indicate that constant concentration flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+      "keyword to indicate that constant concentration flow terms will be written to the file specified with `BUDGET FILEOUT` in Output Control.": [
         "gwt-cnc"
       ],
-      "keyword to indicate that constant temperature flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+      "keyword to indicate that constant temperature flow terms will be written to the file specified with `BUDGET FILEOUT` in Output Control.": [
         "gwe-ctp"
       ],
-      "keyword to indicate that constant-head flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+      "keyword to indicate that constant-head flow terms will be written to the file specified with `BUDGET FILEOUT` in Output Control.": [
         "chf-chd",
         "gwf-chd",
         "olf-chd",
         "swf-chd"
       ],
-      "keyword to indicate that critical depth boundary flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+      "keyword to indicate that critical depth boundary flow terms will be written to the file specified with `BUDGET FILEOUT` in Output Control.": [
         "chf-cdb",
         "olf-cdb",
         "swf-cdb"
       ],
-      "keyword to indicate that drain flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+      "keyword to indicate that drain flow terms will be written to the file specified with `BUDGET FILEOUT` in Output Control.": [
         "gwf-drn"
       ],
-      "keyword to indicate that energy source loading flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+      "keyword to indicate that energy source loading flow terms will be written to the file specified with `BUDGET FILEOUT` in Output Control.": [
         "gwe-esl"
       ],
-      "keyword to indicate that evaporation flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+      "keyword to indicate that evaporation flow terms will be written to the file specified with `BUDGET FILEOUT` in Output Control.": [
         "chf-evp",
         "olf-evp",
         "swf-evp"
       ],
-      "keyword to indicate that evapotranspiration flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+      "keyword to indicate that evapotranspiration flow terms will be written to the file specified with `BUDGET FILEOUT` in Output Control.": [
         "gwf-evt",
         "gwf-evta"
       ],
-      "keyword to indicate that general-head boundary flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+      "keyword to indicate that general-head boundary flow terms will be written to the file specified with `BUDGET FILEOUT` in Output Control.": [
         "gwf-ghb"
       ],
-      "keyword to indicate that inflow flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+      "keyword to indicate that inflow flow terms will be written to the file specified with `BUDGET FILEOUT` in Output Control.": [
         "chf-flw",
         "olf-flw",
         "swf-flw"
       ],
-      "keyword to indicate that lake flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+      "keyword to indicate that lake flow terms will be written to the file specified with `BUDGET FILEOUT` in Output Control.": [
         "gwe-lke",
         "gwe-mve",
         "gwf-lak",
         "gwt-lkt",
         "gwt-mvt"
       ],
-      "keyword to indicate that mass source flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+      "keyword to indicate that mass source flow terms will be written to the file specified with `BUDGET FILEOUT` in Output Control.": [
         "gwt-src"
       ],
-      "keyword to indicate that multi-aquifer well flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+      "keyword to indicate that multi-aquifer well flow terms will be written to the file specified with `BUDGET FILEOUT` in Output Control.": [
         "gwf-maw"
       ],
-      "keyword to indicate that precipitation flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+      "keyword to indicate that precipitation flow terms will be written to the file specified with `BUDGET FILEOUT` in Output Control.": [
         "chf-pcp",
         "olf-pcp",
         "swf-pcp"
       ],
-      "keyword to indicate that reach flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+      "keyword to indicate that reach flow terms will be written to the file specified with `BUDGET FILEOUT` in Output Control.": [
         "gwe-sfe",
         "gwt-sft"
       ],
-      "keyword to indicate that recharge flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+      "keyword to indicate that recharge flow terms will be written to the file specified with `BUDGET FILEOUT` in Output Control.": [
         "gwf-rch",
         "gwf-rcha"
       ],
-      "keyword to indicate that river flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+      "keyword to indicate that river flow terms will be written to the file specified with `BUDGET FILEOUT` in Output Control.": [
         "gwf-riv"
       ],
-      "keyword to indicate that stream reach flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+      "keyword to indicate that stream reach flow terms will be written to the file specified with `BUDGET FILEOUT` in Output Control.": [
         "gwf-sfr"
       ],
-      "keyword to indicate that unsaturated zone flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+      "keyword to indicate that unsaturated zone flow terms will be written to the file specified with `BUDGET FILEOUT` in Output Control.": [
         "gwe-uze",
         "gwt-uzt"
       ],
-      "keyword to indicate that well flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+      "keyword to indicate that well flow terms will be written to the file specified with `BUDGET FILEOUT` in Output Control.": [
         "gwe-mwe",
         "gwf-wel",
         "gwt-mwt"
       ],
-      "keyword to indicate that zero-depth-gradient boundary flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.": [
+      "keyword to indicate that zero-depth-gradient boundary flow terms will be written to the file specified with `BUDGET FILEOUT` in Output Control.": [
         "chf-zdg",
         "olf-zdg",
         "swf-zdg"
@@ -3497,21 +3497,21 @@
   },
   "save_saturation": {
     "options": {
-      "keyword to indicate that cell saturation will be written to the budget file, which is specified with ``BUDGET SAVE FILE'' in Output Control.  Saturation will be saved to the budget file as an auxiliary variable saved with the DATA-SAT text label.  Saturation is a cell variable that ranges from zero to one and can be used by post processing programs to determine how much of a cell volume is saturated.  If ICELLTYPE is 0, then saturation is always one.": [
+      "keyword to indicate that cell saturation will be written to the budget file, which is specified with `BUDGET SAVE FILE` in Output Control.  Saturation will be saved to the budget file as an auxiliary variable saved with the DATA-SAT text label.  Saturation is a cell variable that ranges from zero to one and can be used by post processing programs to determine how much of a cell volume is saturated.  If ICELLTYPE is 0, then saturation is always one.": [
         "gwf-npf"
       ]
     }
   },
   "save_specific_discharge": {
     "options": {
-      "keyword to indicate that x, y, and z components of specific discharge will be calculated at cell centers and written to the budget file, which is specified with ``BUDGET SAVE FILE'' in Output Control.  If this option is activated, then additional information may be required in the discretization packages and the GWF Exchange package (if GWF models are coupled).  Specifically, ANGLDEGX must be specified in the CONNECTIONDATA block of the DISU Package; ANGLDEGX must also be specified for the GWF Exchange as an auxiliary variable.": [
+      "keyword to indicate that x, y, and z components of specific discharge will be calculated at cell centers and written to the budget file, which is specified with `BUDGET SAVE FILE` in Output Control.  If this option is activated, then additional information may be required in the discretization packages and the GWF Exchange package (if GWF models are coupled).  Specifically, ANGLDEGX must be specified in the CONNECTIONDATA block of the DISU Package; ANGLDEGX must also be specified for the GWF Exchange as an auxiliary variable.": [
         "gwf-npf"
       ]
     }
   },
   "save_velocity": {
     "options": {
-      "keyword to indicate that x, y, and z components of velocity will be calculated at cell centers and written to the budget file, which is specified with ``BUDGET SAVE FILE'' in Output Control.  If this option is activated, then additional information may be required in the discretization packages and the GWF Exchange package (if GWF models are coupled).  Specifically, ANGLDEGX must be specified in the CONNECTIONDATA block of the DISU Package; ANGLDEGX must also be specified for the GWF Exchange as an auxiliary variable.": [
+      "keyword to indicate that x, y, and z components of velocity will be calculated at cell centers and written to the budget file, which is specified with `BUDGET SAVE FILE` in Output Control.  If this option is activated, then additional information may be required in the discretization packages and the GWF Exchange package (if GWF models are coupled).  Specifically, ANGLDEGX must be specified in the CONNECTIONDATA block of the DISU Package; ANGLDEGX must also be specified for the GWF Exchange as an auxiliary variable.": [
         "chf-dfw",
         "olf-dfw",
         "swf-dfw"
@@ -3605,7 +3605,7 @@
   },
   "slope": {
     "period": {
-      "real or character value that defines the bed slope for the lake outlet. A specified SLOPE value is only used for active lakes if COUTTYPE for lake outlet OUTLETNO is MANNING. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+      "real or character value that defines the bed slope for the lake outlet. A specified SLOPE value is only used for active lakes if COUTTYPE for lake outlet OUTLETNO is MANNING. If the Options block includes a TIMESERIESFILE entry (see the `Time-Variable Input` section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
         "gwf-lak"
       ]
     }
@@ -3682,7 +3682,7 @@
       ]
     },
     "period": {
-      "is the new value to be assigned as the cell's specific storage (or storage coefficient if the STORAGECOEFFICIENT STO package option is specified) from the start of the specified stress period, as per SS in the STO package.  Specific storage values must be greater than or equal to 0.  If the OPTIONS block includes a TS6 entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+      "is the new value to be assigned as the cell's specific storage (or storage coefficient if the STORAGECOEFFICIENT STO package option is specified) from the start of the specified stress period, as per SS in the STO package.  Specific storage values must be greater than or equal to 0.  If the OPTIONS block includes a TS6 entry (see the `Time-Variable Input` section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
         "utl-tvs"
       ]
     }
@@ -3705,10 +3705,10 @@
       ]
     },
     "period": {
-      "real or character value that defines the stage for the lake. The specified STAGE is only applied if the lake is a constant stage lake. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+      "real or character value that defines the stage for the lake. The specified STAGE is only applied if the lake is a constant stage lake. If the Options block includes a TIMESERIESFILE entry (see the `Time-Variable Input` section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
         "gwf-lak"
       ],
-      "real or character value that defines the stage for the reach. The specified STAGE is only applied if the reach uses the simple routing option. If STAGE is not specified for reaches that use the simple routing option, the specified stage is set to the top of the reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+      "real or character value that defines the stage for the reach. The specified STAGE is only applied if the reach uses the simple routing option. If STAGE is not specified for reaches that use the simple routing option, the specified stage is set to the top of the reach. If the Options block includes a TIMESERIESFILE entry (see the `Time-Variable Input` section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
         "gwf-sfr"
       ]
     }
@@ -3884,7 +3884,7 @@
       ]
     },
     "period": {
-      "is the new value to be assigned as the cell's specific yield from the start of the specified stress period, as per SY in the STO package.  Specific yield values must be greater than or equal to 0.  If the OPTIONS block includes a TS6 entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+      "is the new value to be assigned as the cell's specific yield from the start of the specified stress period, as per SY in the STO package.  Specific yield values must be greater than or equal to 0.  If the OPTIONS block includes a TS6 entry (see the `Time-Variable Input` section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
         "utl-tvs"
       ]
     }
@@ -3936,19 +3936,19 @@
       "is the temperature of the associated Recharge or Evapotranspiration stress package.  The temperature array may be defined by a time-array series (see the \"Using Time-Array Series in a Package\" section).": [
         "utl-spca"
       ],
-      "is the user-supplied boundary temperature. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, the TEMPERATURE for each boundary feature is zero.": [
+      "is the user-supplied boundary temperature. If the Options block includes a TIMESERIESFILE entry (see the `Time-Variable Input` section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, the TEMPERATURE for each boundary feature is zero.": [
         "utl-spc"
       ],
-      "real or character value that defines the temperature for the lake. The specified TEMPERATURE is only applied if the lake is a constant temperature lake. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+      "real or character value that defines the temperature for the lake. The specified TEMPERATURE is only applied if the lake is a constant temperature lake. If the Options block includes a TIMESERIESFILE entry (see the `Time-Variable Input` section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
         "gwe-lke"
       ],
-      "real or character value that defines the temperature for the reach. The specified TEMPERATURE is only applied if the reach is a constant temperature reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+      "real or character value that defines the temperature for the reach. The specified TEMPERATURE is only applied if the reach is a constant temperature reach. If the Options block includes a TIMESERIESFILE entry (see the `Time-Variable Input` section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
         "gwe-sfe"
       ],
-      "real or character value that defines the temperature for the unsaturated zone flow cell. The specified TEMPERATURE is only applied if the unsaturated zone flow cell is a constant temperature cell. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+      "real or character value that defines the temperature for the unsaturated zone flow cell. The specified TEMPERATURE is only applied if the unsaturated zone flow cell is a constant temperature cell. If the Options block includes a TIMESERIESFILE entry (see the `Time-Variable Input` section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
         "gwe-uze"
       ],
-      "real or character value that defines the temperature for the well. The specified TEMPERATURE is only applied if the well is a constant temperature well. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+      "real or character value that defines the temperature for the well. The specified TEMPERATURE is only applied if the well is a constant temperature well. If the Options block includes a TIMESERIESFILE entry (see the `Time-Variable Input` section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
         "gwe-mwe"
       ]
     }
@@ -4010,7 +4010,7 @@
   },
   "time_units": {
     "options": {
-      "is the time units of the simulation.  This is a text string that is used as a label within model output files.  Values for time\\_units may be ``unknown'',  ``seconds'', ``minutes'', ``hours'', ``days'', or ``years''.  The default time unit is ``unknown''.": [
+      "is the time units of the simulation.  This is a text string that is used as a label within model output files.  Values for time\\_units may be `unknown`,  `seconds`, `minutes`, `hours`, `days`, or `years`.  The default time unit is `unknown`.": [
         "sim-tdis"
       ]
     }
@@ -4257,10 +4257,10 @@
   },
   "uzet": {
     "period": {
-      "real or character value that defines the concentration of unsaturated zone evapotranspiration water $(ML^{-3})$ for the UZF cell. If this concentration value is larger than the simulated concentration in the UZF cell, then the unsaturated zone ET water will be removed at the same concentration as the UZF cell.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+      "real or character value that defines the concentration of unsaturated zone evapotranspiration water $(ML^{-3})$ for the UZF cell. If this concentration value is larger than the simulated concentration in the UZF cell, then the unsaturated zone ET water will be removed at the same concentration as the UZF cell.  If the Options block includes a TIMESERIESFILE entry (see the `Time-Variable Input` section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
         "gwt-uzt"
       ],
-      "real or character value that states what fraction of the simulated unsaturated zone evapotranspiration is associated with evaporation.  The evaporative losses from the unsaturated zone moisture content will have an evaporative cooling effect on the GWE cell from which the evaporation originated. If this value is larger than 1, then it will be reset to 1.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+      "real or character value that states what fraction of the simulated unsaturated zone evapotranspiration is associated with evaporation.  The evaporative losses from the unsaturated zone moisture content will have an evaporative cooling effect on the GWE cell from which the evaporation originated. If this value is larger than 1, then it will be reset to 1.  If the Options block includes a TIMESERIESFILE entry (see the `Time-Variable Input` section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
         "gwe-uze"
       ]
     }
@@ -4312,14 +4312,14 @@
   },
   "well_head": {
     "period": {
-      "is the head in the multi-aquifer well. WELL\\_HEAD is only applied to constant head (STATUS is CONSTANT) and inactive (STATUS is INACTIVE) multi-aquifer wells. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. The program will terminate with an error if WELL\\_HEAD is less than the bottom of the well.": [
+      "is the head in the multi-aquifer well. WELL\\_HEAD is only applied to constant head (STATUS is CONSTANT) and inactive (STATUS is INACTIVE) multi-aquifer wells. If the Options block includes a TIMESERIESFILE entry (see the `Time-Variable Input` section), values can be obtained from a time series by entering the time-series name in place of a numeric value. The program will terminate with an error if WELL\\_HEAD is less than the bottom of the well.": [
         "gwf-maw"
       ]
     }
   },
   "wetdry": {
     "griddata": {
-      "is a combination of the wetting threshold and a flag to indicate which neighboring cells can cause a cell to become wet. If WETDRY $<$ 0, only a cell below a dry cell can cause the cell to become wet. If WETDRY $>$ 0, the cell below a dry cell and horizontally adjacent cells can cause a cell to become wet. If WETDRY is 0, the cell cannot be wetted. The absolute value of WETDRY is the wetting threshold. When the sum of BOT and the absolute value of WETDRY at a dry cell is equaled or exceeded by the head at an adjacent cell, the cell is wetted.  WETDRY must be specified if ``REWET'' is specified in the OPTIONS block.  If ``REWET'' is not specified in the options block, then WETDRY can be entered, and memory will be allocated for it, even though it is not used.": [
+      "is a combination of the wetting threshold and a flag to indicate which neighboring cells can cause a cell to become wet. If WETDRY $<$ 0, only a cell below a dry cell can cause the cell to become wet. If WETDRY $>$ 0, the cell below a dry cell and horizontally adjacent cells can cause a cell to become wet. If WETDRY is 0, the cell cannot be wetted. The absolute value of WETDRY is the wetting threshold. When the sum of BOT and the absolute value of WETDRY at a dry cell is equaled or exceeded by the head at an adjacent cell, the cell is wetted.  WETDRY must be specified if `REWET` is specified in the OPTIONS block.  If `REWET` is not specified in the options block, then WETDRY can be entered, and memory will be allocated for it, even though it is not used.": [
         "gwf-npf"
       ]
     }
@@ -4351,14 +4351,14 @@
       ]
     },
     "period": {
-      "real or character value that defines the width of the lake outlet. A specified WIDTH value is only used for active lakes if COUTTYPE for lake outlet OUTLETNO is not SPECIFIED. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+      "real or character value that defines the width of the lake outlet. A specified WIDTH value is only used for active lakes if COUTTYPE for lake outlet OUTLETNO is not SPECIFIED. If the Options block includes a TIMESERIESFILE entry (see the `Time-Variable Input` section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
         "gwf-lak"
       ]
     }
   },
   "withdrawal": {
     "period": {
-      "real or character value that defines the maximum withdrawal rate $(L^3 T^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
+      "real or character value that defines the maximum withdrawal rate $(L^3 T^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the `Time-Variable Input` section), values can be obtained from a time series by entering the time-series name in place of a numeric value.": [
         "gwf-lak"
       ]
     }

--- a/src/providers/hover.json
+++ b/src/providers/hover.json
@@ -1,143 +1,217 @@
 {
-  "boundnames": {
+  "adv_scheme": {
     "options": {
-      ".csub": "keyword to indicate that boundary names may be provided with the list of CSUB cells.",
-      ".ctp": "keyword to indicate that boundary names may be provided with the list of constant temperature cells.",
-      ".cdb": "keyword to indicate that boundary names may be provided with the list of critical depth boundary cells.",
-      ".sft": "keyword to indicate that boundary names may be provided with the list of reach cells.",
-      ".evp": "keyword to indicate that boundary names may be provided with the list of evaporation cells.",
-      ".flw": "keyword to indicate that boundary names may be provided with the list of inflow cells.",
-      ".chd": "keyword to indicate that boundary names may be provided with the list of constant-head cells.",
-      ".uze": "keyword to indicate that boundary names may be provided with the list of unsaturated zone flow cells.",
-      ".prp": "keyword to indicate that boundary names may be provided with the list of particle release points.",
-      ".pcp": "keyword to indicate that boundary names may be provided with the list of precipitation cells.",
-      ".api": "keyword to indicate that boundary names may be provided with the list of api boundary cells.",
-      ".drn": "keyword to indicate that boundary names may be provided with the list of drain cells.",
-      ".gwegwe": "keyword to indicate that boundary names may be provided with the list of GWE Exchange cells.",
-      ".wel": "keyword to indicate that boundary names may be provided with the list of well cells.",
-      ".lak": "keyword to indicate that boundary names may be provided with the list of lake cells.",
-      ".esl": "keyword to indicate that boundary names may be provided with the list of energy source loading cells.",
-      ".lkt": "keyword to indicate that boundary names may be provided with the list of lake cells.",
-      ".gwtgwt": "keyword to indicate that boundary names may be provided with the list of GWT Exchange cells.",
-      ".lke": "keyword to indicate that boundary names may be provided with the list of lake cells.",
-      ".src": "keyword to indicate that boundary names may be provided with the list of mass source cells.",
-      ".ghb": "keyword to indicate that boundary names may be provided with the list of general-head boundary cells.",
-      ".zdg": "keyword to indicate that boundary names may be provided with the list of zero-depth-gradient boundary cells.",
-      ".sfe": "keyword to indicate that boundary names may be provided with the list of reach cells.",
-      ".mwt": "keyword to indicate that boundary names may be provided with the list of well cells.",
-      ".sfr": "keyword to indicate that boundary names may be provided with the list of stream reach cells.",
-      ".riv": "keyword to indicate that boundary names may be provided with the list of river cells.",
-      ".uzf": "keyword to indicate that boundary names may be provided with the list of UZF cells.",
-      ".cnc": "keyword to indicate that boundary names may be provided with the list of constant concentration cells.",
-      ".maw": "keyword to indicate that boundary names may be provided with the list of multi-aquifer well cells.",
-      ".rch": "keyword to indicate that boundary names may be provided with the list of recharge cells.",
-      ".evt": "keyword to indicate that boundary names may be provided with the list of evapotranspiration cells.",
-      ".uzt": "keyword to indicate that boundary names may be provided with the list of unsaturated zone flow cells.",
-      ".mwe": "keyword to indicate that boundary names may be provided with the list of well cells."
+      ".gwegwe": "scheme used to solve the advection term.  Can be upstream, central, or TVD.  If not specified, upstream weighting is the default weighting scheme.",
+      ".gwtgwt": "scheme used to solve the advection term.  Can be upstream, central, or TVD.  If not specified, upstream weighting is the default weighting scheme."
     }
   },
-  "print_input": {
-    "options": {
-      ".csub": "keyword to indicate that the list of CSUB information will be written to the listing file immediately after it is read.",
-      ".spca": "keyword to indicate that the list of spc information will be written to the listing file immediately after it is read.",
-      ".ctp": "keyword to indicate that the list of constant temperature information will be written to the listing file immediately after it is read.",
-      ".hfb": "keyword to indicate that the list of horizontal flow barriers will be written to the listing file immediately after it is read.",
-      ".cdb": "keyword to indicate that the list of critical depth boundary information will be written to the listing file immediately after it is read.",
-      ".sft": "keyword to indicate that the list of reach information will be written to the listing file immediately after it is read.",
-      ".mve": "keyword to indicate that the list of mover information will be written to the listing file immediately after it is read.",
-      ".evp": "keyword to indicate that the list of evaporation information will be written to the listing file immediately after it is read.",
-      ".flw": "keyword to indicate that the list of inflow information will be written to the listing file immediately after it is read.",
-      ".chd": "keyword to indicate that the list of constant-head information will be written to the listing file immediately after it is read.",
-      ".uze": "keyword to indicate that the list of unsaturated zone flow information will be written to the listing file immediately after it is read.",
-      ".nam": "keyword to indicate that the list of all model stress package information will be written to the listing file immediately after it is read.",
-      ".prp": "keyword to indicate that the list of all model stress package information will be written to the listing file immediately after it is read.",
-      ".pcp": "keyword to indicate that the list of precipitation information will be written to the listing file immediately after it is read.",
-      ".api": "keyword to indicate that the list of api boundary information will be written to the listing file immediately after it is read.",
-      ".drn": "keyword to indicate that the list of drain information will be written to the listing file immediately after it is read.",
-      ".gwegwe": "keyword to indicate that the list of exchange entries will be echoed to the listing file immediately after it is read.",
-      ".olfgwf": "keyword to indicate that the list of exchange entries will be echoed to the listing file immediately after it is read.",
-      ".wel": "keyword to indicate that the list of well information will be written to the listing file immediately after it is read.",
-      ".cxs": "keyword to indicate that the list of stream reach information will be written to the listing file immediately after it is read.",
-      ".lak": "keyword to indicate that the list of lake information will be written to the listing file immediately after it is read.",
-      ".esl": "keyword to indicate that the list of energy source loading information will be written to the listing file immediately after it is read.",
-      ".lkt": "keyword to indicate that the list of lake information will be written to the listing file immediately after it is read.",
-      ".gwtgwt": "keyword to indicate that the list of exchange entries will be echoed to the listing file immediately after it is read.",
-      ".lke": "keyword to indicate that the list of lake information will be written to the listing file immediately after it is read.",
-      ".tvk": "keyword to indicate that information for each change to the hydraulic conductivity in a cell will be written to the model listing file.",
-      ".evta": "keyword to indicate that the list of evapotranspiration information will be written to the listing file immediately after it is read.",
-      ".src": "keyword to indicate that the list of mass source information will be written to the listing file immediately after it is read.",
-      ".ghb": "keyword to indicate that the list of general-head boundary information will be written to the listing file immediately after it is read.",
-      ".rcha": "keyword to indicate that the list of recharge information will be written to the listing file immediately after it is read.",
-      ".zdg": "keyword to indicate that the list of zero-depth-gradient boundary information will be written to the listing file immediately after it is read.",
-      ".gwfgwf": "keyword to indicate that the list of exchange entries will be echoed to the listing file immediately after it is read.",
-      ".sfe": "keyword to indicate that the list of reach information will be written to the listing file immediately after it is read.",
-      ".mvt": "keyword to indicate that the list of mover information will be written to the listing file immediately after it is read.",
-      ".mvr": "keyword to indicate that the list of MVR information will be written to the listing file immediately after it is read.",
-      ".mwt": "keyword to indicate that the list of well information will be written to the listing file immediately after it is read.",
-      ".gnc": "keyword to indicate that the list of GNC information will be written to the listing file immediately after it is read.",
-      ".obs": "keyword to indicate that the list of observation information will be written to the listing file immediately after it is read.",
-      ".chfgwf": "keyword to indicate that the list of exchange entries will be echoed to the listing file immediately after it is read.",
-      ".tvs": "keyword to indicate that information for each change to a storage property in a cell will be written to the model listing file.",
-      ".sfr": "keyword to indicate that the list of stream reach information will be written to the listing file immediately after it is read.",
-      ".spc": "keyword to indicate that the list of spc information will be written to the listing file immediately after it is read.",
-      ".riv": "keyword to indicate that the list of river information will be written to the listing file immediately after it is read.",
-      ".uzf": "keyword to indicate that the list of UZF information will be written to the listing file immediately after it is read.",
-      ".cnc": "keyword to indicate that the list of constant concentration information will be written to the listing file immediately after it is read.",
-      ".maw": "keyword to indicate that the list of multi-aquifer well information will be written to the listing file immediately after it is read.",
-      ".rch": "keyword to indicate that the list of recharge information will be written to the listing file immediately after it is read.",
-      ".evt": "keyword to indicate that the list of evapotranspiration information will be written to the listing file immediately after it is read.",
-      ".uzt": "keyword to indicate that the list of unsaturated zone flow information will be written to the listing file immediately after it is read.",
-      ".mwe": "keyword to indicate that the list of well information will be written to the listing file immediately after it is read."
+  "alh": {
+    "griddata": {
+      ".cnd": "longitudinal dispersivity in horizontal direction.  If flow is strictly horizontal, then this is the longitudinal dispersivity that will be used.  If flow is not strictly horizontal or strictly vertical, then the longitudinal dispersivity is a function of both ALH and ALV.  If mechanical dispersion is represented (by specifying any dispersivity values) then this array is required.",
+      ".dsp": "longitudinal dispersivity in horizontal direction.  If flow is strictly horizontal, then this is the longitudinal dispersivity that will be used.  If flow is not strictly horizontal or strictly vertical, then the longitudinal dispersivity is a function of both ALH and ALV.  If mechanical dispersion is represented (by specifying any dispersivity values) then this array is required."
     }
   },
-  "save_flows": {
+  "all": {
+    "period": {
+      ".oc": "keyword to indicate save for all time steps in period.",
+      ".prp": "keyword to indicate release at the start of all time steps in the period."
+    }
+  },
+  "alternative_cell_averaging": {
     "options": {
-      ".csub": "keyword to indicate that cell-by-cell flow terms will be written to the file specified with ``BUDGET SAVE FILE'' in Output Control.",
-      ".sto": "keyword to indicate that cell-by-cell flow terms will be written to the file specified with ``BUDGET SAVE FILE'' in Output Control.",
-      ".ctp": "keyword to indicate that constant temperature flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".cdb": "keyword to indicate that critical depth boundary flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".sft": "keyword to indicate that reach flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".mve": "keyword to indicate that lake flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".evp": "keyword to indicate that evaporation flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".fmi": "keyword to indicate that FMI flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".npf": "keyword to indicate that budget flow terms will be written to the file specified with ``BUDGET SAVE FILE'' in Output Control.",
-      ".flw": "keyword to indicate that inflow flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".chd": "keyword to indicate that constant-head flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".uze": "keyword to indicate that unsaturated zone flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".nam": "keyword to indicate that all model package flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".pcp": "keyword to indicate that precipitation flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".api": "keyword to indicate that api boundary flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".drn": "keyword to indicate that drain flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".gwegwe": "keyword to indicate that cell-by-cell flow terms will be written to the budget file for each model provided that the Output Control for the models are set up with the ``BUDGET SAVE FILE'' option.",
-      ".wel": "keyword to indicate that well flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".lak": "keyword to indicate that lake flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".esl": "keyword to indicate that energy source loading flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".lkt": "keyword to indicate that lake flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".gwtgwt": "keyword to indicate that cell-by-cell flow terms will be written to the budget file for each model provided that the Output Control for the models are set up with the ``BUDGET SAVE FILE'' option.",
-      ".lke": "keyword to indicate that lake flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".evta": "keyword to indicate that evapotranspiration flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".src": "keyword to indicate that mass source flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".ghb": "keyword to indicate that general-head boundary flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".rcha": "keyword to indicate that recharge flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".zdg": "keyword to indicate that zero-depth-gradient boundary flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".mst": "keyword to indicate that MST flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".gwfgwf": "keyword to indicate that cell-by-cell flow terms will be written to the budget file for each model provided that the Output Control for the models are set up with the ``BUDGET SAVE FILE'' option.",
-      ".sfe": "keyword to indicate that reach flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".mvt": "keyword to indicate that lake flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".est": "keyword to indicate that EST flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".dfw": "keyword to indicate that budget flow terms will be written to the file specified with ``BUDGET SAVE FILE'' in Output Control.",
-      ".mwt": "keyword to indicate that well flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".sfr": "keyword to indicate that stream reach flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".riv": "keyword to indicate that river flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".uzf": "keyword to indicate that UZF flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".cnc": "keyword to indicate that constant concentration flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".ist": "keyword to indicate that IST flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".maw": "keyword to indicate that multi-aquifer well flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".ssm": "keyword to indicate that SSM flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".rch": "keyword to indicate that recharge flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".evt": "keyword to indicate that evapotranspiration flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".uzt": "keyword to indicate that unsaturated zone flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".mwe": "keyword to indicate that well flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control."
+      ".npf": "is a text keyword to indicate that an alternative method will be used for calculating the conductance for horizontal cell connections.  The text value for ALTERNATIVE\\_CELL\\_AVERAGING can be ``LOGARITHMIC'', ``AMT-LMK'', or ``AMT-HMK''.  ``AMT-LMK'' signifies that the conductance will be calculated using arithmetic-mean thickness and logarithmic-mean hydraulic conductivity.  ``AMT-HMK'' signifies that the conductance will be calculated using arithmetic-mean thickness and harmonic-mean hydraulic conductivity. If the user does not specify a value for ALTERNATIVE\\_CELL\\_AVERAGING, then the harmonic-mean method will be used.  This option cannot be used if the XT3D option is invoked."
+    }
+  },
+  "alv": {
+    "griddata": {
+      ".cnd": "longitudinal dispersivity in vertical direction.  If flow is strictly vertical, then this is the longitudinal dispsersivity value that will be used.  If flow is not strictly horizontal or strictly vertical, then the longitudinal dispersivity is a function of both ALH and ALV.  If this value is not specified and mechanical dispersion is represented, then this array is set equal to ALH.",
+      ".dsp": "longitudinal dispersivity in vertical direction.  If flow is strictly vertical, then this is the longitudinal dispsersivity value that will be used.  If flow is not strictly horizontal or strictly vertical, then the longitudinal dispersivity is a function of both ALH and ALV.  If this value is not specified and mechanical dispersion is represented, then this array is set equal to ALH."
+    }
+  },
+  "angldegx": {
+    "connectiondata": {
+      ".disu": "is the angle (in degrees) between the horizontal x-axis and the outward normal to the face between a cell and its connecting cells. The angle varies between zero and 360.0 degrees, where zero degrees points in the positive x-axis direction, and 90 degrees points in the positive y-axis direction.  ANGLDEGX is only needed if horizontal anisotropy is specified in the NPF Package, if the XT3D option is used in the NPF Package, or if the SAVE\\_SPECIFIC\\_DISCHARGE option is specified in the NPF Package.  ANGLDEGX does not need to be specified if these conditions are not met.  ANGLDEGX is of size NJA; values specified for vertical connections and for the diagonal position are not used.  Note that ANGLDEGX is read in degrees, which is different from MODFLOW-USG, which reads a similar variable (ANGLEX) in radians."
+    }
+  },
+  "angle1": {
+    "griddata": {
+      ".npf": "is a rotation angle of the hydraulic conductivity tensor in degrees. The angle represents the first of three sequential rotations of the hydraulic conductivity ellipsoid. With the K11, K22, and K33 axes of the ellipsoid initially aligned with the x, y, and z coordinate axes, respectively, ANGLE1 rotates the ellipsoid about its K33 axis (within the x - y plane). A positive value represents counter-clockwise rotation when viewed from any point on the positive K33 axis, looking toward the center of the ellipsoid. A value of zero indicates that the K11 axis lies within the x - z plane. If ANGLE1 is not specified, default values of zero are assigned to ANGLE1, ANGLE2, and ANGLE3, in which case the K11, K22, and K33 axes are aligned with the x, y, and z axes, respectively."
+    }
+  },
+  "angle2": {
+    "griddata": {
+      ".npf": "is a rotation angle of the hydraulic conductivity tensor in degrees. The angle represents the second of three sequential rotations of the hydraulic conductivity ellipsoid. Following the rotation by ANGLE1 described above, ANGLE2 rotates the ellipsoid about its K22 axis (out of the x - y plane). An array can be specified for ANGLE2 only if ANGLE1 is also specified. A positive value of ANGLE2 represents clockwise rotation when viewed from any point on the positive K22 axis, looking toward the center of the ellipsoid. A value of zero indicates that the K11 axis lies within the x - y plane. If ANGLE2 is not specified, default values of zero are assigned to ANGLE2 and ANGLE3; connections that are not user-designated as vertical are assumed to be strictly horizontal (that is, to have no z component to their orientation); and connection lengths are based on horizontal distances."
+    }
+  },
+  "angle3": {
+    "griddata": {
+      ".npf": "is a rotation angle of the hydraulic conductivity tensor in degrees. The angle represents the third of three sequential rotations of the hydraulic conductivity ellipsoid. Following the rotations by ANGLE1 and ANGLE2 described above, ANGLE3 rotates the ellipsoid about its K11 axis. An array can be specified for ANGLE3 only if ANGLE1 and ANGLE2 are also specified. An array must be specified for ANGLE3 if ANGLE2 is specified. A positive value of ANGLE3 represents clockwise rotation when viewed from any point on the positive K11 axis, looking toward the center of the ellipsoid. A value of zero indicates that the K22 axis lies within the x - y plane."
+    }
+  },
+  "angrot": {
+    "options": {
+      ".dis": "counter-clockwise rotation angle (in degrees) of the lower-left corner of the model grid.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      ".dis2d": "counter-clockwise rotation angle (in degrees) of the lower-left corner of the model grid.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      ".disu": "counter-clockwise rotation angle (in degrees) of the model grid coordinate system relative to a real-world coordinate system.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      ".disv": "counter-clockwise rotation angle (in degrees) of the model grid coordinate system relative to a real-world coordinate system.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      ".disv1d": "counter-clockwise rotation angle (in degrees) of the model grid coordinate system relative to a real-world coordinate system.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      ".disv2d": "counter-clockwise rotation angle (in degrees) of the lower-left corner of the model grid.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space."
+    }
+  },
+  "area": {
+    "griddata": {
+      ".disu": "is the cell surface area (in plan view)."
+    }
+  },
+  "ath1": {
+    "griddata": {
+      ".cnd": "transverse dispersivity in horizontal direction.  This is the transverse dispersivity value for the second ellipsoid axis.  If flow is strictly horizontal and directed in the x direction (along a row for a regular grid), then this value controls spreading in the y direction.  If mechanical dispersion is represented (by specifying any dispersivity values) then this array is required.",
+      ".dsp": "transverse dispersivity in horizontal direction.  This is the transverse dispersivity value for the second ellipsoid axis.  If flow is strictly horizontal and directed in the x direction (along a row for a regular grid), then this value controls spreading in the y direction.  If mechanical dispersion is represented (by specifying any dispersivity values) then this array is required."
+    }
+  },
+  "ath2": {
+    "griddata": {
+      ".cnd": "transverse dispersivity in horizontal direction.  This is the transverse dispersivity value for the third ellipsoid axis.  If flow is strictly horizontal and directed in the x direction (along a row for a regular grid), then this value controls spreading in the z direction.  If this value is not specified and mechanical dispersion is represented, then this array is set equal to ATH1.",
+      ".dsp": "transverse dispersivity in horizontal direction.  This is the transverse dispersivity value for the third ellipsoid axis.  If flow is strictly horizontal and directed in the x direction (along a row for a regular grid), then this value controls spreading in the z direction.  If this value is not specified and mechanical dispersion is represented, then this array is set equal to ATH1."
+    }
+  },
+  "ats6": {
+    "options": {
+      ".tdis": "keyword to specify that record corresponds to an adaptive time step (ATS) input file.  The behavior of ATS and a description of the input file is provided separately."
+    }
+  },
+  "ats_outer_maximum_fraction": {
+    "options": {
+      ".ims": "real value defining the fraction of the maximum allowable outer iterations used with the Adaptive Time Step (ATS) capability if it is active.  If this value is set to zero by the user, then this solution will have no effect on ATS behavior.  This value must be greater than or equal to zero and less than or equal to 0.5 or the program will terminate with an error.  If it is not specified by the user, then it is assigned a default value of one third.  When the number of outer iterations for this solution is less than the product of this value and the maximum allowable outer iterations, then ATS will increase the time step length by a factor of DTADJ in the ATS input file.  When the number of outer iterations for this solution is greater than the maximum allowable outer iterations minus the product of this value and the maximum allowable outer iterations, then the ATS (if active) will decrease the time step length by a factor of 1 / DTADJ.",
+      ".pts": "real value defining the fraction of the maximum allowable outer iterations used with the Adaptive Time Step (ATS) capability if it is active.  If this value is set to zero by the user, then this solution will have no effect on ATS behavior.  This value must be greater than or equal to zero and less than or equal to 0.5 or the program will terminate with an error.  If it is not specified by the user, then it is assigned a default value of one third.  When the number of outer iterations for this solution is less than the product of this value and the maximum allowable outer iterations, then ATS will increase the time step length by a factor of DTADJ in the ATS input file.  When the number of outer iterations for this solution is greater than the maximum allowable outer iterations minus the product of this value and the maximum allowable outer iterations, then the ATS (if active) will decrease the time step length by a factor of 1 / DTADJ."
+    }
+  },
+  "ats_percel": {
+    "options": {
+      ".adv": "fractional cell distance submitted by the ADV Package to the adaptive time stepping (ATS) package.  If ATS\\_PERCEL is specified and the ATS Package is active, a time step calculation will be made for each cell based on flow through the cell and cell properties.  The largest time step will be calculated such that the advective fractional cell distance (ATS\\_PERCEL) is not exceeded for any active cell in the grid.  This time-step constraint will be submitted to the ATS Package, perhaps with constraints submitted by other packages, in the calculation of the time step.  ATS\\_PERCEL must be greater than zero.  If a value of zero is specified for ATS\\_PERCEL the program will automatically reset it to an internal no data value to indicate that time steps should not be subject to this constraint."
+    }
+  },
+  "atv": {
+    "griddata": {
+      ".cnd": "transverse dispersivity when flow is in vertical direction.  If flow is strictly vertical and directed in the z direction, then this value controls spreading in the x and y directions.  If this value is not specified and mechanical dispersion is represented, then this array is set equal to ATH2.",
+      ".dsp": "transverse dispersivity when flow is in vertical direction.  If flow is strictly vertical and directed in the z direction, then this value controls spreading in the x and y directions.  If this value is not specified and mechanical dispersion is represented, then this array is set equal to ATH2."
+    }
+  },
+  "auto_flow_reduce": {
+    "options": {
+      ".wel": "keyword and real value that defines the fraction of the cell thickness used as an interval for smoothly adjusting negative pumping rates to 0 in cells with head values less than or equal to the bottom of the cell. Negative pumping rates are adjusted to 0 or a smaller negative value when the head in the cell is equal to or less than the calculated interval above the cell bottom. AUTO\\_FLOW\\_REDUCE is set to 0.1 if the specified value is less than or equal to zero. By default, negative pumping rates are not reduced during a simulation.  This AUTO\\_FLOW\\_REDUCE option only applies to wells in model cells that are marked as ``convertible'' (ICELLTYPE /= 0) in the Node Property Flow (NPF) input file. Reduction in flow will not occur for wells in cells marked as confined (ICELLTYPE = 0)."
+    }
+  },
+  "auto_flow_reduce_csv": {
+    "options": {
+      ".wel": "keyword to specify that record corresponds to the AUTO\\_FLOW\\_REDUCE output option in which a new record is written for each well and for each time step in which the user-requested extraction rate is reduced by the program."
+    }
+  },
+  "aux": {
+    "period": {
+      ".evta": "is an array of values for auxiliary variable AUX(IAUX), where iaux is a value from 1 to NAUX, and AUX(IAUX) must be listed as part of the auxiliary variables.  A separate array can be specified for each auxiliary variable.  If an array is not specified for an auxiliary variable, then a value of zero is assigned.  If the value specified here for the auxiliary variable is the same as auxmultname, then the evapotranspiration rate will be multiplied by this array.",
+      ".rcha": "is an array of values for auxiliary variable aux(iaux), where iaux is a value from 1 to naux, and aux(iaux) must be listed as part of the auxiliary variables.  A separate array can be specified for each auxiliary variable.  If an array is not specified for an auxiliary variable, then a value of zero is assigned.  If the value specified here for the auxiliary variable is the same as auxmultname, then the recharge array will be multiplied by this array."
+    }
+  },
+  "auxdepthname": {
+    "options": {
+      ".drn": "name of a variable listed in AUXILIARY that defines the depth at which drainage discharge will be scaled. If a positive value is specified for the AUXDEPTHNAME AUXILIARY variable, then ELEV is the elevation at which the drain starts to discharge and ELEV + DDRN (assuming DDRN is the AUXDEPTHNAME variable) is the elevation when the drain conductance (COND) scaling factor is 1. If a negative drainage depth value is specified for DDRN, then ELEV + DDRN is the elevation at which the drain starts to discharge and ELEV is the elevation when the conductance (COND) scaling factor is 1. A linear- or cubic-scaling is used to scale the drain conductance (COND) when the Standard or Newton-Raphson Formulation is used, respectively.  This discharge scaling option is described in more detail in Chapter 3 of the Supplemental Technical Information."
+    }
+  },
+  "auxiliary": {
+    "options": {
+      ".cdb": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".chd": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".cnc": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".ctp": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".drn": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".esl": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".evp": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".evt": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".evta": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".flw": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".ghb": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".gwegwe": "an array of auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided. Most auxiliary variables will not be used by the GWE-GWE Exchange, but they will be available for use by other parts of the program.  If an auxiliary variable with the name ``ANGLDEGX'' is found, then this information will be used as the angle (provided in degrees) between the connection face normal and the x axis, where a value of zero indicates that a normal vector points directly along the positive x axis.  The connection face normal is a normal vector on the cell face shared between the cell in model 1 and the cell in model 2 pointing away from the model 1 cell.  Additional information on ``ANGLDEGX'' is provided in the description of the DISU Package.  If an auxiliary variable with the name ``CDIST'' is found, then this information will be used as the straight-line connection distance, including the vertical component, between the two cell centers.  Both ANGLDEGX and CDIST are required if specific discharge is calculated for either of the groundwater models.",
+      ".gwfgwf": "an array of auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided. Most auxiliary variables will not be used by the GWF-GWF Exchange, but they will be available for use by other parts of the program.  If an auxiliary variable with the name ``ANGLDEGX'' is found, then this information will be used as the angle (provided in degrees) between the connection face normal and the x axis, where a value of zero indicates that a normal vector points directly along the positive x axis.  The connection face normal is a normal vector on the cell face shared between the cell in model 1 and the cell in model 2 pointing away from the model 1 cell.  Additional information on ``ANGLDEGX'' and when it is required is provided in the description of the DISU Package.  If an auxiliary variable with the name ``CDIST'' is found, then this information will be used in the calculation of specific discharge within model cells connected by the exchange.  For a horizontal connection, CDIST should be specified as the horizontal distance between the cell centers, and should not include the vertical component.  For vertical connections, CDIST should be specified as the difference in elevation between the two cell centers.  Both ANGLDEGX and CDIST are required if specific discharge is calculated for either of the groundwater models.",
+      ".gwtgwt": "an array of auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided. Most auxiliary variables will not be used by the GWT-GWT Exchange, but they will be available for use by other parts of the program.  If an auxiliary variable with the name ``ANGLDEGX'' is found, then this information will be used as the angle (provided in degrees) between the connection face normal and the x axis, where a value of zero indicates that a normal vector points directly along the positive x axis.  The connection face normal is a normal vector on the cell face shared between the cell in model 1 and the cell in model 2 pointing away from the model 1 cell.  Additional information on ``ANGLDEGX'' is provided in the description of the DISU Package.  ANGLDEGX must be specified if dispersion is simulated in the connected GWT models.",
+      ".lak": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".lke": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".lkt": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".maw": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".mwe": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".mwt": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".pcp": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".rch": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".rcha": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".riv": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".sfe": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".sfr": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".sft": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".src": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".uze": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".uzf": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".uzt": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".wel": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      ".zdg": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block."
+    },
+    "period": {
+      ".lak": "keyword for specifying auxiliary variable.",
+      ".lke": "keyword for specifying auxiliary variable.",
+      ".lkt": "keyword for specifying auxiliary variable.",
+      ".maw": "keyword for specifying auxiliary variable.",
+      ".mwe": "keyword for specifying auxiliary variable.",
+      ".mwt": "keyword for specifying auxiliary variable.",
+      ".sfe": "keyword for specifying auxiliary variable.",
+      ".sfr": "keyword for specifying auxiliary variable.",
+      ".sft": "keyword for specifying auxiliary variable.",
+      ".uze": "keyword for specifying auxiliary variable.",
+      ".uzt": "keyword for specifying auxiliary variable."
+    }
+  },
+  "auxmultname": {
+    "options": {
+      ".chd": "name of auxiliary variable to be used as multiplier of CHD head value.",
+      ".cnc": "name of auxiliary variable to be used as multiplier of concentration value.",
+      ".ctp": "name of auxiliary variable to be used as multiplier of temperature value.",
+      ".drn": "name of auxiliary variable to be used as multiplier of drain conductance.",
+      ".esl": "name of auxiliary variable to be used as multiplier of energy loading rate.",
+      ".evp": "name of auxiliary variable to be used as multiplier of evaporation.",
+      ".evt": "name of auxiliary variable to be used as multiplier of evapotranspiration rate.",
+      ".evta": "name of auxiliary variable to be used as multiplier of evapotranspiration rate.",
+      ".flw": "name of auxiliary variable to be used as multiplier of flow rate.",
+      ".ghb": "name of auxiliary variable to be used as multiplier of general-head boundary conductance.",
+      ".pcp": "name of auxiliary variable to be used as multiplier of precipitation.",
+      ".rch": "name of auxiliary variable to be used as multiplier of recharge.",
+      ".rcha": "name of auxiliary variable to be used as multiplier of recharge.",
+      ".riv": "name of auxiliary variable to be used as multiplier of riverbed conductance.",
+      ".src": "name of auxiliary variable to be used as multiplier of mass loading rate.",
+      ".uzf": "name of auxiliary variable to be used as multiplier of GWF cell area used by UZF cell.",
+      ".wel": "name of auxiliary variable to be used as multiplier of well flow rate."
+    }
+  },
+  "backtracking_number": {
+    "nonlinear": {
+      ".ims": "integer value defining the maximum number of backtracking iterations allowed for residual reduction computations. If BACKTRACKING\\_NUMBER = 0 then the backtracking iterations are omitted. The value usually ranges from 2 to 20; a value of 10 works well for most problems."
+    }
+  },
+  "backtracking_reduction_factor": {
+    "nonlinear": {
+      ".ims": "real value defining the reduction in step size used for residual reduction computations. The value of BACKTRACKING\\_REDUCTION\\_FACTOR is between zero and one. The value usually ranges from 0.1 to 0.3; a value of 0.2 works well for most problems. BACKTRACKING\\_REDUCTION\\_FACTOR only needs to be specified if BACKTRACKING\\_NUMBER is greater than zero."
+    }
+  },
+  "backtracking_residual_limit": {
+    "nonlinear": {
+      ".ims": "real value defining the limit to which the residual is reduced with backtracking. If the residual is smaller than BACKTRACKING\\_RESIDUAL\\_LIMIT, then further backtracking is not performed. A value of 100 is suitable for large problems and residual reduction to smaller values may only slow down computations. BACKTRACKING\\_RESIDUAL\\_LIMIT only needs to be specified if BACKTRACKING\\_NUMBER is greater than zero."
+    }
+  },
+  "backtracking_tolerance": {
+    "nonlinear": {
+      ".ims": "real value defining the tolerance for residual change that is allowed for residual reduction computations. BACKTRACKING\\_TOLERANCE should not be less than one to avoid getting stuck in local minima. A large value serves to check for extreme residual increases, while a low value serves to control step size more severely. The value usually ranges from 1.0 to 10$^6$; a value of 10$^4$ works well for most problems but lower values like 1.1 may be required for harder problems. BACKTRACKING\\_TOLERANCE only needs to be specified if BACKTRACKING\\_NUMBER is greater than zero."
+    }
+  },
+  "bedk": {
+    "period": {
+      ".sfr": "real or character value that defines the hydraulic conductivity of the reach streambed. BEDK can be any positive value if the reach is not connected to an underlying GWF cell. Otherwise, BEDK must be greater than zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
     }
   },
   "beta": {
@@ -145,29 +219,117 @@
       ".csub": "compressibility of water. Typical values of BETA are 4.6512e-10 1/Pa or 2.2270e-8 lb/square foot in SI and English units, respectively. By default, BETA is 4.6512e-10 1/Pa."
     }
   },
-  "head_based": {
-    "options": {
-      ".csub": "keyword to indicate the head-based formulation will be used to simulate coarse-grained aquifer materials and no-delay and delay interbeds. Specifying HEAD\\_BASED also specifies the INITIAL\\_PRECONSOLIDATION\\_HEAD option."
+  "binary": {
+    "continuous": {
+      ".obs": "an optional keyword used to indicate that the output file should be written in binary (unformatted) form."
     }
   },
-  "initial_preconsolidation_head": {
-    "options": {
-      ".csub": "keyword to indicate that preconsolidation heads will be specified for no-delay and delay interbeds in the PACKAGEDATA block. If the SPECIFIED\\_INITIAL\\_INTERBED\\_STATE option is specified in the OPTIONS block, user-specified preconsolidation heads in the PACKAGEDATA block are absolute values. Otherwise, user-specified preconsolidation heads in the PACKAGEDATA block are relative to steady-state or initial heads."
+  "bot": {
+    "griddata": {
+      ".disu": "is the bottom elevation for each cell."
     }
   },
-  "ndelaycells": {
-    "options": {
-      ".csub": "number of nodes used to discretize delay interbeds. If not specified, then a default value of 19 is assigned."
+  "botm": {
+    "griddata": {
+      ".dis": "is the bottom elevation for each cell.",
+      ".disv": "is the bottom elevation for each cell."
     }
   },
-  "compression_indices": {
-    "options": {
-      ".csub": "keyword to indicate that the recompression (CR) and compression (CC) indices are specified instead of the elastic specific storage (SSE) and inelastic specific storage (SSV) coefficients. If not specified, then elastic specific storage (SSE) and inelastic specific storage (SSV) coefficients must be specified."
+  "bottom": {
+    "griddata": {
+      ".dis2d": "is the bottom elevation for each cell.",
+      ".disv1d": "bottom elevation for the one-dimensional cell.",
+      ".disv2d": "is the bottom elevation for each cell."
     }
   },
-  "update_material_properties": {
+  "boundnames": {
     "options": {
-      ".csub": "keyword to indicate that the thickness and void ratio of coarse-grained and interbed sediments (delay and no-delay) will vary during the simulation. If not specified, the thickness and void ratio of coarse-grained and interbed sediments will not vary during the simulation."
+      ".api": "keyword to indicate that boundary names may be provided with the list of api boundary cells.",
+      ".cdb": "keyword to indicate that boundary names may be provided with the list of critical depth boundary cells.",
+      ".chd": "keyword to indicate that boundary names may be provided with the list of constant-head cells.",
+      ".cnc": "keyword to indicate that boundary names may be provided with the list of constant concentration cells.",
+      ".csub": "keyword to indicate that boundary names may be provided with the list of CSUB cells.",
+      ".ctp": "keyword to indicate that boundary names may be provided with the list of constant temperature cells.",
+      ".drn": "keyword to indicate that boundary names may be provided with the list of drain cells.",
+      ".esl": "keyword to indicate that boundary names may be provided with the list of energy source loading cells.",
+      ".evp": "keyword to indicate that boundary names may be provided with the list of evaporation cells.",
+      ".evt": "keyword to indicate that boundary names may be provided with the list of evapotranspiration cells.",
+      ".flw": "keyword to indicate that boundary names may be provided with the list of inflow cells.",
+      ".ghb": "keyword to indicate that boundary names may be provided with the list of general-head boundary cells.",
+      ".gwegwe": "keyword to indicate that boundary names may be provided with the list of GWE Exchange cells.",
+      ".gwtgwt": "keyword to indicate that boundary names may be provided with the list of GWT Exchange cells.",
+      ".lak": "keyword to indicate that boundary names may be provided with the list of lake cells.",
+      ".lke": "keyword to indicate that boundary names may be provided with the list of lake cells.",
+      ".lkt": "keyword to indicate that boundary names may be provided with the list of lake cells.",
+      ".maw": "keyword to indicate that boundary names may be provided with the list of multi-aquifer well cells.",
+      ".mwe": "keyword to indicate that boundary names may be provided with the list of well cells.",
+      ".mwt": "keyword to indicate that boundary names may be provided with the list of well cells.",
+      ".pcp": "keyword to indicate that boundary names may be provided with the list of precipitation cells.",
+      ".prp": "keyword to indicate that boundary names may be provided with the list of particle release points.",
+      ".rch": "keyword to indicate that boundary names may be provided with the list of recharge cells.",
+      ".riv": "keyword to indicate that boundary names may be provided with the list of river cells.",
+      ".sfe": "keyword to indicate that boundary names may be provided with the list of reach cells.",
+      ".sfr": "keyword to indicate that boundary names may be provided with the list of stream reach cells.",
+      ".sft": "keyword to indicate that boundary names may be provided with the list of reach cells.",
+      ".src": "keyword to indicate that boundary names may be provided with the list of mass source cells.",
+      ".uze": "keyword to indicate that boundary names may be provided with the list of unsaturated zone flow cells.",
+      ".uzf": "keyword to indicate that boundary names may be provided with the list of UZF cells.",
+      ".uzt": "keyword to indicate that boundary names may be provided with the list of unsaturated zone flow cells.",
+      ".wel": "keyword to indicate that boundary names may be provided with the list of well cells.",
+      ".zdg": "keyword to indicate that boundary names may be provided with the list of zero-depth-gradient boundary cells."
+    }
+  },
+  "budget": {
+    "options": {
+      ".ist": "keyword to specify that record corresponds to the budget.",
+      ".lak": "keyword to specify that record corresponds to the budget.",
+      ".lke": "keyword to specify that record corresponds to the budget.",
+      ".lkt": "keyword to specify that record corresponds to the budget.",
+      ".maw": "keyword to specify that record corresponds to the budget.",
+      ".mve": "keyword to specify that record corresponds to the budget.",
+      ".mvr": "keyword to specify that record corresponds to the budget.",
+      ".mvt": "keyword to specify that record corresponds to the budget.",
+      ".mwe": "keyword to specify that record corresponds to the budget.",
+      ".mwt": "keyword to specify that record corresponds to the budget.",
+      ".oc": "keyword to specify that record corresponds to the budget.",
+      ".sfe": "keyword to specify that record corresponds to the budget.",
+      ".sfr": "keyword to specify that record corresponds to the budget.",
+      ".sft": "keyword to specify that record corresponds to the budget.",
+      ".uze": "keyword to specify that record corresponds to the budget.",
+      ".uzf": "keyword to specify that record corresponds to the budget.",
+      ".uzt": "keyword to specify that record corresponds to the budget."
+    }
+  },
+  "budgetcsv": {
+    "options": {
+      ".ist": "keyword to specify that record corresponds to the budget CSV.",
+      ".lak": "keyword to specify that record corresponds to the budget CSV.",
+      ".lke": "keyword to specify that record corresponds to the budget CSV.",
+      ".lkt": "keyword to specify that record corresponds to the budget CSV.",
+      ".maw": "keyword to specify that record corresponds to the budget CSV.",
+      ".mve": "keyword to specify that record corresponds to the budget CSV.",
+      ".mvr": "keyword to specify that record corresponds to the budget CSV.",
+      ".mvt": "keyword to specify that record corresponds to the budget CSV.",
+      ".mwe": "keyword to specify that record corresponds to the budget CSV.",
+      ".mwt": "keyword to specify that record corresponds to the budget CSV.",
+      ".oc": "keyword to specify that record corresponds to the budget CSV.",
+      ".sfe": "keyword to specify that record corresponds to the budget CSV.",
+      ".sfr": "keyword to specify that record corresponds to the budget CSV.",
+      ".sft": "keyword to specify that record corresponds to the budget CSV.",
+      ".uze": "keyword to specify that record corresponds to the budget CSV.",
+      ".uzf": "keyword to specify that record corresponds to the budget CSV.",
+      ".uzt": "keyword to specify that record corresponds to the budget CSV."
+    }
+  },
+  "bulk_density": {
+    "griddata": {
+      ".ist": "is the bulk density of this immobile domain in mass per length cubed.  Bulk density is defined as the immobile domain solid mass per volume of the immobile domain.  bulk\\_density is not required unless the SORPTION keyword is specified in the options block.  If the SORPTION keyword is not specified in the options block, bulk\\_density will have no effect on simulation results.  ",
+      ".mst": "is the bulk density of the aquifer in mass per length cubed.  bulk\\_density is not required unless the SORPTION keyword is specified.  Bulk density is defined as the mobile domain solid mass per mobile domain volume.  Additional information on bulk density is included in the MODFLOW 6 Supplemental Technical Information document."
+    }
+  },
+  "cell_averaging": {
+    "options": {
+      ".gwfgwf": "is a keyword and text keyword to indicate the method that will be used for calculating the conductance for horizontal cell connections.  The text value for CELL\\_AVERAGING can be ``HARMONIC'', ``LOGARITHMIC'', or ``AMT-LMK'', which means ``arithmetic-mean thickness and logarithmic-mean hydraulic conductivity''. If the user does not specify a value for CELL\\_AVERAGING, then the harmonic-mean method will be used."
     }
   },
   "cell_fraction": {
@@ -175,72 +337,83 @@
       ".csub": "keyword to indicate that the thickness of interbeds will be specified in terms of the fraction of cell thickness. If not specified, interbed thicknness must be specified."
     }
   },
-  "specified_initial_interbed_state": {
+  "central_in_space": {
     "options": {
-      ".csub": "keyword to indicate that absolute preconsolidation stresses (heads) and delay bed heads will be specified for interbeds defined in the PACKAGEDATA block. The SPECIFIED\\_INITIAL\\_INTERBED\\_STATE option is equivalent to specifying the SPECIFIED\\_INITIAL\\_PRECONSOLITATION\\_STRESS and SPECIFIED\\_INITIAL\\_DELAY\\_HEAD. If SPECIFIED\\_INITIAL\\_INTERBED\\_STATE is not specified then preconsolidation stress (head) and delay bed head values specified in the PACKAGEDATA block are relative to simulated values of the first stress period if steady-state or initial stresses and GWF heads if the first stress period is transient."
+      ".dfw": "keyword to indicate conductance should be calculated using central-in-space weighting instead of the default upstream weighting approach.  This option should be used with caution as it does not work well unless all of the stream reaches are saturated.  With this option, there is no way for water to flow into a dry reach from connected reaches."
     }
   },
-  "specified_initial_preconsolidation_stress": {
-    "options": {
-      ".csub": "keyword to indicate that absolute preconsolidation stresses (heads) will be specified for interbeds defined in the PACKAGEDATA block. If SPECIFIED\\_INITIAL\\_PRECONSOLITATION\\_STRESS and SPECIFIED\\_INITIAL\\_INTERBED\\_STATE are not specified then preconsolidation stress (head) values specified in the PACKAGEDATA block are relative to simulated values if the first stress period is steady-state or initial stresses (heads) if the first stress period is transient."
+  "cg_ske_cr": {
+    "griddata": {
+      ".csub": "is the initial elastic coarse-grained material specific storage or recompression index. The recompression index is specified if COMPRESSION\\_INDICES is specified in the OPTIONS block.  Specified or calculated elastic coarse-grained material specific storage values are not adjusted from initial values if HEAD\\_BASED is specified in the OPTIONS block."
     }
   },
-  "specified_initial_delay_head": {
-    "options": {
-      ".csub": "keyword to indicate that absolute initial delay bed head will be specified for interbeds defined in the PACKAGEDATA block. If SPECIFIED\\_INITIAL\\_DELAY\\_HEAD and SPECIFIED\\_INITIAL\\_INTERBED\\_STATE are not specified then delay bed head values specified in the PACKAGEDATA block are relative to simulated values if the first stress period is steady-state or initial GWF heads if the first stress period is transient."
+  "cg_theta": {
+    "griddata": {
+      ".csub": "is the initial porosity of coarse-grained materials."
     }
   },
-  "effective_stress_lag": {
+  "chunk_face": {
     "options": {
-      ".csub": "keyword to indicate the effective stress from the previous time step will be used to calculate specific storage values. This option can 1) help with convergence in models with thin cells and water table elevations close to land surface; 2) is identical to the approach used in the SUBWT package for MODFLOW-2005; and 3) is only used if the effective-stress formulation is being used. By default, current effective stress values are used to calculate specific storage values."
+      ".ncf": "is the keyword used to provide a data chunk size for the face dimension in a NETCDF\\_MESH2D output file. Must be used in combination with the the chunk\\_time parameter to have an effect."
     }
   },
-  "strain_csv_interbed": {
+  "chunk_time": {
     "options": {
-      ".csub": "keyword to specify the record that corresponds to final interbed strain output."
+      ".ncf": "is the keyword used to provide a data chunk size for the time dimension in a NETCDF\\_MESH2D or NETCDF\\_STRUCTURED output file. Must be used in combination with the the chunk\\_face parameter (NETCDF\\_MESH2D) or the chunk\\_z, chunk\\_y, and chunk\\_x parameter set (NETCDF\\_STRUCTURED) to have an effect."
     }
   },
-  "fileout": {
+  "chunk_x": {
     "options": {
-      ".csub": "keyword to specify that an output filename is expected next.",
-      ".oc": "keyword to specify that an output filename is expected next.",
-      ".sft": "keyword to specify that an output filename is expected next.",
-      ".mve": "keyword to specify that an output filename is expected next.",
-      ".vsc": "keyword to specify that an output filename is expected next.",
-      ".uze": "keyword to specify that an output filename is expected next.",
-      ".prp": "keyword to specify that an output filename is expected next.",
-      ".ims": "keyword to specify that an output filename is expected next.",
-      ".wel": "keyword to specify that an output filename is expected next.",
-      ".lak": "keyword to specify that an output filename is expected next.",
-      ".lkt": "keyword to specify that an output filename is expected next.",
-      ".lke": "keyword to specify that an output filename is expected next.",
-      ".mst": "keyword to specify that an output filename is expected next.",
-      ".buy": "keyword to specify that an output filename is expected next.",
-      ".sfe": "keyword to specify that an output filename is expected next.",
-      ".mvt": "keyword to specify that an output filename is expected next.",
-      ".mvr": "keyword to specify that an output filename is expected next.",
-      ".mwt": "keyword to specify that an output filename is expected next.",
-      ".pts": "keyword to specify that an output filename is expected next.",
-      ".sfr": "keyword to specify that an output filename is expected next.",
-      ".uzf": "keyword to specify that an output filename is expected next.",
-      ".ist": "keyword to specify that an output filename is expected next.",
-      ".nam": "keyword to specify that an output filename is expected next.",
-      ".maw": "keyword to specify that an output filename is expected next.",
-      ".uzt": "keyword to specify that an output filename is expected next.",
-      ".mwe": "keyword to specify that an output filename is expected next."
+      ".ncf": "is the keyword used to provide a data chunk size for the x dimension in a NETCDF\\_STRUCTURED output file. Must be used in combination with the the chunk\\_time, chunk\\_y and chunk\\_z parameter set to have an effect."
+    }
+  },
+  "chunk_y": {
+    "options": {
+      ".ncf": "is the keyword used to provide a data chunk size for the y dimension in a NETCDF\\_STRUCTURED output file. Must be used in combination with the the chunk\\_time, chunk\\_x and chunk\\_z parameter set to have an effect."
+    }
+  },
+  "chunk_z": {
+    "options": {
+      ".ncf": "is the keyword used to provide a data chunk size for the z dimension in a NETCDF\\_STRUCTURED output file. Must be used in combination with the the chunk\\_time, chunk\\_x and chunk\\_y parameter set to have an effect."
+    }
+  },
+  "cim": {
+    "griddata": {
+      ".ist": "initial concentration of the immobile domain in mass per length cubed.  If CIM is not specified, then it is assumed to be zero."
     },
-    "continuous": {
-      ".obs": "keyword to specify that an output filename is expected next."
+    "options": {
+      ".ist": "keyword to specify that record corresponds to immobile concentration."
     }
   },
-  "strain_csv_coarse": {
+  "cl12": {
+    "connectiondata": {
+      ".disu": "is the array containing connection lengths between the center of cell n and the shared face with each adjacent m cell."
+    }
+  },
+  "cnd_xt3d_off": {
     "options": {
-      ".csub": "keyword to specify the record that corresponds to final coarse-grained material strain output."
+      ".gwegwe": "deactivate the xt3d method for the dispersive flux and use the faster and less accurate approximation for this exchange."
+    }
+  },
+  "cnd_xt3d_rhs": {
+    "options": {
+      ".gwegwe": "add xt3d dispersion terms to right-hand side, when possible, for this exchange."
+    }
+  },
+  "columns": {
+    "options": {
+      ".ist": "number of columns for writing data.",
+      ".oc": "number of columns for writing data."
     }
   },
   "compaction": {
     "options": {
       ".csub": "keyword to specify that record corresponds to the compaction."
+    }
+  },
+  "compaction_coarse": {
+    "options": {
+      ".csub": "keyword to specify that record corresponds to the elastic coarse-grained material compaction binary file."
     }
   },
   "compaction_elastic": {
@@ -258,291 +431,407 @@
       ".csub": "keyword to specify that record corresponds to the interbed compaction binary file."
     }
   },
-  "compaction_coarse": {
+  "complexity": {
     "options": {
-      ".csub": "keyword to specify that record corresponds to the elastic coarse-grained material compaction binary file."
+      ".ims": "is an optional keyword that defines default non-linear and linear solver parameters.  SIMPLE - indicates that default solver input values will be defined that work well for nearly linear models. This would be used for models that do not include nonlinear stress packages and models that are either confined or consist of a single unconfined layer that is thick enough to contain the water table within a single layer. MODERATE - indicates that default solver input values will be defined that work well for moderately nonlinear models. This would be used for models that include nonlinear stress packages and models that consist of one or more unconfined layers. The MODERATE option should be used when the SIMPLE option does not result in successful convergence.  COMPLEX - indicates that default solver input values will be defined that work well for highly nonlinear models. This would be used for models that include nonlinear stress packages and models that consist of one or more unconfined layers representing complex geology and surface-water/groundwater interaction. The COMPLEX option should be used when the MODERATE option does not result in successful convergence.  Non-linear and linear solver parameters assigned using a specified complexity can be modified in the NONLINEAR and LINEAR blocks. If the COMPLEXITY option is not specified, NONLINEAR and LINEAR variables will be assigned the simple complexity values.",
+      ".pts": "is an optional keyword that defines default non-linear and linear solver parameters.  SIMPLE - indicates that default solver input values will be defined that work well for nearly linear models. This would be used for models that do not include nonlinear stress packages and models that are either confined or consist of a single unconfined layer that is thick enough to contain the water table within a single layer. MODERATE - indicates that default solver input values will be defined that work well for moderately nonlinear models. This would be used for models that include nonlinear stress packages and models that consist of one or more unconfined layers. The MODERATE option should be used when the SIMPLE option does not result in successful convergence.  COMPLEX - indicates that default solver input values will be defined that work well for highly nonlinear models. This would be used for models that include nonlinear stress packages and models that consist of one or more unconfined layers representing complex geology and surface-water/groundwater interaction. The COMPLEX option should be used when the MODERATE option does not result in successful convergence.  Non-linear and linear solver parameters assigned using a specified complexity can be modified in the NONLINEAR and LINEAR blocks. If the COMPLEXITY option is not specified, NONLINEAR and LINEAR variables will be assigned the simple complexity values."
     }
   },
-  "zdisplacement": {
+  "compression_indices": {
     "options": {
-      ".csub": "keyword to specify that record corresponds to the z-displacement binary file."
+      ".csub": "keyword to indicate that the recompression (CR) and compression (CC) indices are specified instead of the elastic specific storage (SSE) and inelastic specific storage (SSV) coefficients. If not specified, then elastic specific storage (SSE) and inelastic specific storage (SSV) coefficients must be specified."
     }
   },
-  "package_convergence": {
+  "concentration": {
     "options": {
-      ".csub": "keyword to specify that record corresponds to the package convergence comma spaced values file. Package convergence data is for delay interbeds. A warning message will be issued if package convergence data is requested but delay interbeds are not included in the package.",
-      ".lak": "keyword to specify that record corresponds to the package convergence comma spaced values file.",
-      ".sfr": "keyword to specify that record corresponds to the package convergence comma spaced values file.",
-      ".uzf": "keyword to specify that record corresponds to the package convergence comma spaced values file."
-    }
-  },
-  "ts6": {
-    "options": {
-      ".csub": "keyword to specify that record corresponds to a time-series file.",
-      ".ctp": "keyword to specify that record corresponds to a time-series file.",
-      ".sft": "keyword to specify that record corresponds to a time-series file.",
-      ".evp": "keyword to specify that record corresponds to a time-series file.",
-      ".flw": "keyword to specify that record corresponds to a time-series file.",
-      ".chd": "keyword to specify that record corresponds to a time-series file.",
-      ".uze": "keyword to specify that record corresponds to a time-series file.",
-      ".pcp": "keyword to specify that record corresponds to a time-series file.",
-      ".drn": "keyword to specify that record corresponds to a time-series file.",
-      ".wel": "keyword to specify that record corresponds to a time-series file.",
-      ".lak": "keyword to specify that record corresponds to a time-series file.",
-      ".esl": "keyword to specify that record corresponds to a time-series file.",
-      ".lkt": "keyword to specify that record corresponds to a time-series file.",
-      ".lke": "keyword to specify that record corresponds to a time-series file.",
-      ".tvk": "keyword to specify that record corresponds to a time-series file.",
-      ".src": "keyword to specify that record corresponds to a time-series file.",
-      ".ghb": "keyword to specify that record corresponds to a time-series file.",
-      ".zdg": "keyword to specify that record corresponds to a time-series file.",
-      ".sfe": "keyword to specify that record corresponds to a time-series file.",
-      ".mwt": "keyword to specify that record corresponds to a time-series file.",
-      ".tvs": "keyword to specify that record corresponds to a time-series file.",
-      ".sfr": "keyword to specify that record corresponds to a time-series file.",
-      ".spc": "keyword to specify that record corresponds to a time-series file.",
-      ".riv": "keyword to specify that record corresponds to a time-series file.",
-      ".uzf": "keyword to specify that record corresponds to a time-series file.",
-      ".cnc": "keyword to specify that record corresponds to a time-series file.",
-      ".maw": "keyword to specify that record corresponds to a time-series file.",
-      ".rch": "keyword to specify that record corresponds to a time-series file.",
-      ".evt": "keyword to specify that record corresponds to a time-series file.",
-      ".uzt": "keyword to specify that record corresponds to a time-series file.",
-      ".mwe": "keyword to specify that record corresponds to a time-series file."
-    }
-  },
-  "filein": {
-    "options": {
-      ".csub": "keyword to specify that an input filename is expected next.",
-      ".spca": "keyword to specify that an input filename is expected next.",
-      ".ctp": "keyword to specify that an input filename is expected next.",
-      ".cdb": "keyword to specify that an input filename is expected next.",
-      ".sft": "keyword to specify that an input filename is expected next.",
-      ".evp": "keyword to specify that an input filename is expected next.",
-      ".npf": "keyword to specify that an input filename is expected next.",
-      ".flw": "keyword to specify that an input filename is expected next.",
-      ".chd": "keyword to specify that an input filename is expected next.",
-      ".uze": "keyword to specify that an input filename is expected next.",
-      ".nam": "keyword to specify that an input filename is expected next.",
-      ".pcp": "keyword to specify that an input filename is expected next.",
-      ".api": "keyword to specify that an input filename is expected next.",
-      ".disv": "keyword to specify that an input filename is expected next.",
-      ".dis": "keyword to specify that an input filename is expected next.",
-      ".sto": "keyword to specify that an input filename is expected next.",
-      ".drn": "keyword to specify that an input filename is expected next.",
-      ".gwegwe": "keyword to specify that an input filename is expected next.",
-      ".olfgwf": "keyword to specify that an input filename is expected next.",
-      ".wel": "keyword to specify that an input filename is expected next.",
-      ".lak": "keyword to specify that an input filename is expected next.",
-      ".esl": "keyword to specify that an input filename is expected next.",
-      ".lkt": "keyword to specify that an input filename is expected next.",
-      ".gwtgwt": "keyword to specify that an input filename is expected next.",
-      ".lke": "keyword to specify that an input filename is expected next.",
-      ".tvk": "keyword to specify that an input filename is expected next.",
-      ".evta": "keyword to specify that an input filename is expected next.",
-      ".src": "keyword to specify that an input filename is expected next.",
-      ".ghb": "keyword to specify that an input filename is expected next.",
-      ".rcha": "keyword to specify that an input filename is expected next.",
-      ".zdg": "keyword to specify that an input filename is expected next.",
-      ".gwfgwf": "keyword to specify that an input filename is expected next.",
-      ".sfe": "keyword to specify that an input filename is expected next.",
-      ".dfw": "keyword to specify that an input filename is expected next.",
-      ".mwt": "keyword to specify that an input filename is expected next.",
-      ".chfgwf": "keyword to specify that an input filename is expected next.",
-      ".tvs": "keyword to specify that an input filename is expected next.",
-      ".sfr": "keyword to specify that an input filename is expected next.",
-      ".spc": "keyword to specify that an input filename is expected next.",
-      ".riv": "keyword to specify that an input filename is expected next.",
-      ".uzf": "keyword to specify that an input filename is expected next.",
-      ".cnc": "keyword to specify that an input filename is expected next.",
-      ".maw": "keyword to specify that an input filename is expected next.",
-      ".rch": "keyword to specify that an input filename is expected next.",
-      ".evt": "keyword to specify that an input filename is expected next.",
-      ".uzt": "keyword to specify that an input filename is expected next.",
-      ".tdis": "keyword to specify that an input filename is expected next.",
-      ".mwe": "keyword to specify that an input filename is expected next."
-    },
-    "packagedata": {
-      ".fmi": "keyword to specify that an input filename is expected next."
-    },
-    "tables": {
-      ".lak": "keyword to specify that an input filename is expected next."
-    },
-    "crosssections": {
-      ".sfr": "keyword to specify that an input filename is expected next."
+      ".lkt": "keyword to specify that record corresponds to concentration.",
+      ".mwt": "keyword to specify that record corresponds to concentration.",
+      ".oc": "keyword to specify that record corresponds to concentration.",
+      ".sft": "keyword to specify that record corresponds to concentration.",
+      ".uzt": "keyword to specify that record corresponds to concentration."
     },
     "period": {
-      ".sfr": "keyword to specify that an input filename is expected next."
-    },
-    "fileinput": {
-      ".ssm": "keyword to specify that an input filename is expected next."
+      ".lkt": "real or character value that defines the concentration for the lake. The specified CONCENTRATION is only applied if the lake is a constant concentration lake. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      ".mwt": "real or character value that defines the concentration for the well. The specified CONCENTRATION is only applied if the well is a constant concentration well. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      ".sft": "real or character value that defines the concentration for the reach. The specified CONCENTRATION is only applied if the reach is a constant concentration reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      ".spc": "is the boundary concentration. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, the CONCENTRATION for each boundary feature is zero.",
+      ".spca": "is the concentration of the associated Recharge or Evapotranspiration stress package.  The concentration array may be defined by a time-array series (see the \"Using Time-Array Series in a Package\" section).",
+      ".uzt": "real or character value that defines the concentration for the unsaturated zone flow cell. The specified CONCENTRATION is only applied if the unsaturated zone flow cell is a constant concentration cell. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
     }
   },
-  "obs6": {
+  "continue": {
     "options": {
-      ".csub": "keyword to specify that record corresponds to an observations file.",
-      ".ctp": "keyword to specify that record corresponds to an observations file.",
-      ".cdb": "keyword to specify that record corresponds to an observations file.",
-      ".sft": "keyword to specify that record corresponds to an observations file.",
-      ".evp": "keyword to specify that record corresponds to an observations file.",
-      ".flw": "keyword to specify that record corresponds to an observations file.",
-      ".chd": "keyword to specify that record corresponds to an observations file.",
-      ".uze": "keyword to specify that record corresponds to an observations file.",
-      ".pcp": "keyword to specify that record corresponds to an observations file.",
-      ".api": "keyword to specify that record corresponds to an observations file.",
-      ".drn": "keyword to specify that record corresponds to an observations file.",
-      ".gwegwe": "keyword to specify that record corresponds to an observations file.",
-      ".olfgwf": "keyword to specify that record corresponds to an observations file.",
-      ".wel": "keyword to specify that record corresponds to an observations file.",
-      ".lak": "keyword to specify that record corresponds to an observations file.",
-      ".esl": "keyword to specify that record corresponds to an observations file.",
-      ".lkt": "keyword to specify that record corresponds to an observations file.",
-      ".gwtgwt": "keyword to specify that record corresponds to an observations file.",
-      ".lke": "keyword to specify that record corresponds to an observations file.",
-      ".evta": "keyword to specify that record corresponds to an observations file.",
-      ".src": "keyword to specify that record corresponds to an observations file.",
-      ".ghb": "keyword to specify that record corresponds to an observations file.",
-      ".rcha": "keyword to specify that record corresponds to an observations file.",
-      ".zdg": "keyword to specify that record corresponds to an observations file.",
-      ".gwfgwf": "keyword to specify that record corresponds to an observations file.",
-      ".sfe": "keyword to specify that record corresponds to an observations file.",
-      ".dfw": "keyword to specify that record corresponds to an observations file.",
-      ".mwt": "keyword to specify that record corresponds to an observations file.",
-      ".chfgwf": "keyword to specify that record corresponds to an observations file.",
-      ".sfr": "keyword to specify that record corresponds to an observations file.",
-      ".riv": "keyword to specify that record corresponds to an observations file.",
-      ".uzf": "keyword to specify that record corresponds to an observations file.",
-      ".cnc": "keyword to specify that record corresponds to an observations file.",
-      ".maw": "keyword to specify that record corresponds to an observations file.",
-      ".rch": "keyword to specify that record corresponds to an observations file.",
-      ".evt": "keyword to specify that record corresponds to an observations file.",
-      ".uzt": "keyword to specify that record corresponds to an observations file.",
-      ".mwe": "keyword to specify that record corresponds to an observations file."
+      ".nam": "keyword flag to indicate that the simulation should continue even if one or more solutions do not converge."
     }
   },
-  "ninterbeds": {
-    "dimensions": {
-      ".csub": "is the number of CSUB interbed systems.  More than 1 CSUB interbed systems can be assigned to a GWF cell; however, only 1 GWF cell can be assigned to a single CSUB interbed system."
-    }
-  },
-  "maxsig0": {
-    "dimensions": {
-      ".csub": "is the maximum number of cells that can have a specified stress offset.  More than 1 stress offset can be assigned to a GWF cell. By default, MAXSIG0 is 0."
-    }
-  },
-  "cg_ske_cr": {
-    "griddata": {
-      ".csub": "is the initial elastic coarse-grained material specific storage or recompression index. The recompression index is specified if COMPRESSION\\_INDICES is specified in the OPTIONS block.  Specified or calculated elastic coarse-grained material specific storage values are not adjusted from initial values if HEAD\\_BASED is specified in the OPTIONS block."
-    }
-  },
-  "cg_theta": {
-    "griddata": {
-      ".csub": "is the initial porosity of coarse-grained materials."
-    }
-  },
-  "sgm": {
-    "griddata": {
-      ".csub": "is the specific gravity of moist or unsaturated sediments.  If not specified, then a default value of 1.7 is assigned."
-    }
-  },
-  "sgs": {
-    "griddata": {
-      ".csub": "is the specific gravity of saturated sediments. If not specified, then a default value of 2.0 is assigned."
-    }
-  },
-  "budget": {
-    "options": {
-      ".oc": "keyword to specify that record corresponds to the budget.",
-      ".sft": "keyword to specify that record corresponds to the budget.",
-      ".mve": "keyword to specify that record corresponds to the budget.",
-      ".uze": "keyword to specify that record corresponds to the budget.",
-      ".lak": "keyword to specify that record corresponds to the budget.",
-      ".lkt": "keyword to specify that record corresponds to the budget.",
-      ".lke": "keyword to specify that record corresponds to the budget.",
-      ".sfe": "keyword to specify that record corresponds to the budget.",
-      ".mvt": "keyword to specify that record corresponds to the budget.",
-      ".mvr": "keyword to specify that record corresponds to the budget.",
-      ".mwt": "keyword to specify that record corresponds to the budget.",
-      ".sfr": "keyword to specify that record corresponds to the budget.",
-      ".uzf": "keyword to specify that record corresponds to the budget.",
-      ".ist": "keyword to specify that record corresponds to the budget.",
-      ".maw": "keyword to specify that record corresponds to the budget.",
-      ".uzt": "keyword to specify that record corresponds to the budget.",
-      ".mwe": "keyword to specify that record corresponds to the budget."
-    }
-  },
-  "budgetcsv": {
-    "options": {
-      ".oc": "keyword to specify that record corresponds to the budget CSV.",
-      ".sft": "keyword to specify that record corresponds to the budget CSV.",
-      ".mve": "keyword to specify that record corresponds to the budget CSV.",
-      ".uze": "keyword to specify that record corresponds to the budget CSV.",
-      ".lak": "keyword to specify that record corresponds to the budget CSV.",
-      ".lkt": "keyword to specify that record corresponds to the budget CSV.",
-      ".lke": "keyword to specify that record corresponds to the budget CSV.",
-      ".sfe": "keyword to specify that record corresponds to the budget CSV.",
-      ".mvt": "keyword to specify that record corresponds to the budget CSV.",
-      ".mvr": "keyword to specify that record corresponds to the budget CSV.",
-      ".mwt": "keyword to specify that record corresponds to the budget CSV.",
-      ".sfr": "keyword to specify that record corresponds to the budget CSV.",
-      ".uzf": "keyword to specify that record corresponds to the budget CSV.",
-      ".ist": "keyword to specify that record corresponds to the budget CSV.",
-      ".maw": "keyword to specify that record corresponds to the budget CSV.",
-      ".uzt": "keyword to specify that record corresponds to the budget CSV.",
-      ".mwe": "keyword to specify that record corresponds to the budget CSV."
-    }
-  },
-  "head": {
-    "options": {
-      ".oc": "keyword to specify that record corresponds to head.",
-      ".maw": "keyword to specify that record corresponds to head."
-    }
-  },
-  "print_format": {
-    "options": {
-      ".oc": "keyword to specify format for printing to the listing file.",
-      ".ist": "keyword to specify format for printing to the listing file."
-    }
-  },
-  "columns": {
-    "options": {
-      ".oc": "number of columns for writing data.",
-      ".ist": "number of columns for writing data."
-    }
-  },
-  "width": {
-    "options": {
-      ".oc": "width for writing each number.",
-      ".ist": "width for writing each number."
-    },
-    "griddata": {
-      ".disv1d": "real value that defines the width for each one-dimensional cell. WIDTH must be greater than zero.  If the Cross Section (CXS) Package is used, then the WIDTH value will be multiplied by the specified cross section x-fraction values."
-    },
+  "cross_section": {
     "period": {
-      ".lak": "real or character value that defines the width of the lake outlet. A specified WIDTH value is only used for active lakes if COUTTYPE for lake outlet OUTLETNO is not SPECIFIED. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+      ".sfr": "keyword to specify that record corresponds to a reach cross-section."
+    }
+  },
+  "csv_inner_output": {
+    "options": {
+      ".ims": "keyword to specify that the record corresponds to the comma separated values solver convergence output.",
+      ".pts": "keyword to specify that the record corresponds to the comma separated values solver convergence output."
+    }
+  },
+  "csv_outer_output": {
+    "options": {
+      ".ims": "keyword to specify that the record corresponds to the comma separated values outer iteration convergence output.",
+      ".pts": "keyword to specify that the record corresponds to the comma separated values outer iteration convergence output."
+    }
+  },
+  "csv_output": {
+    "options": {
+      ".ims": "keyword to specify that the record corresponds to the comma separated values solver convergence output.  The CSV\\_OUTPUT option has been deprecated and split into the CSV_OUTER_OUTPUT and CSV_INNER_OUTPUT options.  Starting with MODFLOW 6 version 6.1.1 if the CSV_OUTPUT option is specified, then it is treated as the CSV_OUTER_OUTPUT option.",
+      ".pts": "keyword to specify that the record corresponds to the comma separated values solver convergence output.  The CSV\\_OUTPUT option has been deprecated and split into the CSV_OUTER_OUTPUT and CSV_INNER_OUTPUT options.  Starting with MODFLOW 6 version 6.1.1 if the CSV_OUTPUT option is specified, then it is treated as the CSV_OUTER_OUTPUT option."
+    }
+  },
+  "cvoptions": {
+    "options": {
+      ".gwfgwf": "none",
+      ".npf": "none"
+    }
+  },
+  "decay": {
+    "griddata": {
+      ".ist": "is the rate coefficient for first or zero-order decay for the aqueous phase of the immobile domain.  A negative value indicates solute production.  The dimensions of decay for first-order decay is one over time.  The dimensions of decay for zero-order decay is mass per length cubed per time.  Decay will have no effect on simulation results unless either first- or zero-order decay is specified in the options block.",
+      ".mst": "is the rate coefficient for first or zero-order decay for the aqueous phase of the mobile domain.  A negative value indicates solute production.  The dimensions of decay for first-order decay is one over time.  The dimensions of decay for zero-order decay is mass per length cubed per time.  decay will have no effect on simulation results unless either first- or zero-order decay is specified in the options block."
+    }
+  },
+  "decay_solid": {
+    "griddata": {
+      ".est": "is the rate coefficient for zero-order decay for the solid phase.  A negative value indicates heat (energy) production. The dimensions of zero-order decay in the solid phase are energy per mass of solid per time. Zero-order decay in the solid phase will have no effect on simulation results unless ZERO\\_ORDER\\_DECAY\\_SOLID is specified in the options block."
+    }
+  },
+  "decay_sorbed": {
+    "griddata": {
+      ".ist": "is the rate coefficient for first or zero-order decay for the sorbed phase of the immobile domain.  A negative value indicates solute production.  The dimensions of decay\\_sorbed for first-order decay is one over time.  The dimensions of decay\\_sorbed for zero-order decay is mass of solute per mass of aquifer per time.  If decay\\_sorbed is not specified and both decay and sorption are active, then the program will terminate with an error.  decay\\_sorbed will have no effect on simulation results unless the SORPTION keyword and either first- or zero-order decay are specified in the options block.",
+      ".mst": "is the rate coefficient for first or zero-order decay for the sorbed phase of the mobile domain.  A negative value indicates solute production.  The dimensions of decay\\_sorbed for first-order decay is one over time.  The dimensions of decay\\_sorbed for zero-order decay is mass of solute per mass of aquifer per time.  If decay\\_sorbed is not specified and both decay and sorption are active, then the program will terminate with an error.  decay\\_sorbed will have no effect on simulation results unless the SORPTION keyword and either first- or zero-order decay are specified in the options block."
+    }
+  },
+  "decay_water": {
+    "griddata": {
+      ".est": "is the rate coefficient for zero-order decay for the aqueous phase of the mobile domain.  A negative value indicates heat (energy) production.  The dimensions of zero-order decay in the aqueous phase are energy per length cubed (volume of water) per time.  Zero-order decay in the aqueous phase will have no effect on simulation results unless ZERO\\_ORDER\\_DECAY\\_WATER is specified in the options block."
+    }
+  },
+  "deflate": {
+    "options": {
+      ".ncf": "is the variable deflate level (0=min, 9=max) in the netcdf file. Defining this parameter activates per-variable compression at the level specified."
+    }
+  },
+  "delc": {
+    "griddata": {
+      ".dis": "is the row spacing in the column direction.",
+      ".dis2d": "is the row spacing in the column direction."
+    }
+  },
+  "delr": {
+    "griddata": {
+      ".dis": "is the column spacing in the row direction.",
+      ".dis2d": "is the column spacing in the row direction."
+    }
+  },
+  "denseref": {
+    "options": {
+      ".buy": "fluid reference density used in the equation of state.  This value is set to 1000. if not specified as an option."
+    }
+  },
+  "density": {
+    "options": {
+      ".buy": "keyword to specify that record corresponds to density."
+    }
+  },
+  "density_solid": {
+    "griddata": {
+      ".est": "is a user-specified value of the density of aquifer material not considering the voids. Value will remain fixed for the entire simulation.  For example, if working in SI units, values may be entered as kilograms per cubic meter. "
+    }
+  },
+  "density_water": {
+    "options": {
+      ".est": "density of water used by calculations related to heat storage and conduction.  This value is set to 1,000 kg/m3 if no overriding value is specified.  A user-specified value should be provided for models that use units other than kilograms and meters or if it is necessary to use a value other than the default."
+    }
+  },
+  "depth": {
+    "period": {
+      ".evta": "is the ET extinction depth ($L$)."
+    }
+  },
+  "dev_efh_formulation": {
+    "options": {
+      ".buy": "use the variable-density equivalent freshwater head formulation instead of the hydraulic head head formulation.  This dev option has only been implemented for confined aquifer conditions and should generally not be used."
+    }
+  },
+  "dev_exit_solve_method": {
+    "options": {
+      ".prp": "the method for iterative solution of particle exit location and time in the generalized Pollock's method.  0 default, 1 Brent, 2 Chandrupatla.  The default is Brent's method."
+    }
+  },
+  "dev_forceternary": {
+    "options": {
+      ".prp": "force use of the ternary tracking method regardless of cell type in DISV grids."
+    }
+  },
+  "dev_interfacemodel_on": {
+    "options": {
+      ".gwegwe": "activates the interface model mechanism for calculating the coefficients at (and possibly near) the exchange. This keyword should only be used for development purposes.",
+      ".gwfgwf": "activates the interface model mechanism for calculating the coefficients at (and possibly near) the exchange. This keyword should only be used for development purposes.",
+      ".gwtgwt": "activates the interface model mechanism for calculating the coefficients at (and possibly near) the exchange. This keyword should only be used for development purposes."
+    }
+  },
+  "dev_log_mpi": {
+    "options": {
+      ".hpc": "keyword to enable (extremely verbose) logging of mpi traffic to file."
+    }
+  },
+  "dev_no_newton": {
+    "options": {
+      ".npf": "turn off Newton for unconfined cells"
+    }
+  },
+  "dev_oldstorageformulation": {
+    "options": {
+      ".sto": "development option flag for old storage formulation"
+    }
+  },
+  "dev_omega": {
+    "options": {
+      ".npf": "set saturation omega value"
+    }
+  },
+  "dev_storage_weight": {
+    "options": {
+      ".sfr": "real number value that defines the time weighting factor used to calculate the change in channel storage. STORAGE\\_WEIGHT must have a value between 0.5 and 1. Default STORAGE\\_WEIGHT value is 1."
+    }
+  },
+  "dev_swr_conductance": {
+    "options": {
+      ".dfw": "use the conductance formulation in the Surface Water Routing (SWR) Process for MODFLOW-2005."
+    }
+  },
+  "dewatered": {
+    "options": {
+      ".gwfgwf": "If the DEWATERED keyword is specified, then the vertical conductance is calculated using only the saturated thickness and properties of the overlying cell if the head in the underlying cell is below its top.",
+      ".npf": "If the DEWATERED keyword is specified, then the vertical conductance is calculated using only the saturated thickness and properties of the overlying cell if the head in the underlying cell is below its top."
+    }
+  },
+  "diffc": {
+    "griddata": {
+      ".dsp": "effective molecular diffusion coefficient."
     }
   },
   "digits": {
     "options": {
-      ".oc": "number of digits to use for writing a number.",
+      ".ist": "number of digits to use for writing a number.",
       ".obs": "Keyword and an integer digits specifier used for conversion of simulated values to text on output. If not specified, the default is the maximum number of digits stored in the program (as written with the G0 Fortran specifier). When simulated values are written to a comma-separated value text file specified in a CONTINUOUS block below, the digits specifier controls the number of significant digits with which simulated values are written to the output file. The digits specifier has no effect on the number of significant digits with which the simulation time is written for continuous observations.  If DIGITS is specified as zero, then observations are written with the default setting, which is the maximum number of digits.",
-      ".ist": "number of digits to use for writing a number."
+      ".oc": "number of digits to use for writing a number."
     }
   },
-  "save": {
-    "period": {
-      ".oc": "keyword to indicate that information will be saved this stress period."
+  "disable_storage_change_integration": {
+    "options": {
+      ".tvs": "keyword that deactivates inclusion of storage derivative terms in the STO package matrix formulation.  In the absence of this keyword (the default), the groundwater storage formulation will be modified to correctly adjust heads based on transient variations in stored water volumes arising from changes to SS and SY properties."
     }
   },
-  "print": {
-    "period": {
-      ".oc": "keyword to indicate that information will be printed this stress period."
+  "distcoef": {
+    "griddata": {
+      ".ist": "is the distribution coefficient for the equilibrium-controlled linear sorption isotherm in dimensions of length cubed per mass.  distcoef is not required unless the SORPTION keyword is specified in the options block.  If the SORPTION keyword is not specified in the options block, distcoef will have no effect on simulation results. ",
+      ".mst": "is the distribution coefficient for the equilibrium-controlled linear sorption isotherm in dimensions of length cubed per mass.  If the Freunchlich isotherm is specified, then discoef is the Freundlich constant.  If the Langmuir isotherm is specified, then distcoef is the Langmuir constant.  distcoef is not required unless the SORPTION keyword is specified."
     }
   },
-  "all": {
+  "diversion": {
     "period": {
-      ".oc": "keyword to indicate save for all time steps in period.",
-      ".prp": "keyword to indicate release at the start of all time steps in the period."
+      ".sfr": "keyword to indicate diversion record."
+    }
+  },
+  "drape": {
+    "options": {
+      ".prp": "is a text keyword to indicate that if a particle's release point is in a cell that happens to be inactive at release time, the particle is to be moved to the topmost active cell below it, if any. By default, a particle is not released into the simulation if its release point's cell is inactive at release time."
+    }
+  },
+  "dry_tracking_method": {
+    "options": {
+      ".prp": "is a string indicating how particles should behave in dry-but-active cells (as can occur with the Newton formulation).  The value can be ``DROP'', ``STOP'', or ``STAY''.  The default is ``DROP'', which passes particles vertically and instantaneously to the water table. ``STOP'' causes particles to terminate. ``STAY'' causes particles to remain stationary but active."
+    }
+  },
+  "dsp_xt3d_off": {
+    "options": {
+      ".gwtgwt": "deactivate the xt3d method for the dispersive flux and use the faster and less accurate approximation for this exchange."
+    }
+  },
+  "dsp_xt3d_rhs": {
+    "options": {
+      ".gwtgwt": "add xt3d dispersion terms to right-hand side, when possible, for this exchange."
+    }
+  },
+  "effective_stress_lag": {
+    "options": {
+      ".csub": "keyword to indicate the effective stress from the previous time step will be used to calculate specific storage values. This option can 1) help with convergence in models with thin cells and water table elevations close to land surface; 2) is identical to the approach used in the SUBWT package for MODFLOW-2005; and 3) is only used if the effective-stress formulation is being used. By default, current effective stress values are used to calculate specific storage values."
+    }
+  },
+  "evaporation": {
+    "period": {
+      ".lak": "real or character value that defines the maximum evaporation rate $(LT^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      ".lke": "use of the EVAPORATION keyword is allowed in the LKE package; however, the specified value is not currently used in LKE calculations.  Instead, the latent heat of evaporation is multiplied by the simulated evaporation rate for determining the thermal energy lost from a stream reach.",
+      ".lkt": "real or character value that defines the concentration of evaporated water $(ML^{-3})$ for the lake. If this concentration value is larger than the simulated concentration in the lake, then the evaporated water will be removed at the same concentration as the lake.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      ".sfe": "use of the EVAPORATION keyword is allowed in the SFE package; however, the specified value is not currently used in SFE calculations.  Instead, the latent heat of evaporation is multiplied by the simulated evaporation rate for determining the thermal energy lost from a stream reach.",
+      ".sfr": "real or character value that defines the volumetric rate per unit area of water subtracted by evaporation from the streamflow routing reach. A positive evaporation rate should be provided. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. If the volumetric evaporation rate for a reach exceeds the sources of water to the reach (upstream and specified inflows, rainfall, and runoff but excluding groundwater leakage into the reach) the volumetric evaporation rate is limited to the sources of water to the reach. By default, evaporation rates are zero for each reach.",
+      ".sft": "real or character value that defines the concentration of evaporated water $(ML^{-3})$ for the reach. If this concentration value is larger than the simulated concentration in the reach, then the evaporated water will be removed at the same concentration as the reach.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+    }
+  },
+  "exchanges": {
+    "exchanges": {
+      ".nam": "is the list of exchange types, exchange files, and model names."
+    }
+  },
+  "exit_solve_tolerance": {
+    "options": {
+      ".prp": "the convergence tolerance for iterative solution of particle exit location and time in the generalized Pollock's method.  A value of 0.00001 works well for many problems, but the value that strikes the best balance between accuracy and runtime is problem-dependent."
+    }
+  },
+  "explicit": {
+    "options": {
+      ".gnc": "keyword to indicate that the ghost node correction is applied in an explicit manner on the right-hand side of the matrix.  The explicit approach will likely require additional outer iterations.  If the keyword is not specified, then the correction will be applied in an implicit manner on the left-hand side.  The implicit approach will likely converge better, but may require additional memory.  If the EXPLICIT keyword is not specified, then the BICGSTAB linear acceleration option should be specified within the LINEAR block of the Sparse Matrix Solver."
+    }
+  },
+  "export_array_ascii": {
+    "options": {
+      ".cnd": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
+      ".dfw": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
+      ".dis": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
+      ".dis2d": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
+      ".disu": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
+      ".disv": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
+      ".disv1d": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
+      ".disv2d": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
+      ".dsp": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
+      ".ic": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
+      ".mip": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
+      ".npf": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
+      ".sto": "keyword that specifies input grid arrays, which already support the layered keyword, should be written to layered ascii output files."
+    }
+  },
+  "export_array_netcdf": {
+    "options": {
+      ".cnd": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
+      ".dis": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
+      ".disv": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
+      ".dsp": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
+      ".evta": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
+      ".ic": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
+      ".npf": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
+      ".rcha": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
+      ".sto": "keyword that specifies input griddata arrays should be written to the model output netcdf file."
+    }
+  },
+  "ext-inflow": {
+    "period": {
+      ".lke": "real or character value that defines the temperature of external inflow for the lake.  Users are free to use whatever temperature scale they want, which might include negative temperatures.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      ".lkt": "real or character value that defines the concentration of external inflow $(ML^{-3})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+    }
+  },
+  "extend_tracking": {
+    "options": {
+      ".prp": "indicates that particles should be tracked beyond the end of the simulation's final time step (using that time step's flows) until particles terminate or reach a specified stop time.  By default, particles are terminated at the end of the simulation's final time step."
+    }
+  },
+  "filein": {
+    "crosssections": {
+      ".sfr": "keyword to specify that an input filename is expected next."
+    },
+    "fileinput": {
+      ".ssm": "keyword to specify that an input filename is expected next."
+    },
+    "options": {
+      ".api": "keyword to specify that an input filename is expected next.",
+      ".cdb": "keyword to specify that an input filename is expected next.",
+      ".chd": "keyword to specify that an input filename is expected next.",
+      ".chfgwf": "keyword to specify that an input filename is expected next.",
+      ".cnc": "keyword to specify that an input filename is expected next.",
+      ".csub": "keyword to specify that an input filename is expected next.",
+      ".ctp": "keyword to specify that an input filename is expected next.",
+      ".dfw": "keyword to specify that an input filename is expected next.",
+      ".dis": "keyword to specify that an input filename is expected next.",
+      ".disv": "keyword to specify that an input filename is expected next.",
+      ".drn": "keyword to specify that an input filename is expected next.",
+      ".esl": "keyword to specify that an input filename is expected next.",
+      ".evp": "keyword to specify that an input filename is expected next.",
+      ".evt": "keyword to specify that an input filename is expected next.",
+      ".evta": "keyword to specify that an input filename is expected next.",
+      ".flw": "keyword to specify that an input filename is expected next.",
+      ".ghb": "keyword to specify that an input filename is expected next.",
+      ".gwegwe": "keyword to specify that an input filename is expected next.",
+      ".gwfgwf": "keyword to specify that an input filename is expected next.",
+      ".gwtgwt": "keyword to specify that an input filename is expected next.",
+      ".lak": "keyword to specify that an input filename is expected next.",
+      ".lke": "keyword to specify that an input filename is expected next.",
+      ".lkt": "keyword to specify that an input filename is expected next.",
+      ".maw": "keyword to specify that an input filename is expected next.",
+      ".mwe": "keyword to specify that an input filename is expected next.",
+      ".mwt": "keyword to specify that an input filename is expected next.",
+      ".nam": "keyword to specify that an input filename is expected next.",
+      ".npf": "keyword to specify that an input filename is expected next.",
+      ".olfgwf": "keyword to specify that an input filename is expected next.",
+      ".pcp": "keyword to specify that an input filename is expected next.",
+      ".rch": "keyword to specify that an input filename is expected next.",
+      ".rcha": "keyword to specify that an input filename is expected next.",
+      ".riv": "keyword to specify that an input filename is expected next.",
+      ".sfe": "keyword to specify that an input filename is expected next.",
+      ".sfr": "keyword to specify that an input filename is expected next.",
+      ".sft": "keyword to specify that an input filename is expected next.",
+      ".spc": "keyword to specify that an input filename is expected next.",
+      ".spca": "keyword to specify that an input filename is expected next.",
+      ".src": "keyword to specify that an input filename is expected next.",
+      ".sto": "keyword to specify that an input filename is expected next.",
+      ".tdis": "keyword to specify that an input filename is expected next.",
+      ".tvk": "keyword to specify that an input filename is expected next.",
+      ".tvs": "keyword to specify that an input filename is expected next.",
+      ".uze": "keyword to specify that an input filename is expected next.",
+      ".uzf": "keyword to specify that an input filename is expected next.",
+      ".uzt": "keyword to specify that an input filename is expected next.",
+      ".wel": "keyword to specify that an input filename is expected next.",
+      ".zdg": "keyword to specify that an input filename is expected next."
+    },
+    "packagedata": {
+      ".fmi": "keyword to specify that an input filename is expected next."
+    },
+    "period": {
+      ".sfr": "keyword to specify that an input filename is expected next."
+    },
+    "tables": {
+      ".lak": "keyword to specify that an input filename is expected next."
+    }
+  },
+  "fileout": {
+    "continuous": {
+      ".obs": "keyword to specify that an output filename is expected next."
+    },
+    "options": {
+      ".buy": "keyword to specify that an output filename is expected next.",
+      ".csub": "keyword to specify that an output filename is expected next.",
+      ".ims": "keyword to specify that an output filename is expected next.",
+      ".ist": "keyword to specify that an output filename is expected next.",
+      ".lak": "keyword to specify that an output filename is expected next.",
+      ".lke": "keyword to specify that an output filename is expected next.",
+      ".lkt": "keyword to specify that an output filename is expected next.",
+      ".maw": "keyword to specify that an output filename is expected next.",
+      ".mst": "keyword to specify that an output filename is expected next.",
+      ".mve": "keyword to specify that an output filename is expected next.",
+      ".mvr": "keyword to specify that an output filename is expected next.",
+      ".mvt": "keyword to specify that an output filename is expected next.",
+      ".mwe": "keyword to specify that an output filename is expected next.",
+      ".mwt": "keyword to specify that an output filename is expected next.",
+      ".nam": "keyword to specify that an output filename is expected next.",
+      ".oc": "keyword to specify that an output filename is expected next.",
+      ".prp": "keyword to specify that an output filename is expected next.",
+      ".pts": "keyword to specify that an output filename is expected next.",
+      ".sfe": "keyword to specify that an output filename is expected next.",
+      ".sfr": "keyword to specify that an output filename is expected next.",
+      ".sft": "keyword to specify that an output filename is expected next.",
+      ".uze": "keyword to specify that an output filename is expected next.",
+      ".uzf": "keyword to specify that an output filename is expected next.",
+      ".uzt": "keyword to specify that an output filename is expected next.",
+      ".vsc": "keyword to specify that an output filename is expected next.",
+      ".wel": "keyword to specify that an output filename is expected next."
     }
   },
   "first": {
@@ -551,10 +840,73 @@
       ".prp": "keyword to indicate release at the start of the first time step in the period. This keyword may be used in conjunction with other RELEASESETTING options."
     }
   },
-  "last": {
+  "first_order_decay": {
+    "options": {
+      ".ist": "is a text keyword to indicate that first-order decay will occur.  Use of this keyword requires that DECAY and DECAY\\_SORBED (if sorption is active) are specified in the GRIDDATA block.",
+      ".mst": "is a text keyword to indicate that first-order decay will occur.  Use of this keyword requires that DECAY and DECAY\\_SORBED (if sorption is active) are specified in the GRIDDATA block."
+    }
+  },
+  "fixed_cell": {
+    "options": {
+      ".evt": "indicates that evapotranspiration will not be reassigned to a cell underlying the cell specified in the list if the specified cell is inactive.",
+      ".evta": "indicates that evapotranspiration will not be reassigned to a cell underlying the cell specified in the list if the specified cell is inactive.",
+      ".rch": "indicates that recharge will not be reassigned to a cell underlying the cell specified in the list if the specified cell is inactive.",
+      ".rcha": "indicates that recharge will not be reassigned to a cell underlying the cell specified in the list if the specified cell is inactive."
+    }
+  },
+  "fixed_conductance": {
+    "options": {
+      ".chfgwf": "keyword to indicate that the product of the bedleak and cfact input variables in the exchangedata block represents conductance.  This conductance is fixed and does not change as a function of head in the surface water and groundwater models.",
+      ".olfgwf": "keyword to indicate that the product of the bedleak and cfact input variables in the exchangedata block represents conductance.  This conductance is fixed and does not change as a function of head in the surface water and groundwater models."
+    }
+  },
+  "flow_correction": {
+    "options": {
+      ".maw": "keyword that activates flow corrections in cases where the head in a multi-aquifer well is below the bottom of the screen for a connection or the head in a convertible cell connected to a multi-aquifer well is below the cell bottom. When flow corrections are activated, unit head gradients are used to calculate the flow between a multi-aquifer well and a connected GWF cell. By default, flow corrections are not made."
+    }
+  },
+  "flow_imbalance_correction": {
+    "options": {
+      ".fmi": "correct for an imbalance in flows by assuming that any residual flow error comes in or leaves at the concentration of the cell.  When this option is activated, the GWT Model budget written to the listing file will contain two additional entries: FLOW-ERROR and FLOW-CORRECTION.  These two entries will be equal but opposite in sign.  The FLOW-CORRECTION term is a mass flow that is added to offset the error caused by an imprecise flow balance.  If these terms are not relatively small, the flow model should be rerun with stricter convergence tolerances."
+    }
+  },
+  "flow_package_auxiliary_name": {
+    "options": {
+      ".lke": "keyword to specify the name of an auxiliary variable in the corresponding flow package.  If specified, then the simulated temperatures from this advanced transport package will be copied into the auxiliary variable specified with this name.  Note that the flow package must have an auxiliary variable with this name or the program will terminate with an error.  If the flows for this advanced transport package are read from a file, then this option will have no effect.",
+      ".lkt": "keyword to specify the name of an auxiliary variable in the corresponding flow package.  If specified, then the simulated concentrations from this advanced transport package will be copied into the auxiliary variable specified with this name.  Note that the flow package must have an auxiliary variable with this name or the program will terminate with an error.  If the flows for this advanced transport package are read from a file, then this option will have no effect.",
+      ".mwe": "keyword to specify the name of an auxiliary variable in the corresponding flow package.  If specified, then the simulated temperatures from this advanced transport package will be copied into the auxiliary variable specified with this name.  Note that the flow package must have an auxiliary variable with this name or the program will terminate with an error.  If the flows for this advanced transport package are read from a file, then this option will have no effect.",
+      ".mwt": "keyword to specify the name of an auxiliary variable in the corresponding flow package.  If specified, then the simulated concentrations from this advanced transport package will be copied into the auxiliary variable specified with this name.  Note that the flow package must have an auxiliary variable with this name or the program will terminate with an error.  If the flows for this advanced transport package are read from a file, then this option will have no effect.",
+      ".sfe": "keyword to specify the name of an auxiliary variable provided in the corresponding flow package (i.e., FLOW\\_PACKAGE\\_NAME).  If specified, then the simulated temperatures from this advanced energy transport package will be copied into the auxiliary variable specified with this name.  Note that the flow package must have an auxiliary variable with this name or the program will terminate with an error.  If the flows for this advanced energy transport package are read from a file, then this option will have no effect.",
+      ".sft": "keyword to specify the name of an auxiliary variable in the corresponding flow package.  If specified, then the simulated concentrations from this advanced transport package will be copied into the auxiliary variable specified with this name.  Note that the flow package must have an auxiliary variable with this name or the program will terminate with an error.  If the flows for this advanced transport package are read from a file, then this option will have no effect.",
+      ".uze": "keyword to specify the name of an auxiliary variable in the corresponding flow package.  If specified, then the simulated temperatures from this advanced transport package will be copied into the auxiliary variable specified with this name.  Note that the flow package must have an auxiliary variable with this name or the program will terminate with an error.  If the flows for this advanced transport package are read from a file, then this option will have no effect.",
+      ".uzt": "keyword to specify the name of an auxiliary variable in the corresponding flow package.  If specified, then the simulated concentrations from this advanced transport package will be copied into the auxiliary variable specified with this name.  Note that the flow package must have an auxiliary variable with this name or the program will terminate with an error.  If the flows for this advanced transport package are read from a file, then this option will have no effect."
+    }
+  },
+  "flow_package_name": {
+    "options": {
+      ".lke": "keyword to specify the name of the corresponding flow package.  If not specified, then the corresponding flow package must have the same name as this advanced transport package (the name associated with this package in the GWE name file).",
+      ".lkt": "keyword to specify the name of the corresponding flow package.  If not specified, then the corresponding flow package must have the same name as this advanced transport package (the name associated with this package in the GWT name file).",
+      ".mwe": "keyword to specify the name of the corresponding flow package.  If not specified, then the corresponding flow package must have the same name as this advanced transport package (the name associated with this package in the GWE name file).",
+      ".mwt": "keyword to specify the name of the corresponding flow package.  If not specified, then the corresponding flow package must have the same name as this advanced transport package (the name associated with this package in the GWT name file).",
+      ".sfe": "keyword to specify the name of the corresponding flow package.  If not specified, then the corresponding flow package must have the same name as this advanced transport package (the name associated with this package in the GWE name file).",
+      ".sft": "keyword to specify the name of the corresponding flow package.  If not specified, then the corresponding flow package must have the same name as this advanced transport package (the name associated with this package in the GWT name file).",
+      ".uze": "keyword to specify the name of the corresponding flow package.  If not specified, then the corresponding flow package must have the same name as this advanced transport package (the name associated with this package in the GWE name file).",
+      ".uzt": "keyword to specify the name of the corresponding flow package.  If not specified, then the corresponding flow package must have the same name as this advanced transport package (the name associated with this package in the GWT name file)."
+    }
+  },
+  "flowing_well": {
     "period": {
-      ".oc": "keyword to indicate save for last step in period. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
-      ".prp": "keyword to indicate release at the start of the last time step in the period. This keyword may be used in conjunction with other RELEASESETTING options."
+      ".maw": "keyword to indicate the well is a flowing well.  The FLOWING\\_WELL option can be used to simulate flowing wells when the simulated well head exceeds the specified drainage elevation."
+    }
+  },
+  "flowing_wells": {
+    "options": {
+      ".maw": "keyword that activates the flowing wells option for the multi-aquifer well package."
+    }
+  },
+  "fraction": {
+    "period": {
+      ".prp": "release particles after the specified fraction of the time step has elapsed. If FRACTION is not set, particles are released at the start of the specified time step(s). FRACTION must be a single value when used with ALL, FIRST, or FREQUENCY. When used with STEPS, FRACTION may be a single value or an array of the same length as STEPS. If a single FRACTION value is provided with STEPS, the fraction applies to all steps. NOTE: The FRACTION option has been removed. For fine control over release timing, specify times explicitly using the RELEASETIMES block."
     }
   },
   "frequency": {
@@ -563,596 +915,102 @@
       ".prp": "release at the specified time step frequency. This keyword may be used in conjunction with other RELEASESETTING options."
     }
   },
-  "steps": {
+  "gnc6": {
+    "options": {
+      ".gwfgwf": "keyword to specify that record corresponds to a ghost-node correction file."
+    }
+  },
+  "gwfmodelname1": {
+    "options": {
+      ".gwegwe": "keyword to specify name of first corresponding GWF Model.  In the simulation name file, the GWE6-GWE6 entry contains names for GWE Models (exgmnamea and exgmnameb).  The GWE Model with the name exgmnamea must correspond to the GWF Model with the name gwfmodelname1.",
+      ".gwtgwt": "keyword to specify name of first corresponding GWF Model.  In the simulation name file, the GWT6-GWT6 entry contains names for GWT Models (exgmnamea and exgmnameb).  The GWT Model with the name exgmnamea must correspond to the GWF Model with the name gwfmodelname1."
+    }
+  },
+  "gwfmodelname2": {
+    "options": {
+      ".gwegwe": "keyword to specify name of second corresponding GWF Model.  In the simulation name file, the GWE6-GWE6 entry contains names for GWE Models (exgmnamea and exgmnameb).  The GWE Model with the name exgmnameb must correspond to the GWF Model with the name gwfmodelname2.",
+      ".gwtgwt": "keyword to specify name of second corresponding GWF Model.  In the simulation name file, the GWT6-GWT6 entry contains names for GWT Models (exgmnamea and exgmnameb).  The GWT Model with the name exgmnameb must correspond to the GWF Model with the name gwfmodelname2."
+    }
+  },
+  "head": {
+    "options": {
+      ".maw": "keyword to specify that record corresponds to head.",
+      ".oc": "keyword to specify that record corresponds to head."
+    }
+  },
+  "head_based": {
+    "options": {
+      ".csub": "keyword to indicate the head-based formulation will be used to simulate coarse-grained aquifer materials and no-delay and delay interbeds. Specifying HEAD\\_BASED also specifies the INITIAL\\_PRECONSOLIDATION\\_HEAD option."
+    }
+  },
+  "head_limit": {
     "period": {
-      ".oc": "save for each step specified in STEPS. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
-      ".prp": "release at the start of each step specified in STEPS. This option may be used in conjunction with other RELEASESETTING options."
+      ".maw": "is the limiting water level (head) in the well, which is the minimum of the well RATE or the well inflow rate from the aquifer. HEAD\\_LIMIT can be applied to extraction wells (RATE $<$ 0) or injection wells (RATE $>$ 0). HEAD\\_LIMIT can be deactivated by specifying the text string `OFF'. The HEAD\\_LIMIT option is based on the HEAD\\_LIMIT functionality available in the MNW2~\\citep{konikow2009} package for MODFLOW-2005. The HEAD\\_LIMIT option has been included to facilitate backward compatibility with previous versions of MODFLOW but use of the RATE\\_SCALING option instead of the HEAD\\_LIMIT option is recommended. By default, HEAD\\_LIMIT is `OFF'."
     }
   },
-  "qoutflow": {
-    "options": {
-      ".oc": "keyword to specify that record corresponds to qoutflow."
-    }
-  },
-  "stage": {
-    "options": {
-      ".oc": "keyword to specify that record corresponds to stage.",
-      ".lak": "keyword to specify that record corresponds to stage.",
-      ".sfr": "keyword to specify that record corresponds to stage."
-    },
-    "period": {
-      ".lak": "real or character value that defines the stage for the lake. The specified STAGE is only applied if the lake is a constant stage lake. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      ".sfr": "real or character value that defines the stage for the reach. The specified STAGE is only applied if the reach uses the simple routing option. If STAGE is not specified for reaches that use the simple routing option, the specified stage is set to the top of the reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
-    }
-  },
-  "xt3d_off": {
-    "options": {
-      ".cnd": "deactivate the xt3d method and use the faster and less accurate approximation.  This option may provide a fast and accurate solution under some circumstances, such as when flow aligns with the model grid, there is no mechanical dispersion, or when the longitudinal and transverse dispersivities are equal.  This option may also be used to assess the computational demand of the XT3D approach by noting the run time differences with and without this option on.",
-      ".dsp": "deactivate the xt3d method and use the faster and less accurate approximation.  This option may provide a fast and accurate solution under some circumstances, such as when flow aligns with the model grid, there is no mechanical dispersion, or when the longitudinal and transverse dispersivities are equal.  This option may also be used to assess the computational demand of the XT3D approach by noting the run time differences with and without this option on."
-    }
-  },
-  "xt3d_rhs": {
-    "options": {
-      ".cnd": "add xt3d terms to right-hand side, when possible.  This option uses less memory, but may require more iterations.",
-      ".dsp": "add xt3d terms to right-hand side, when possible.  This option uses less memory, but may require more iterations."
-    }
-  },
-  "export_array_ascii": {
-    "options": {
-      ".cnd": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
-      ".sto": "keyword that specifies input grid arrays, which already support the layered keyword, should be written to layered ascii output files.",
-      ".disv1d": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
-      ".ic": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
-      ".npf": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
-      ".mip": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
-      ".dis2d": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
-      ".disv": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
-      ".disv2d": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
-      ".dis": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
-      ".dsp": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
-      ".dfw": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
-      ".disu": "keyword that specifies input griddata arrays should be written to layered ascii output files."
-    }
-  },
-  "export_array_netcdf": {
-    "options": {
-      ".cnd": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
-      ".ic": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
-      ".npf": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
-      ".disv": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
-      ".dis": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
-      ".sto": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
-      ".evta": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
-      ".rcha": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
-      ".dsp": "keyword that specifies input griddata arrays should be written to the model output netcdf file."
-    }
-  },
-  "alh": {
+  "heat_capacity_solid": {
     "griddata": {
-      ".cnd": "longitudinal dispersivity in horizontal direction.  If flow is strictly horizontal, then this is the longitudinal dispersivity that will be used.  If flow is not strictly horizontal or strictly vertical, then the longitudinal dispersivity is a function of both ALH and ALV.  If mechanical dispersion is represented (by specifying any dispersivity values) then this array is required.",
-      ".dsp": "longitudinal dispersivity in horizontal direction.  If flow is strictly horizontal, then this is the longitudinal dispersivity that will be used.  If flow is not strictly horizontal or strictly vertical, then the longitudinal dispersivity is a function of both ALH and ALV.  If mechanical dispersion is represented (by specifying any dispersivity values) then this array is required."
+      ".est": "is the mass-based heat capacity of dry solids (aquifer material). For example, units of J/kg/C may be used (or equivalent)."
     }
   },
-  "alv": {
+  "heat_capacity_water": {
+    "options": {
+      ".est": "heat capacity of water used by calculations related to heat storage and conduction.  This value is set to 4,184 J/kg/C if no overriding value is specified.  A user-specified value should be provided for models that use units other than kilograms, joules, and degrees Celsius or it is necessary to use a value other than the default."
+    }
+  },
+  "hhformulation_rhs": {
+    "options": {
+      ".buy": "use the variable-density hydraulic head formulation and add off-diagonal terms to the right-hand.  This option will prevent the BUY Package from adding asymmetric terms to the flow matrix."
+    }
+  },
+  "hpc6": {
+    "options": {
+      ".nam": "keyword to specify that record corresponds to a hpc file."
+    }
+  },
+  "hwva": {
+    "connectiondata": {
+      ".disu": "is a symmetric array of size NJA.  For horizontal connections, entries in HWVA are the horizontal width perpendicular to flow.  For vertical connections, entries in HWVA are the vertical area for flow.  Thus, values in the HWVA array contain dimensions of both length and area.  Entries in the HWVA array have a one-to-one correspondence with the connections specified in the JA array.  Likewise, there is a one-to-one correspondence between entries in the HWVA array and entries in the IHC array, which specifies the connection type (horizontal or vertical).  Entries in the HWVA array must be symmetric; the program will terminate with an error if the value for HWVA for an n to m connection does not equal the value for HWVA for the corresponding n to m connection."
+    }
+  },
+  "iac": {
+    "connectiondata": {
+      ".disu": "is the number of connections (plus 1) for each cell.  The sum of all the entries in IAC must be equal to NJA."
+    }
+  },
+  "icelltype": {
     "griddata": {
-      ".cnd": "longitudinal dispersivity in vertical direction.  If flow is strictly vertical, then this is the longitudinal dispsersivity value that will be used.  If flow is not strictly horizontal or strictly vertical, then the longitudinal dispersivity is a function of both ALH and ALV.  If this value is not specified and mechanical dispersion is represented, then this array is set equal to ALH.",
-      ".dsp": "longitudinal dispersivity in vertical direction.  If flow is strictly vertical, then this is the longitudinal dispsersivity value that will be used.  If flow is not strictly horizontal or strictly vertical, then the longitudinal dispersivity is a function of both ALH and ALV.  If this value is not specified and mechanical dispersion is represented, then this array is set equal to ALH."
+      ".npf": "flag for each cell that specifies how saturated thickness is treated.  0 means saturated thickness is held constant;  $>$0 means saturated thickness varies with computed head when head is below the cell top; $<$0 means saturated thickness varies with computed head unless the THICKSTRT option is in effect.  When THICKSTRT is in effect, a negative value for ICELLTYPE indicates that the saturated thickness value used in conductance calculations in the NPF Package will be computed as STRT-BOT and held constant.  If the THICKSTRT option is not in effect, then negative values provided by the user for ICELLTYPE are automatically reassigned by the program to a value of one."
     }
   },
-  "ath1": {
+  "iconvert": {
     "griddata": {
-      ".cnd": "transverse dispersivity in horizontal direction.  This is the transverse dispersivity value for the second ellipsoid axis.  If flow is strictly horizontal and directed in the x direction (along a row for a regular grid), then this value controls spreading in the y direction.  If mechanical dispersion is represented (by specifying any dispersivity values) then this array is required.",
-      ".dsp": "transverse dispersivity in horizontal direction.  This is the transverse dispersivity value for the second ellipsoid axis.  If flow is strictly horizontal and directed in the x direction (along a row for a regular grid), then this value controls spreading in the y direction.  If mechanical dispersion is represented (by specifying any dispersivity values) then this array is required."
+      ".sto": "is a flag for each cell that specifies whether or not a cell is convertible for the storage calculation. 0 indicates confined storage is used. $>$0 indicates confined storage is used when head is above cell top and a mixed formulation of unconfined and confined storage is used when head is below cell top."
     }
   },
-  "ath2": {
+  "idcxs": {
     "griddata": {
-      ".cnd": "transverse dispersivity in horizontal direction.  This is the transverse dispersivity value for the third ellipsoid axis.  If flow is strictly horizontal and directed in the x direction (along a row for a regular grid), then this value controls spreading in the z direction.  If this value is not specified and mechanical dispersion is represented, then this array is set equal to ATH1.",
-      ".dsp": "transverse dispersivity in horizontal direction.  This is the transverse dispersivity value for the third ellipsoid axis.  If flow is strictly horizontal and directed in the x direction (along a row for a regular grid), then this value controls spreading in the z direction.  If this value is not specified and mechanical dispersion is represented, then this array is set equal to ATH1."
-    }
-  },
-  "atv": {
-    "griddata": {
-      ".cnd": "transverse dispersivity when flow is in vertical direction.  If flow is strictly vertical and directed in the z direction, then this value controls spreading in the x and y directions.  If this value is not specified and mechanical dispersion is represented, then this array is set equal to ATH2.",
-      ".dsp": "transverse dispersivity when flow is in vertical direction.  If flow is strictly vertical and directed in the z direction, then this value controls spreading in the x and y directions.  If this value is not specified and mechanical dispersion is represented, then this array is set equal to ATH2."
-    }
-  },
-  "ktw": {
-    "griddata": {
-      ".cnd": "thermal conductivity of the simulated fluid.   Note that the CND Package does not account for the tortuosity of the flow paths when solving for the conductive spread of heat.  If tortuosity plays an important role in the thermal conductivity calculation, its effect should be reflected in the value specified for KTW."
-    }
-  },
-  "kts": {
-    "griddata": {
-      ".cnd": "thermal conductivity of the solid aquifer material"
-    }
-  },
-  "steady-state": {
-    "period": {
-      ".sto": "keyword to indicate that stress period IPER is steady-state. Steady-state conditions will apply until the TRANSIENT keyword is specified in a subsequent BEGIN PERIOD block."
-    }
-  },
-  "transient": {
-    "period": {
-      ".sto": "keyword to indicate that stress period IPER is transient. Transient conditions will apply until the STEADY-STATE keyword is specified in a subsequent BEGIN PERIOD block."
-    }
-  },
-  "readasarrays": {
-    "options": {
-      ".spca": "indicates that array-based input will be used for the SPC Package.  This keyword must be specified to use array-based input.  When READASARRAYS is specified, values must be provided for every cell within a model layer, even those cells that have an IDOMAIN value less than one.  Values assigned to cells with IDOMAIN values less than one are not used and have no effect on simulation results.",
-      ".evta": "indicates that array-based input will be used for the Evapotranspiration Package.  This keyword must be specified to use array-based input.  When READASARRAYS is specified, values must be provided for every cell within a model layer, even those cells that have an IDOMAIN value less than one.  Values assigned to cells with IDOMAIN values less than one are not used and have no effect on simulation results.",
-      ".rcha": "indicates that array-based input will be used for the Recharge Package.  This keyword must be specified to use array-based input.  When READASARRAYS is specified, values must be provided for every cell within a model layer, even those cells that have an IDOMAIN value less than one.  Values assigned to cells with IDOMAIN values less than one are not used and have no effect on simulation results. "
-    }
-  },
-  "tas6": {
-    "options": {
-      ".spca": "keyword to specify that record corresponds to a time-array-series file.",
-      ".evta": "keyword to specify that record corresponds to a time-array-series file.",
-      ".rcha": "keyword to specify that record corresponds to a time-array-series file."
-    }
-  },
-  "concentration": {
-    "period": {
-      ".spca": "is the concentration of the associated Recharge or Evapotranspiration stress package.  The concentration array may be defined by a time-array series (see the \"Using Time-Array Series in a Package\" section).",
-      ".sft": "real or character value that defines the concentration for the reach. The specified CONCENTRATION is only applied if the reach is a constant concentration reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      ".lkt": "real or character value that defines the concentration for the lake. The specified CONCENTRATION is only applied if the lake is a constant concentration lake. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      ".mwt": "real or character value that defines the concentration for the well. The specified CONCENTRATION is only applied if the well is a constant concentration well. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      ".spc": "is the boundary concentration. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, the CONCENTRATION for each boundary feature is zero.",
-      ".uzt": "real or character value that defines the concentration for the unsaturated zone flow cell. The specified CONCENTRATION is only applied if the unsaturated zone flow cell is a constant concentration cell. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
-    },
-    "options": {
-      ".sft": "keyword to specify that record corresponds to concentration.",
-      ".lkt": "keyword to specify that record corresponds to concentration.",
-      ".mwt": "keyword to specify that record corresponds to concentration.",
-      ".oc": "keyword to specify that record corresponds to concentration.",
-      ".uzt": "keyword to specify that record corresponds to concentration."
-    }
-  },
-  "temperature": {
-    "period": {
-      ".spca": "is the temperature of the associated Recharge or Evapotranspiration stress package.  The temperature array may be defined by a time-array series (see the \"Using Time-Array Series in a Package\" section).",
-      ".uze": "real or character value that defines the temperature for the unsaturated zone flow cell. The specified TEMPERATURE is only applied if the unsaturated zone flow cell is a constant temperature cell. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      ".lke": "real or character value that defines the temperature for the lake. The specified TEMPERATURE is only applied if the lake is a constant temperature lake. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      ".sfe": "real or character value that defines the temperature for the reach. The specified TEMPERATURE is only applied if the reach is a constant temperature reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      ".spc": "is the user-supplied boundary temperature. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, the TEMPERATURE for each boundary feature is zero.",
-      ".mwe": "real or character value that defines the temperature for the well. The specified TEMPERATURE is only applied if the well is a constant temperature well. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
-    },
-    "options": {
-      ".uze": "keyword to specify that record corresponds to temperature.",
-      ".lke": "keyword to specify that record corresponds to temperature.",
-      ".sfe": "keyword to specify that record corresponds to temperature.",
-      ".oc": "keyword to specify that record corresponds to temperature.",
-      ".mwe": "keyword to specify that record corresponds to temperature."
-    }
-  },
-  "auxiliary": {
-    "options": {
-      ".ctp": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".cdb": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".sft": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".evp": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".flw": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".chd": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".uze": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".pcp": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".drn": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".gwegwe": "an array of auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided. Most auxiliary variables will not be used by the GWE-GWE Exchange, but they will be available for use by other parts of the program.  If an auxiliary variable with the name ``ANGLDEGX'' is found, then this information will be used as the angle (provided in degrees) between the connection face normal and the x axis, where a value of zero indicates that a normal vector points directly along the positive x axis.  The connection face normal is a normal vector on the cell face shared between the cell in model 1 and the cell in model 2 pointing away from the model 1 cell.  Additional information on ``ANGLDEGX'' is provided in the description of the DISU Package.  If an auxiliary variable with the name ``CDIST'' is found, then this information will be used as the straight-line connection distance, including the vertical component, between the two cell centers.  Both ANGLDEGX and CDIST are required if specific discharge is calculated for either of the groundwater models.",
-      ".wel": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".lak": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".esl": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".lkt": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".gwtgwt": "an array of auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided. Most auxiliary variables will not be used by the GWT-GWT Exchange, but they will be available for use by other parts of the program.  If an auxiliary variable with the name ``ANGLDEGX'' is found, then this information will be used as the angle (provided in degrees) between the connection face normal and the x axis, where a value of zero indicates that a normal vector points directly along the positive x axis.  The connection face normal is a normal vector on the cell face shared between the cell in model 1 and the cell in model 2 pointing away from the model 1 cell.  Additional information on ``ANGLDEGX'' is provided in the description of the DISU Package.  ANGLDEGX must be specified if dispersion is simulated in the connected GWT models.",
-      ".lke": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".evta": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".src": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".ghb": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".rcha": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".zdg": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".gwfgwf": "an array of auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided. Most auxiliary variables will not be used by the GWF-GWF Exchange, but they will be available for use by other parts of the program.  If an auxiliary variable with the name ``ANGLDEGX'' is found, then this information will be used as the angle (provided in degrees) between the connection face normal and the x axis, where a value of zero indicates that a normal vector points directly along the positive x axis.  The connection face normal is a normal vector on the cell face shared between the cell in model 1 and the cell in model 2 pointing away from the model 1 cell.  Additional information on ``ANGLDEGX'' and when it is required is provided in the description of the DISU Package.  If an auxiliary variable with the name ``CDIST'' is found, then this information will be used in the calculation of specific discharge within model cells connected by the exchange.  For a horizontal connection, CDIST should be specified as the horizontal distance between the cell centers, and should not include the vertical component.  For vertical connections, CDIST should be specified as the difference in elevation between the two cell centers.  Both ANGLDEGX and CDIST are required if specific discharge is calculated for either of the groundwater models.",
-      ".sfe": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".mwt": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".sfr": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".riv": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".uzf": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".cnc": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".maw": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".rch": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".evt": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".uzt": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".mwe": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block."
-    },
-    "period": {
-      ".sft": "keyword for specifying auxiliary variable.",
-      ".uze": "keyword for specifying auxiliary variable.",
-      ".lak": "keyword for specifying auxiliary variable.",
-      ".lkt": "keyword for specifying auxiliary variable.",
-      ".lke": "keyword for specifying auxiliary variable.",
-      ".sfe": "keyword for specifying auxiliary variable.",
-      ".mwt": "keyword for specifying auxiliary variable.",
-      ".sfr": "keyword for specifying auxiliary variable.",
-      ".maw": "keyword for specifying auxiliary variable.",
-      ".uzt": "keyword for specifying auxiliary variable.",
-      ".mwe": "keyword for specifying auxiliary variable."
-    }
-  },
-  "auxmultname": {
-    "options": {
-      ".ctp": "name of auxiliary variable to be used as multiplier of temperature value.",
-      ".evp": "name of auxiliary variable to be used as multiplier of evaporation.",
-      ".flw": "name of auxiliary variable to be used as multiplier of flow rate.",
-      ".chd": "name of auxiliary variable to be used as multiplier of CHD head value.",
-      ".pcp": "name of auxiliary variable to be used as multiplier of precipitation.",
-      ".drn": "name of auxiliary variable to be used as multiplier of drain conductance.",
-      ".wel": "name of auxiliary variable to be used as multiplier of well flow rate.",
-      ".esl": "name of auxiliary variable to be used as multiplier of energy loading rate.",
-      ".evta": "name of auxiliary variable to be used as multiplier of evapotranspiration rate.",
-      ".src": "name of auxiliary variable to be used as multiplier of mass loading rate.",
-      ".ghb": "name of auxiliary variable to be used as multiplier of general-head boundary conductance.",
-      ".rcha": "name of auxiliary variable to be used as multiplier of recharge.",
-      ".riv": "name of auxiliary variable to be used as multiplier of riverbed conductance.",
-      ".uzf": "name of auxiliary variable to be used as multiplier of GWF cell area used by UZF cell.",
-      ".cnc": "name of auxiliary variable to be used as multiplier of concentration value.",
-      ".rch": "name of auxiliary variable to be used as multiplier of recharge.",
-      ".evt": "name of auxiliary variable to be used as multiplier of evapotranspiration rate."
-    }
-  },
-  "print_flows": {
-    "options": {
-      ".ctp": "keyword to indicate that the list of constant temperature flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".cdb": "keyword to indicate that the list of critical depth boundary flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".sft": "keyword to indicate that the list of reach flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".mve": "keyword to indicate that the list of lake flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".evp": "keyword to indicate that the list of evaporation flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".npf": "keyword to indicate that calculated flows between cells will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control. If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.  This option can produce extremely large list files because all cell-by-cell flows are printed.  It should only be used with the NPF Package for models that have a small number of cells.",
-      ".flw": "keyword to indicate that the list of inflow flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".chd": "keyword to indicate that the list of constant-head flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".uze": "keyword to indicate that the list of unsaturated zone flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".nam": "keyword to indicate that the list of all model package flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".pcp": "keyword to indicate that the list of precipitation flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".api": "keyword to indicate that the list of api boundary flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".drn": "keyword to indicate that the list of drain flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".gwegwe": "keyword to indicate that the list of exchange flow rates will be printed to the listing file for every stress period in which ``SAVE BUDGET'' is specified in Output Control.",
-      ".olfgwf": "keyword to indicate that the list of exchange flow rates will be printed to the listing file for every stress period in which ``SAVE BUDGET'' is specified in Output Control.",
-      ".wel": "keyword to indicate that the list of well flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".lak": "keyword to indicate that the list of lake flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".esl": "keyword to indicate that the list of energy source loading flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".lkt": "keyword to indicate that the list of lake flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".gwtgwt": "keyword to indicate that the list of exchange flow rates will be printed to the listing file for every stress period in which ``SAVE BUDGET'' is specified in Output Control.",
-      ".lke": "keyword to indicate that the list of lake flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".evta": "keyword to indicate that the list of evapotranspiration flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".src": "keyword to indicate that the list of mass source flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".ghb": "keyword to indicate that the list of general-head boundary flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".rcha": "keyword to indicate that the list of recharge flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".zdg": "keyword to indicate that the list of zero-depth-gradient boundary flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".gwfgwf": "keyword to indicate that the list of exchange flow rates will be printed to the listing file for every stress period in which ``SAVE BUDGET'' is specified in Output Control.",
-      ".sfe": "keyword to indicate that the list of reach flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".mvt": "keyword to indicate that the list of lake flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".mvr": "keyword to indicate that the list of MVR flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".dfw": "keyword to indicate that calculated flows between cells will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control. If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.  This option can produce extremely large list files because all cell-by-cell flows are printed.  It should only be used with the DFW Package for models that have a small number of cells.",
-      ".mwt": "keyword to indicate that the list of well flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".gnc": "keyword to indicate that the list of GNC flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".chfgwf": "keyword to indicate that the list of exchange flow rates will be printed to the listing file for every stress period in which ``SAVE BUDGET'' is specified in Output Control.",
-      ".sfr": "keyword to indicate that the list of stream reach flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".riv": "keyword to indicate that the list of river flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".uzf": "keyword to indicate that the list of UZF flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".cnc": "keyword to indicate that the list of constant concentration flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".maw": "keyword to indicate that the list of multi-aquifer well flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".ssm": "keyword to indicate that the list of SSM flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".rch": "keyword to indicate that the list of recharge flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".evt": "keyword to indicate that the list of evapotranspiration flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".uzt": "keyword to indicate that the list of unsaturated zone flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".mwe": "keyword to indicate that the list of well flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period."
-    }
-  },
-  "maxbound": {
-    "dimensions": {
-      ".ctp": "integer value specifying the maximum number of constant temperature cells that will be specified for use during any stress period.",
-      ".cdb": "integer value specifying the maximum number of critical depth boundary cells that will be specified for use during any stress period.",
-      ".evp": "integer value specifying the maximum number of evaporation cells cells that will be specified for use during any stress period.",
-      ".flw": "integer value specifying the maximum number of inflow cells that will be specified for use during any stress period.",
-      ".chd": "integer value specifying the maximum number of constant-head cells that will be specified for use during any stress period.",
-      ".pcp": "integer value specifying the maximum number of precipitation cells cells that will be specified for use during any stress period.",
-      ".api": "integer value specifying the maximum number of api boundary cells that will be specified for use during any stress period.",
-      ".drn": "integer value specifying the maximum number of drains cells that will be specified for use during any stress period.",
-      ".wel": "integer value specifying the maximum number of wells cells that will be specified for use during any stress period.",
-      ".esl": "integer value specifying the maximum number of source cells that will be specified for use during any stress period.",
-      ".src": "integer value specifying the maximum number of sources cells that will be specified for use during any stress period.",
-      ".ghb": "integer value specifying the maximum number of general-head boundary cells that will be specified for use during any stress period.",
-      ".zdg": "integer value specifying the maximum number of zero-depth-gradient boundary cells that will be specified for use during any stress period.",
-      ".spc": "integer value specifying the maximum number of spc cells that will be specified for use during any stress period.",
-      ".riv": "integer value specifying the maximum number of rivers cells that will be specified for use during any stress period.",
-      ".cnc": "integer value specifying the maximum number of constant concentrations cells that will be specified for use during any stress period.",
-      ".rch": "integer value specifying the maximum number of recharge cells cells that will be specified for use during any stress period.",
-      ".evt": "integer value specifying the maximum number of evapotranspiration cells cells that will be specified for use during any stress period."
-    }
-  },
-  "print_table": {
-    "options": {
-      ".hpc": "keyword to indicate that the partition table will be printed to the listing file."
-    }
-  },
-  "dev_log_mpi": {
-    "options": {
-      ".hpc": "keyword to enable (extremely verbose) logging of mpi traffic to file."
-    }
-  },
-  "partitions": {
-    "partitions": {
-      ".hpc": "is the list of zero-based partition numbers."
-    }
-  },
-  "maxhfb": {
-    "dimensions": {
-      ".hfb": "integer value specifying the maximum number of horizontal flow barriers that will be entered in this input file.  The value of MAXHFB is used to allocate memory for the horizontal flow barriers."
-    }
-  },
-  "length_units": {
-    "options": {
-      ".disv1d": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.",
-      ".dis2d": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.",
-      ".disv": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.",
-      ".disv2d": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.",
-      ".dis": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.",
-      ".disu": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''."
-    }
-  },
-  "nogrb": {
-    "options": {
-      ".disv1d": "keyword to deactivate writing of the binary grid file.",
-      ".dis2d": "keyword to deactivate writing of the binary grid file.",
-      ".disv": "keyword to deactivate writing of the binary grid file.",
-      ".disv2d": "keyword to deactivate writing of the binary grid file.",
-      ".dis": "keyword to deactivate writing of the binary grid file.",
-      ".disu": "keyword to deactivate writing of the binary grid file."
-    }
-  },
-  "xorigin": {
-    "options": {
-      ".disv1d": "x-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      ".dis2d": "x-position of the lower-left corner of the model grid.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      ".disv": "x-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      ".disv2d": "x-position of the lower-left corner of the model grid.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      ".dis": "x-position of the lower-left corner of the model grid.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      ".disu": "x-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space."
-    }
-  },
-  "yorigin": {
-    "options": {
-      ".disv1d": "y-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      ".dis2d": "y-position of the lower-left corner of the model grid.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      ".disv": "y-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      ".disv2d": "y-position of the lower-left corner of the model grid.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      ".dis": "y-position of the lower-left corner of the model grid.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      ".disu": "y-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space."
-    }
-  },
-  "angrot": {
-    "options": {
-      ".disv1d": "counter-clockwise rotation angle (in degrees) of the model grid coordinate system relative to a real-world coordinate system.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      ".dis2d": "counter-clockwise rotation angle (in degrees) of the lower-left corner of the model grid.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      ".disv": "counter-clockwise rotation angle (in degrees) of the model grid coordinate system relative to a real-world coordinate system.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      ".disv2d": "counter-clockwise rotation angle (in degrees) of the lower-left corner of the model grid.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      ".dis": "counter-clockwise rotation angle (in degrees) of the lower-left corner of the model grid.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      ".disu": "counter-clockwise rotation angle (in degrees) of the model grid coordinate system relative to a real-world coordinate system.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space."
-    }
-  },
-  "nodes": {
-    "dimensions": {
-      ".disv1d": "is the number of linear cells.",
-      ".disv2d": "is the number of cells per layer.  This is a constant value for the grid and it applies to all layers.",
-      ".disu": "is the number of cells in the model grid."
-    }
-  },
-  "nvert": {
-    "dimensions": {
-      ".disv1d": "is the total number of (x, y, z) vertex pairs used to characterize the model grid.",
-      ".disv": "is the total number of (x, y) vertex pairs used to characterize the horizontal configuration of the model grid.",
-      ".disv2d": "is the total number of (x, y) vertex pairs used to characterize the horizontal configuration of the model grid.",
-      ".disu": "is the total number of (x, y) vertex pairs used to define the plan-view shape of each cell in the model grid.  If NVERT is not specified or is specified as zero, then the VERTICES and CELL2D blocks below are not read.  NVERT and the accompanying VERTICES and CELL2D blocks should be specified for most simulations.  If the XT3D or SAVE\\_SPECIFIC\\_DISCHARGE options are specified in the NPF Package, then this information is required."
-    }
-  },
-  "bottom": {
-    "griddata": {
-      ".disv1d": "bottom elevation for the one-dimensional cell.",
-      ".dis2d": "is the bottom elevation for each cell.",
-      ".disv2d": "is the bottom elevation for each cell."
+      ".dfw": "integer value indication the cross section identifier in the Cross Section Package that applies to the reach.  If not provided then reach will be treated as hydraulically wide."
     }
   },
   "idomain": {
     "griddata": {
-      ".disv1d": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1, the cell exists in the simulation.",
-      ".dis2d": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1, the cell exists in the simulation.  If the IDOMAIN value for a cell is -1, the cell does not exist in the simulation.  Furthermore, the first existing cell above will be connected to the first existing cell below.  This type of cell is referred to as a ``vertical pass through'' cell.",
-      ".disv": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1 or greater, the cell exists in the simulation.  If the IDOMAIN value for a cell is -1, the cell does not exist in the simulation.  Furthermore, the first existing cell above will be connected to the first existing cell below.  This type of cell is referred to as a ``vertical pass through'' cell.",
-      ".disv2d": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1 or greater, the cell exists in the simulation.  If the IDOMAIN value for a cell is -1, the cell does not exist in the simulation.  Furthermore, the first existing cell above will be connected to the first existing cell below.  This type of cell is referred to as a ``vertical pass through'' cell.",
       ".dis": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1, the cell exists in the simulation.  If the IDOMAIN value for a cell is -1, the cell does not exist in the simulation.  Furthermore, the first existing cell above will be connected to the first existing cell below.  This type of cell is referred to as a ``vertical pass through'' cell.",
-      ".disu": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1 or greater, the cell exists in the simulation.  IDOMAIN values of -1 cannot be specified for the DISU Package."
+      ".dis2d": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1, the cell exists in the simulation.  If the IDOMAIN value for a cell is -1, the cell does not exist in the simulation.  Furthermore, the first existing cell above will be connected to the first existing cell below.  This type of cell is referred to as a ``vertical pass through'' cell.",
+      ".disu": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1 or greater, the cell exists in the simulation.  IDOMAIN values of -1 cannot be specified for the DISU Package.",
+      ".disv": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1 or greater, the cell exists in the simulation.  If the IDOMAIN value for a cell is -1, the cell does not exist in the simulation.  Furthermore, the first existing cell above will be connected to the first existing cell below.  This type of cell is referred to as a ``vertical pass through'' cell.",
+      ".disv1d": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1, the cell exists in the simulation.",
+      ".disv2d": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1 or greater, the cell exists in the simulation.  If the IDOMAIN value for a cell is -1, the cell does not exist in the simulation.  Furthermore, the first existing cell above will be connected to the first existing cell below.  This type of cell is referred to as a ``vertical pass through'' cell."
     }
   },
-  "strt": {
-    "griddata": {
-      ".ic": "is the initial (starting) concentration---that is, concentration at the beginning of the GWT Model simulation.  STRT must be specified for all GWT Model simulations. One value is read for every model cell."
-    }
-  },
-  "flow_package_name": {
-    "options": {
-      ".sft": "keyword to specify the name of the corresponding flow package.  If not specified, then the corresponding flow package must have the same name as this advanced transport package (the name associated with this package in the GWT name file).",
-      ".uze": "keyword to specify the name of the corresponding flow package.  If not specified, then the corresponding flow package must have the same name as this advanced transport package (the name associated with this package in the GWE name file).",
-      ".lkt": "keyword to specify the name of the corresponding flow package.  If not specified, then the corresponding flow package must have the same name as this advanced transport package (the name associated with this package in the GWT name file).",
-      ".lke": "keyword to specify the name of the corresponding flow package.  If not specified, then the corresponding flow package must have the same name as this advanced transport package (the name associated with this package in the GWE name file).",
-      ".sfe": "keyword to specify the name of the corresponding flow package.  If not specified, then the corresponding flow package must have the same name as this advanced transport package (the name associated with this package in the GWE name file).",
-      ".mwt": "keyword to specify the name of the corresponding flow package.  If not specified, then the corresponding flow package must have the same name as this advanced transport package (the name associated with this package in the GWT name file).",
-      ".uzt": "keyword to specify the name of the corresponding flow package.  If not specified, then the corresponding flow package must have the same name as this advanced transport package (the name associated with this package in the GWT name file).",
-      ".mwe": "keyword to specify the name of the corresponding flow package.  If not specified, then the corresponding flow package must have the same name as this advanced transport package (the name associated with this package in the GWE name file)."
-    }
-  },
-  "flow_package_auxiliary_name": {
-    "options": {
-      ".sft": "keyword to specify the name of an auxiliary variable in the corresponding flow package.  If specified, then the simulated concentrations from this advanced transport package will be copied into the auxiliary variable specified with this name.  Note that the flow package must have an auxiliary variable with this name or the program will terminate with an error.  If the flows for this advanced transport package are read from a file, then this option will have no effect.",
-      ".uze": "keyword to specify the name of an auxiliary variable in the corresponding flow package.  If specified, then the simulated temperatures from this advanced transport package will be copied into the auxiliary variable specified with this name.  Note that the flow package must have an auxiliary variable with this name or the program will terminate with an error.  If the flows for this advanced transport package are read from a file, then this option will have no effect.",
-      ".lkt": "keyword to specify the name of an auxiliary variable in the corresponding flow package.  If specified, then the simulated concentrations from this advanced transport package will be copied into the auxiliary variable specified with this name.  Note that the flow package must have an auxiliary variable with this name or the program will terminate with an error.  If the flows for this advanced transport package are read from a file, then this option will have no effect.",
-      ".lke": "keyword to specify the name of an auxiliary variable in the corresponding flow package.  If specified, then the simulated temperatures from this advanced transport package will be copied into the auxiliary variable specified with this name.  Note that the flow package must have an auxiliary variable with this name or the program will terminate with an error.  If the flows for this advanced transport package are read from a file, then this option will have no effect.",
-      ".sfe": "keyword to specify the name of an auxiliary variable provided in the corresponding flow package (i.e., FLOW\\_PACKAGE\\_NAME).  If specified, then the simulated temperatures from this advanced energy transport package will be copied into the auxiliary variable specified with this name.  Note that the flow package must have an auxiliary variable with this name or the program will terminate with an error.  If the flows for this advanced energy transport package are read from a file, then this option will have no effect.",
-      ".mwt": "keyword to specify the name of an auxiliary variable in the corresponding flow package.  If specified, then the simulated concentrations from this advanced transport package will be copied into the auxiliary variable specified with this name.  Note that the flow package must have an auxiliary variable with this name or the program will terminate with an error.  If the flows for this advanced transport package are read from a file, then this option will have no effect.",
-      ".uzt": "keyword to specify the name of an auxiliary variable in the corresponding flow package.  If specified, then the simulated concentrations from this advanced transport package will be copied into the auxiliary variable specified with this name.  Note that the flow package must have an auxiliary variable with this name or the program will terminate with an error.  If the flows for this advanced transport package are read from a file, then this option will have no effect.",
-      ".mwe": "keyword to specify the name of an auxiliary variable in the corresponding flow package.  If specified, then the simulated temperatures from this advanced transport package will be copied into the auxiliary variable specified with this name.  Note that the flow package must have an auxiliary variable with this name or the program will terminate with an error.  If the flows for this advanced transport package are read from a file, then this option will have no effect."
-    }
-  },
-  "print_concentration": {
-    "options": {
-      ".sft": "keyword to indicate that the list of reach concentration will be printed to the listing file for every stress period in which ``CONCENTRATION PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_CONCENTRATION is specified, then concentration are printed for the last time step of each stress period.",
-      ".lkt": "keyword to indicate that the list of lake concentration will be printed to the listing file for every stress period in which ``CONCENTRATION PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_CONCENTRATION is specified, then concentration are printed for the last time step of each stress period.",
-      ".mwt": "keyword to indicate that the list of well concentration will be printed to the listing file for every stress period in which ``CONCENTRATION PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_CONCENTRATION is specified, then concentration are printed for the last time step of each stress period.",
-      ".uzt": "keyword to indicate that the list of UZF cell concentration will be printed to the listing file for every stress period in which ``CONCENTRATION PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_CONCENTRATION is specified, then concentration are printed for the last time step of each stress period."
-    }
-  },
-  "status": {
+  "ievt": {
     "period": {
-      ".sft": "keyword option to define reach status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that concentration will be calculated for the reach.  If a reach is inactive, then there will be no solute mass fluxes into or out of the reach and the inactive value will be written for the reach concentration.  If a reach is constant, then the concentration for the reach will be fixed at the user specified value.",
-      ".uze": "keyword option to define UZF cell status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that temperature will be calculated for the UZF cell.  If a UZF cell is inactive, then there will be no energy fluxes into or out of the UZF cell and the inactive value will be written for the UZF cell temperature.  If a UZF cell is constant, then the temperature for the UZF cell will be fixed at the user specified value.",
-      ".lak": "keyword option to define lake status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE.",
-      ".lkt": "keyword option to define lake status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that concentration will be calculated for the lake.  If a lake is inactive, then there will be no solute mass fluxes into or out of the lake and the inactive value will be written for the lake concentration.  If a lake is constant, then the concentration for the lake will be fixed at the user specified value.",
-      ".lke": "keyword option to define lake status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that temperature will be calculated for the lake.  If a lake is inactive, then there will be no energy fluxes into or out of the lake and the inactive value will be written for the lake temperature.  If a lake is constant, then the temperature for the lake will be fixed at the user specified value.",
-      ".sfe": "keyword option to define reach status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that temperature will be calculated for the reach.  If a reach is inactive, then there will be no energy fluxes into or out of the reach and the inactive value will be written for the reach temperature.  If a reach is constant, then the temperature for the reach will be fixed at the user specified value.",
-      ".mwt": "keyword option to define well status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that concentration will be calculated for the well.  If a well is inactive, then there will be no solute mass fluxes into or out of the well and the inactive value will be written for the well concentration.  If a well is constant, then the concentration for the well will be fixed at the user specified value.",
-      ".sfr": "keyword option to define stream reach status.  STATUS can be ACTIVE, INACTIVE, or SIMPLE. The SIMPLE STATUS option simulates streamflow using a user-specified stage for a reach or a stage set to the top of the reach (depth = 0). In cases where the simulated leakage calculated using the specified stage exceeds the sum of inflows to the reach, the stage is set to the top of the reach and leakage is set equal to the sum of inflows. Upstream fractions should be changed using the UPSTREAM\\_FRACTION SFRSETTING if the status for one or more reaches is changed to ACTIVE or INACTIVE. For example, if one of two downstream connections for a reach is inactivated, the upstream fraction for the active and inactive downstream reach should be changed to 1.0 and 0.0, respectively, to ensure that the active reach receives all of the downstream outflow from the upstream reach. By default, STATUS is ACTIVE.",
-      ".maw": "keyword option to define well status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE.",
-      ".uzt": "keyword option to define UZF cell status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that concentration will be calculated for the UZF cell.  If a UZF cell is inactive, then there will be no solute mass fluxes into or out of the UZF cell and the inactive value will be written for the UZF cell concentration.  If a UZF cell is constant, then the concentration for the UZF cell will be fixed at the user specified value.",
-      ".mwe": "keyword option to define well status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that temperature will be calculated for the well.  If a well is inactive, then there will be no solute mass fluxes into or out of the well and the inactive value will be written for the well temperature.  If a well is constant, then the temperature for the well will be fixed at the user specified value."
+      ".evta": "IEVT is the layer number that defines the layer in each vertical column where evapotranspiration is applied. If IEVT is omitted, evapotranspiration by default is applied to cells in layer 1.  If IEVT is specified, it must be specified as the first variable in the PERIOD block or MODFLOW will terminate with an error."
     }
   },
-  "rainfall": {
-    "period": {
-      ".sft": "real or character value that defines the rainfall solute concentration $(ML^{-3})$ for the reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      ".lak": "real or character value that defines the rainfall rate $(LT^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      ".lkt": "real or character value that defines the rainfall solute concentration $(ML^{-3})$ for the lake. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      ".lke": "real or character value that defines the rainfall temperature for the lake. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      ".sfe": "real or character value that defines the rainfall temperature $(e.g.,\\:^{\\circ}C\\:or\\:^{\\circ}F)$ for the reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      ".sfr": "real or character value that defines the  volumetric rate per unit area of water added by precipitation directly on the streamflow routing reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, rainfall  rates are zero for each reach."
-    }
-  },
-  "evaporation": {
-    "period": {
-      ".sft": "real or character value that defines the concentration of evaporated water $(ML^{-3})$ for the reach. If this concentration value is larger than the simulated concentration in the reach, then the evaporated water will be removed at the same concentration as the reach.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      ".lak": "real or character value that defines the maximum evaporation rate $(LT^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      ".lkt": "real or character value that defines the concentration of evaporated water $(ML^{-3})$ for the lake. If this concentration value is larger than the simulated concentration in the lake, then the evaporated water will be removed at the same concentration as the lake.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      ".lke": "use of the EVAPORATION keyword is allowed in the LKE package; however, the specified value is not currently used in LKE calculations.  Instead, the latent heat of evaporation is multiplied by the simulated evaporation rate for determining the thermal energy lost from a stream reach.",
-      ".sfe": "use of the EVAPORATION keyword is allowed in the SFE package; however, the specified value is not currently used in SFE calculations.  Instead, the latent heat of evaporation is multiplied by the simulated evaporation rate for determining the thermal energy lost from a stream reach.",
-      ".sfr": "real or character value that defines the volumetric rate per unit area of water subtracted by evaporation from the streamflow routing reach. A positive evaporation rate should be provided. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. If the volumetric evaporation rate for a reach exceeds the sources of water to the reach (upstream and specified inflows, rainfall, and runoff but excluding groundwater leakage into the reach) the volumetric evaporation rate is limited to the sources of water to the reach. By default, evaporation rates are zero for each reach."
-    }
-  },
-  "runoff": {
-    "period": {
-      ".sft": "real or character value that defines the concentration of runoff $(ML^{-3})$ for the reach. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      ".lak": "real or character value that defines the runoff rate $(L^3 T^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      ".lkt": "real or character value that defines the concentration of runoff $(ML^{-3})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      ".sfe": "real or character value that defines the temperature of runoff $(e.g.,\\:^{\\circ}C\\:or\\:^{\\circ}F)$ for the reach.  Users are free to use whatever temperature scale they want, which might include negative temperatures.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      ".sfr": "real or character value that defines the volumetric rate of diffuse overland runoff that enters the streamflow routing reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. If the volumetric runoff rate for a reach is negative and exceeds inflows to the reach (upstream and specified inflows, and rainfall but excluding groundwater leakage into the reach) the volumetric runoff rate is limited to inflows to the reach and the volumetric evaporation rate for the reach is set to zero. By default, runoff rates are zero for each reach."
-    }
-  },
-  "inflow": {
-    "period": {
-      ".sft": "real or character value that defines the concentration of inflow $(ML^{-3})$ for the reach. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      ".lak": "real or character value that defines the volumetric inflow rate $(L^3 T^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, inflow rates are zero for each lake.",
-      ".sfe": "real or character value that defines the temperature of inflow $(e.g.,\\:^{\\circ}C\\:or\\:^{\\circ}F)$ for the reach. Users are free to use whatever temperature scale they want, which might include negative temperatures.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      ".sfr": "real or character value that defines the volumetric inflow rate for the streamflow routing reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, inflow rates are zero for each reach."
-    }
-  },
-  "viscref": {
-    "options": {
-      ".vsc": "fluid reference viscosity used in the equation of state.  This value is set to 1.0 if not specified as an option."
-    }
-  },
-  "temperature_species_name": {
-    "options": {
-      ".vsc": "string used to identify the auxspeciesname in PACKAGEDATA that corresponds to the temperature species.  There can be only one occurrence of this temperature species name in the PACKAGEDATA block or the program will terminate with an error.  This value has no effect if viscosity does not depend on temperature."
-    }
-  },
-  "thermal_formulation": {
-    "options": {
-      ".vsc": "may be used for specifying which viscosity formulation to use for the temperature species. Can be either LINEAR or NONLINEAR. The LINEAR viscosity formulation is the default."
-    }
-  },
-  "thermal_a2": {
-    "options": {
-      ".vsc": "is an empirical parameter specified by the user for calculating viscosity using a nonlinear formulation.  If A2 is not specified, a default value of 10.0 is assigned (Voss, 1984). "
-    }
-  },
-  "thermal_a3": {
-    "options": {
-      ".vsc": "is an empirical parameter specified by the user for calculating viscosity using a nonlinear formulation.  If A3 is not specified, a default value of 248.37 is assigned (Voss, 1984). "
-    }
-  },
-  "thermal_a4": {
-    "options": {
-      ".vsc": "is an empirical parameter specified by the user for calculating viscosity using a nonlinear formulation.  If A4 is not specified, a default value of 133.15 is assigned (Voss, 1984). "
-    }
-  },
-  "viscosity": {
-    "options": {
-      ".vsc": "keyword to specify that record corresponds to viscosity."
-    }
-  },
-  "nviscspecies": {
-    "dimensions": {
-      ".vsc": "number of species used in the viscosity equation of state.  If either concentrations or temperature (or both) are used to update viscosity then then nrhospecies needs to be at least one."
-    }
-  },
-  "flow_imbalance_correction": {
-    "options": {
-      ".fmi": "correct for an imbalance in flows by assuming that any residual flow error comes in or leaves at the concentration of the cell.  When this option is activated, the GWT Model budget written to the listing file will contain two additional entries: FLOW-ERROR and FLOW-CORRECTION.  These two entries will be equal but opposite in sign.  The FLOW-CORRECTION term is a mass flow that is added to offset the error caused by an imprecise flow balance.  If these terms are not relatively small, the flow model should be rerun with stricter convergence tolerances."
-    }
-  },
-  "scheme": {
-    "options": {
-      ".adv": "scheme used to solve the advection term.  Can be upstream, central, or TVD.  If not specified, upstream weighting is the default weighting scheme."
-    }
-  },
-  "alternative_cell_averaging": {
-    "options": {
-      ".npf": "is a text keyword to indicate that an alternative method will be used for calculating the conductance for horizontal cell connections.  The text value for ALTERNATIVE\\_CELL\\_AVERAGING can be ``LOGARITHMIC'', ``AMT-LMK'', or ``AMT-HMK''.  ``AMT-LMK'' signifies that the conductance will be calculated using arithmetic-mean thickness and logarithmic-mean hydraulic conductivity.  ``AMT-HMK'' signifies that the conductance will be calculated using arithmetic-mean thickness and harmonic-mean hydraulic conductivity. If the user does not specify a value for ALTERNATIVE\\_CELL\\_AVERAGING, then the harmonic-mean method will be used.  This option cannot be used if the XT3D option is invoked."
-    }
-  },
-  "thickstrt": {
-    "options": {
-      ".npf": "indicates that cells having a negative ICELLTYPE are confined, and their cell thickness for conductance calculations will be computed as STRT-BOT rather than TOP-BOT.  This option should be used with caution as it only affects conductance calculations in the NPF Package."
-    }
-  },
-  "cvoptions": {
-    "options": {
-      ".npf": "none",
-      ".gwfgwf": "none"
-    }
-  },
-  "variablecv": {
-    "options": {
-      ".npf": "keyword to indicate that the vertical conductance will be calculated using the saturated thickness and properties of the overlying cell and the thickness and properties of the underlying cell.  If the DEWATERED keyword is also specified, then the vertical conductance is calculated using only the saturated thickness and properties of the overlying cell if the head in the underlying cell is below its top.  If these keywords are not specified, then the default condition is to calculate the vertical conductance at the start of the simulation using the initial head and the cell properties.  The vertical conductance remains constant for the entire simulation.",
-      ".gwfgwf": "keyword to indicate that the vertical conductance will be calculated using the saturated thickness and properties of the overlying cell and the thickness and properties of the underlying cell.  If the DEWATERED keyword is also specified, then the vertical conductance is calculated using only the saturated thickness and properties of the overlying cell if the head in the underlying cell is below its top.  If these keywords are not specified, then the default condition is to calculate the vertical conductance at the start of the simulation using the initial head and the cell properties.  The vertical conductance remains constant for the entire simulation."
-    }
-  },
-  "dewatered": {
-    "options": {
-      ".npf": "If the DEWATERED keyword is specified, then the vertical conductance is calculated using only the saturated thickness and properties of the overlying cell if the head in the underlying cell is below its top.",
-      ".gwfgwf": "If the DEWATERED keyword is specified, then the vertical conductance is calculated using only the saturated thickness and properties of the overlying cell if the head in the underlying cell is below its top."
-    }
-  },
-  "perched": {
-    "options": {
-      ".npf": "keyword to indicate that when a cell is overlying a dewatered convertible cell, the head difference used in Darcy's Law is equal to the head in the overlying cell minus the bottom elevation of the overlying cell.  If not specified, then the default is to use the head difference between the two cells."
-    }
-  },
-  "rewet": {
-    "options": {
-      ".npf": "activates model rewetting.  Rewetting is off by default."
-    }
-  },
-  "wetfct": {
-    "options": {
-      ".npf": "is a keyword and factor that is included in the calculation of the head that is initially established at a cell when that cell is converted from dry to wet."
-    }
-  },
-  "iwetit": {
-    "options": {
-      ".npf": "is a keyword and iteration interval for attempting to wet cells. Wetting is attempted every IWETIT iteration. This applies to outer iterations and not inner iterations. If IWETIT is specified as zero or less, then the value is changed to 1."
+  "ihc": {
+    "connectiondata": {
+      ".disu": "is an index array indicating the direction between node n and all of its m connections.  If IHC = 0 then cell n and cell m are connected in the vertical direction.  Cell n overlies cell m if the cell number for n is less than m; cell m overlies cell n if the cell number for m is less than n.  If IHC = 1 then cell n and cell m are connected in the horizontal direction.  If IHC = 2 then cell n and cell m are connected in the horizontal direction, and the connection is vertically staggered.  A vertically staggered connection is one in which a cell is horizontally connected to more than one cell in a horizontal connection."
     }
   },
   "ihdwet": {
@@ -1160,60 +1018,73 @@
       ".npf": "is a keyword and integer flag that determines which equation is used to define the initial head at cells that become wet.  If IHDWET is 0, h = BOT + WETFCT (hm - BOT). If IHDWET is not 0, h = BOT + WETFCT (THRESH)."
     }
   },
-  "xt3doptions": {
-    "options": {
-      ".npf": "none"
+  "infiltration": {
+    "period": {
+      ".uze": "real or character value that defines the temperature of the infiltration $(e.g.,\\:^{\\circ}C\\:or\\:^{\\circ}F)$ for the UZF cell. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      ".uzt": "real or character value that defines the infiltration solute concentration $(ML^{-3})$ for the UZF cell. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
     }
   },
-  "xt3d": {
-    "options": {
-      ".npf": "keyword indicating that the XT3D formulation will be used.  If the RHS keyword is also included, then the XT3D additional terms will be added to the right-hand side.  If the RHS keyword is excluded, then the XT3D terms will be put into the coefficient matrix.  Use of XT3D will substantially increase the computational effort, but will result in improved accuracy for anisotropic conductivity fields and for unstructured grids in which the CVFD requirement is violated.  XT3D requires additional information about the shapes of grid cells.  If XT3D is active and the DISU Package is used, then the user will need to provide in the DISU Package the angldegx array in the CONNECTIONDATA block and the VERTICES and CELL2D blocks.",
-      ".gwfgwf": "keyword that activates the XT3D formulation between the cells connected with this GWF-GWF Exchange."
+  "inflow": {
+    "period": {
+      ".lak": "real or character value that defines the volumetric inflow rate $(L^3 T^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, inflow rates are zero for each lake.",
+      ".sfe": "real or character value that defines the temperature of inflow $(e.g.,\\:^{\\circ}C\\:or\\:^{\\circ}F)$ for the reach. Users are free to use whatever temperature scale they want, which might include negative temperatures.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      ".sfr": "real or character value that defines the volumetric inflow rate for the streamflow routing reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, inflow rates are zero for each reach.",
+      ".sft": "real or character value that defines the concentration of inflow $(ML^{-3})$ for the reach. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
     }
   },
-  "rhs": {
+  "initial_preconsolidation_head": {
     "options": {
-      ".npf": "If the RHS keyword is also included, then the XT3D additional terms will be added to the right-hand side.  If the RHS keyword is excluded, then the XT3D terms will be put into the coefficient matrix."
+      ".csub": "keyword to indicate that preconsolidation heads will be specified for no-delay and delay interbeds in the PACKAGEDATA block. If the SPECIFIED\\_INITIAL\\_INTERBED\\_STATE option is specified in the OPTIONS block, user-specified preconsolidation heads in the PACKAGEDATA block are absolute values. Otherwise, user-specified preconsolidation heads in the PACKAGEDATA block are relative to steady-state or initial heads."
     }
   },
-  "save_specific_discharge": {
-    "options": {
-      ".npf": "keyword to indicate that x, y, and z components of specific discharge will be calculated at cell centers and written to the budget file, which is specified with ``BUDGET SAVE FILE'' in Output Control.  If this option is activated, then additional information may be required in the discretization packages and the GWF Exchange package (if GWF models are coupled).  Specifically, ANGLDEGX must be specified in the CONNECTIONDATA block of the DISU Package; ANGLDEGX must also be specified for the GWF Exchange as an auxiliary variable."
+  "inner_dvclose": {
+    "linear": {
+      ".ims": "real value defining the dependent-variable (for example, head) change criterion for convergence of the inner (linear) iterations, in units of the dependent-variable (for example, length for head). When the maximum absolute value of the dependent-variable change at all nodes during an iteration is less than or equal to INNER\\_DVCLOSE, the matrix solver assumes convergence. Commonly, INNER\\_DVCLOSE is set equal to or an order of magnitude less than the OUTER\\_DVCLOSE value specified for the NONLINEAR block. The keyword, INNER\\_HCLOSE can be still be specified instead of INNER\\_DVCLOSE for backward compatibility with previous versions of MODFLOW 6 but eventually INNER\\_HCLOSE will be deprecated and specification of INNER\\_HCLOSE will cause MODFLOW 6 to terminate with an error."
     }
   },
-  "save_saturation": {
-    "options": {
-      ".npf": "keyword to indicate that cell saturation will be written to the budget file, which is specified with ``BUDGET SAVE FILE'' in Output Control.  Saturation will be saved to the budget file as an auxiliary variable saved with the DATA-SAT text label.  Saturation is a cell variable that ranges from zero to one and can be used by post processing programs to determine how much of a cell volume is saturated.  If ICELLTYPE is 0, then saturation is always one."
+  "inner_hclose": {
+    "linear": {
+      ".ims": "real value defining the head change criterion for convergence of the inner (linear) iterations, in units of length. When the maximum absolute value of the head change at all nodes during an iteration is less than or equal to INNER\\_HCLOSE, the matrix solver assumes convergence. Commonly, INNER\\_HCLOSE is set equal to or an order of magnitude less than the OUTER\\_HCLOSE value specified for the NONLINEAR block.  The INNER\\_HCLOSE keyword has been deprecated in favor of the more general INNER\\_DVCLOSE (for dependent variable), however either one can be specified in order to maintain backward compatibility."
     }
   },
-  "k22overk": {
-    "options": {
-      ".npf": "keyword to indicate that specified K22 is a ratio of K22 divided by K.  If this option is specified, then the K22 array entered in the NPF Package will be multiplied by K after being read."
+  "inner_maximum": {
+    "linear": {
+      ".ims": "integer value defining the maximum number of inner (linear) iterations. The number typically depends on the characteristics of the matrix solution scheme being used. For nonlinear problems, INNER\\_MAXIMUM usually ranges from 60 to 600; a value of 100 will be sufficient for most linear problems."
     }
   },
-  "k33overk": {
-    "options": {
-      ".npf": "keyword to indicate that specified K33 is a ratio of K33 divided by K.  If this option is specified, then the K33 array entered in the NPF Package will be multiplied by K after being read."
+  "inner_rclose": {
+    "linear": {
+      ".ims": "real value that defines the flow residual tolerance for convergence of the IMS linear solver and specific flow residual criteria used. This value represents the maximum allowable residual at any single node.  Value is in units of length cubed per time, and must be consistent with \\mf length and time units. Usually a value of $1.0 \\times 10^{-1}$ is sufficient for the flow-residual criteria when meters and seconds are the defined \\mf length and time."
     }
   },
-  "tvk6": {
-    "options": {
-      ".npf": "keyword to specify that record corresponds to a time-varying hydraulic conductivity (TVK) file.  The behavior of TVK and a description of the input file is provided separately."
+  "invert": {
+    "period": {
+      ".lak": "real or character value that defines the invert elevation for the lake outlet. A specified INVERT value is only used for active lakes if COUTTYPE for lake outlet OUTLETNO is not SPECIFIED. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
     }
   },
-  "dev_no_newton": {
-    "options": {
-      ".npf": "turn off Newton for unconfined cells"
+  "irch": {
+    "period": {
+      ".rcha": "IRCH is the layer number that defines the layer in each vertical column where recharge is applied. If IRCH is omitted, recharge by default is applied to cells in layer 1.  IRCH can only be used if READASARRAYS is specified in the OPTIONS block.  If IRCH is specified, it must be specified as the first variable in the PERIOD block or MODFLOW will terminate with an error."
     }
   },
-  "dev_omega": {
+  "istopzone": {
     "options": {
-      ".npf": "set saturation omega value"
+      ".prp": "integer value defining the stop zone number.  If cells have been assigned IZONE values in the GRIDDATA block, a particle terminates if it enters a cell whose IZONE value matches ISTOPZONE.  An ISTOPZONE value of zero indicates that there is no stop zone.  The default value is zero."
     }
   },
-  "icelltype": {
+  "iwetit": {
+    "options": {
+      ".npf": "is a keyword and iteration interval for attempting to wet cells. Wetting is attempted every IWETIT iteration. This applies to outer iterations and not inner iterations. If IWETIT is specified as zero or less, then the value is changed to 1."
+    }
+  },
+  "izone": {
     "griddata": {
-      ".npf": "flag for each cell that specifies how saturated thickness is treated.  0 means saturated thickness is held constant;  $>$0 means saturated thickness varies with computed head when head is below the cell top; $<$0 means saturated thickness varies with computed head unless the THICKSTRT option is in effect.  When THICKSTRT is in effect, a negative value for ICELLTYPE indicates that the saturated thickness value used in conductance calculations in the NPF Package will be computed as STRT-BOT and held constant.  If the THICKSTRT option is not in effect, then negative values provided by the user for ICELLTYPE are automatically reassigned by the program to a value of one."
+      ".mip": "is an integer zone number assigned to each cell.  IZONE may be positive, negative, or zero.  The current cell's zone number is recorded with each particle track datum.  If a PRP package's ISTOPZONE option is set to any value other than zero, particles released by that PRP Package terminate if they enter a cell whose IZONE value matches ISTOPZONE.  If ISTOPZONE is not specified or is set to zero in a PRP Package, IZONE has no effect on the termination of particles released by that PRP Package.  Each PRP Package may configure a single ISTOPZONE value."
+    }
+  },
+  "ja": {
+    "connectiondata": {
+      ".disu": "is a list of cell number (n) followed by its connecting cell numbers (m) for each of the m cells connected to cell n. The number of values to provide for cell n is IAC(n).  This list is sequentially provided for the first to the last cell. The first value in the list must be cell n itself, and the remaining cells must be listed in an increasing order (sorted from lowest number to highest).  Note that the cell and its connections are only supplied for the GWE cells and their connections to the other GWE cells.  Also note that the JA list input may be divided such that every node and its connectivity list can be on a separate line for ease in readability of the file. To further ease readability of the file, the node number of the cell whose connectivity is subsequently listed, may be expressed as a negative number, the sign of which is subsequently converted to positive by the code."
     }
   },
   "k": {
@@ -1232,6 +1103,11 @@
       ".tvk": "is the new value to be assigned as the cell's hydraulic conductivity of the second ellipsoid axis (or the ratio of K22/K if the K22OVERK NPF package option is specified) from the start of the specified stress period, as per K22 in the NPF package.  For an unrotated case this is the hydraulic conductivity in the y direction.  If the OPTIONS block includes a TS6 entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
     }
   },
+  "k22overk": {
+    "options": {
+      ".npf": "keyword to indicate that specified K22 is a ratio of K22 divided by K.  If this option is specified, then the K22 array entered in the NPF Package will be multiplied by K after being read."
+    }
+  },
   "k33": {
     "griddata": {
       ".npf": "is the hydraulic conductivity of the third ellipsoid axis (or the ratio of K33/K if the K33OVERK option is specified); for an unrotated case, this is the vertical hydraulic conductivity.  When anisotropy is applied, K33 corresponds to the K33 tensor component.  All included cells (IDOMAIN $>$ 0) must have a K33 value greater than zero."
@@ -1240,443 +1116,57 @@
       ".tvk": "is the new value to be assigned as the cell's hydraulic conductivity of the third ellipsoid axis (or the ratio of K33/K if the K33OVERK NPF package option is specified) from the start of the specified stress period, as per K33 in the NPF package.  For an unrotated case, this is the vertical hydraulic conductivity.  If the OPTIONS block includes a TS6 entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
     }
   },
-  "angle1": {
-    "griddata": {
-      ".npf": "is a rotation angle of the hydraulic conductivity tensor in degrees. The angle represents the first of three sequential rotations of the hydraulic conductivity ellipsoid. With the K11, K22, and K33 axes of the ellipsoid initially aligned with the x, y, and z coordinate axes, respectively, ANGLE1 rotates the ellipsoid about its K33 axis (within the x - y plane). A positive value represents counter-clockwise rotation when viewed from any point on the positive K33 axis, looking toward the center of the ellipsoid. A value of zero indicates that the K11 axis lies within the x - z plane. If ANGLE1 is not specified, default values of zero are assigned to ANGLE1, ANGLE2, and ANGLE3, in which case the K11, K22, and K33 axes are aligned with the x, y, and z axes, respectively."
-    }
-  },
-  "angle2": {
-    "griddata": {
-      ".npf": "is a rotation angle of the hydraulic conductivity tensor in degrees. The angle represents the second of three sequential rotations of the hydraulic conductivity ellipsoid. Following the rotation by ANGLE1 described above, ANGLE2 rotates the ellipsoid about its K22 axis (out of the x - y plane). An array can be specified for ANGLE2 only if ANGLE1 is also specified. A positive value of ANGLE2 represents clockwise rotation when viewed from any point on the positive K22 axis, looking toward the center of the ellipsoid. A value of zero indicates that the K11 axis lies within the x - y plane. If ANGLE2 is not specified, default values of zero are assigned to ANGLE2 and ANGLE3; connections that are not user-designated as vertical are assumed to be strictly horizontal (that is, to have no z component to their orientation); and connection lengths are based on horizontal distances."
-    }
-  },
-  "angle3": {
-    "griddata": {
-      ".npf": "is a rotation angle of the hydraulic conductivity tensor in degrees. The angle represents the third of three sequential rotations of the hydraulic conductivity ellipsoid. Following the rotations by ANGLE1 and ANGLE2 described above, ANGLE3 rotates the ellipsoid about its K11 axis. An array can be specified for ANGLE3 only if ANGLE1 and ANGLE2 are also specified. An array must be specified for ANGLE3 if ANGLE2 is specified. A positive value of ANGLE3 represents clockwise rotation when viewed from any point on the positive K11 axis, looking toward the center of the ellipsoid. A value of zero indicates that the K22 axis lies within the x - y plane."
-    }
-  },
-  "wetdry": {
-    "griddata": {
-      ".npf": "is a combination of the wetting threshold and a flag to indicate which neighboring cells can cause a cell to become wet. If WETDRY $<$ 0, only a cell below a dry cell can cause the cell to become wet. If WETDRY $>$ 0, the cell below a dry cell and horizontally adjacent cells can cause a cell to become wet. If WETDRY is 0, the cell cannot be wetted. The absolute value of WETDRY is the wetting threshold. When the sum of BOT and the absolute value of WETDRY at a dry cell is equaled or exceeded by the head at an adjacent cell, the cell is wetted.  WETDRY must be specified if ``REWET'' is specified in the OPTIONS block.  If ``REWET'' is not specified in the options block, then WETDRY can be entered, and memory will be allocated for it, even though it is not used."
-    }
-  },
-  "porosity": {
-    "griddata": {
-      ".mip": "is the aquifer porosity.",
-      ".mst": "is the mobile domain porosity, defined as the mobile domain pore volume per mobile domain volume.  Additional information on porosity within the context of mobile and immobile domain transport simulations is included in the MODFLOW 6 Supplemental Technical Information document. ",
-      ".est": "is the mobile domain porosity, defined as the mobile domain pore volume per mobile domain volume.  The GWE model does not support the concept of an immobile domain in the context of heat transport. ",
-      ".ist": "porosity of the immobile domain specified as the immobile domain pore volume per immobile domain volume."
-    }
-  },
-  "retfactor": {
-    "griddata": {
-      ".mip": "is a real value by which velocity is divided within a given cell.  RETFACTOR can be used to account for solute retardation, i.e., the apparent effect of linear sorption on the velocity of particles that track solute advection.  RETFACTOR may be assigned any real value.  A RETFACTOR value greater than 1 represents particle retardation (slowing), and a value of 1 represents no retardation.  The effect of specifying a RETFACTOR value for each cell is the same as the effect of directly multiplying the POROSITY in each cell by the proposed RETFACTOR value for each cell.  RETFACTOR allows conceptual isolation of effects such as retardation from the effect of porosity.  The default value is 1."
-    }
-  },
-  "izone": {
-    "griddata": {
-      ".mip": "is an integer zone number assigned to each cell.  IZONE may be positive, negative, or zero.  The current cell's zone number is recorded with each particle track datum.  If a PRP package's ISTOPZONE option is set to any value other than zero, particles released by that PRP Package terminate if they enter a cell whose IZONE value matches ISTOPZONE.  If ISTOPZONE is not specified or is set to zero in a PRP Package, IZONE has no effect on the termination of particles released by that PRP Package.  Each PRP Package may configure a single ISTOPZONE value."
-    }
-  },
-  "print_temperature": {
+  "k33overk": {
     "options": {
-      ".uze": "keyword to indicate that the list of UZF cell temperatures will be printed to the listing file for every stress period in which ``TEMPERATURE PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_TEMPERATURE is specified, then temperatures are printed for the last time step of each stress period.",
-      ".lke": "keyword to indicate that the list of lake temperature will be printed to the listing file for every stress period in which ``TEMPERATURE PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_TEMPERATURE is specified, then temperature are printed for the last time step of each stress period.",
-      ".sfe": "keyword to indicate that the list of reach temperatures will be printed to the listing file for every stress period in which ``TEMPERATURE PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_TEMPERATURE is specified, then temperatures are printed for the last time step of each stress period.",
-      ".mwe": "keyword to indicate that the list of well temperature will be printed to the listing file for every stress period in which ``TEMPERATURE PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_TEMPERATURE is specified, then temperature are printed for the last time step of each stress period."
+      ".npf": "keyword to indicate that specified K33 is a ratio of K33 divided by K.  If this option is specified, then the K33 array entered in the NPF Package will be multiplied by K after being read."
     }
   },
-  "infiltration": {
+  "kts": {
+    "griddata": {
+      ".cnd": "thermal conductivity of the solid aquifer material"
+    }
+  },
+  "ktw": {
+    "griddata": {
+      ".cnd": "thermal conductivity of the simulated fluid.   Note that the CND Package does not account for the tortuosity of the flow paths when solving for the conductive spread of heat.  If tortuosity plays an important role in the thermal conductivity calculation, its effect should be reflected in the value specified for KTW."
+    }
+  },
+  "last": {
     "period": {
-      ".uze": "real or character value that defines the temperature of the infiltration $(e.g.,\\:^{\\circ}C\\:or\\:^{\\circ}F)$ for the UZF cell. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      ".uzt": "real or character value that defines the infiltration solute concentration $(ML^{-3})$ for the UZF cell. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+      ".oc": "keyword to indicate save for last step in period. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
+      ".prp": "keyword to indicate release at the start of the last time step in the period. This keyword may be used in conjunction with other RELEASESETTING options."
     }
   },
-  "uzet": {
-    "period": {
-      ".uze": "real or character value that states what fraction of the simulated unsaturated zone evapotranspiration is associated with evaporation.  The evaporative losses from the unsaturated zone moisture content will have an evaporative cooling effect on the GWE cell from which the evaporation originated. If this value is larger than 1, then it will be reset to 1.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      ".uzt": "real or character value that defines the concentration of unsaturated zone evapotranspiration water $(ML^{-3})$ for the UZF cell. If this concentration value is larger than the simulated concentration in the UZF cell, then the unsaturated zone ET water will be removed at the same concentration as the UZF cell.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
-    }
-  },
-  "continue": {
+  "latent_heat_vaporization": {
     "options": {
-      ".nam": "keyword flag to indicate that the simulation should continue even if one or more solutions do not converge."
+      ".est": "latent heat of vaporization is the amount of energy that is required to convert a given quantity of liquid into a gas and is associated with evaporative cooling.  While the EST package does not simulate evaporation, multiple other packages in a GWE simulation may.  To avoid having to specify the latent heat of vaporization in multiple packages, it is specified in a single location and accessed wherever it is needed.  For example, evaporation may occur from the surface of streams or lakes and the energy consumed by the change in phase would be needed in both the SFE and LKE packages.  This value is set to 2,453,500 J/kg if no overriding value is specified.  A user-specified value should be provided for models that use units other than joules and kilograms or if it is necessary to use a value other than the default."
     }
   },
-  "nocheck": {
-    "options": {
-      ".nam": "keyword flag to indicate that the model input check routines should not be called prior to each time step. Checks are performed by default."
-    }
-  },
-  "memory_print_option": {
-    "options": {
-      ".nam": "is a flag that controls printing of detailed memory manager usage to the end of the simulation list file.  NONE means do not print detailed information. SUMMARY means print only the total memory for each simulation component. ALL means print information for each variable stored in the memory manager. NONE is default if MEMORY\\_PRINT\\_OPTION is not specified."
-    }
-  },
-  "profile_option": {
-    "options": {
-      ".nam": "is a flag that controls performance profiling and reporting.  NONE disables profiling. SUMMARY means to measure and print a coarse performance profile. DETAIL means collect and print information with the highest resolution available. NONE is default if PROFILE\\_OPTION is not specified."
-    }
-  },
-  "maxerrors": {
-    "options": {
-      ".nam": "maximum number of errors that will be stored and printed."
-    }
-  },
-  "hpc6": {
-    "options": {
-      ".nam": "keyword to specify that record corresponds to a hpc file."
-    }
-  },
-  "tdis6": {
-    "timing": {
-      ".nam": "is the name of the Temporal Discretization (TDIS) Input File."
-    }
-  },
-  "models": {
-    "models": {
-      ".nam": "is the list of model types, model name files, and model names."
-    }
-  },
-  "exchanges": {
-    "exchanges": {
-      ".nam": "is the list of exchange types, exchange files, and model names."
-    }
-  },
-  "mxiter": {
-    "solutiongroup": {
-      ".nam": "is the maximum number of outer iterations for this solution group.  The default value is 1.  If there is only one solution in the solution group, then MXITER must be 1."
-    }
-  },
-  "solutiongroup": {
-    "solutiongroup": {
-      ".nam": "is the list of solution types and models in the solution."
-    }
-  },
-  "dev_exit_solve_method": {
-    "options": {
-      ".prp": "the method for iterative solution of particle exit location and time in the generalized Pollock's method.  0 default, 1 Brent, 2 Chandrupatla.  The default is Brent's method."
-    }
-  },
-  "exit_solve_tolerance": {
-    "options": {
-      ".prp": "the convergence tolerance for iterative solution of particle exit location and time in the generalized Pollock's method.  A value of 0.00001 works well for many problems, but the value that strikes the best balance between accuracy and runtime is problem-dependent."
-    }
-  },
-  "local_z": {
-    "options": {
-      ".prp": "indicates that ``zrpt'' defines the local z coordinate of the release point within the cell, with value of 0 at the bottom and 1 at the top of the cell.  If the cell is partially saturated at release time, the top of the cell is considered to be the water table elevation (the head in the cell) rather than the top defined by the user."
-    }
-  },
-  "extend_tracking": {
-    "options": {
-      ".prp": "indicates that particles should be tracked beyond the end of the simulation's final time step (using that time step's flows) until particles terminate or reach a specified stop time.  By default, particles are terminated at the end of the simulation's final time step."
-    }
-  },
-  "track": {
-    "options": {
-      ".prp": "keyword to specify that record corresponds to a binary track output file.  Each PRP Package may have a distinct binary track output file.",
-      ".oc": "keyword to specify that record corresponds to a binary track file.  Each PRT Model's OC Package may have only one binary track output file."
-    }
-  },
-  "trackcsv": {
-    "options": {
-      ".prp": "keyword to specify that record corresponds to a CSV track output file.  Each PRP Package may have a distinct CSV track output file.",
-      ".oc": "keyword to specify that record corresponds to a CSV track file.  Each PRT Model's OC Package may have only one CSV track file."
-    }
-  },
-  "stoptime": {
-    "options": {
-      ".prp": "real value defining the maximum simulation time to which particles in the package can be tracked.  Particles that have not terminated earlier due to another termination condition will terminate when simulation time STOPTIME is reached.  If the last stress period in the simulation consists of more than one time step, particles will not be tracked past the ending time of the last stress period, regardless of STOPTIME.  If the EXTEND\\_TRACKING option is enabled and the last stress period in the simulation is steady-state, the simulation ending time will not limit the time to which particles can be tracked, but STOPTIME and STOPTRAVELTIME will continue to apply.  If STOPTIME and STOPTRAVELTIME are both provided, particles will be stopped if either is reached."
-    }
-  },
-  "stoptraveltime": {
-    "options": {
-      ".prp": "real value defining the maximum travel time over which particles in the model can be tracked.  Particles that have not terminated earlier due to another termination condition will terminate when their travel time reaches STOPTRAVELTIME.  If the last stress period in the simulation consists of more than one time step, particles will not be tracked past the ending time of the last stress period, regardless of STOPTRAVELTIME.  If the EXTEND\\_TRACKING option is enabled and the last stress period in the simulation is steady-state, the simulation ending time will not limit the time to which particles can be tracked, but STOPTIME and STOPTRAVELTIME will continue to apply.  If STOPTIME and STOPTRAVELTIME are both provided, particles will be stopped if either is reached."
-    }
-  },
-  "stop_at_weak_sink": {
-    "options": {
-      ".prp": "is a text keyword to indicate that a particle is to terminate when it enters a cell that is a weak sink.  By default, particles are allowed to pass though cells that are weak sinks."
-    }
-  },
-  "istopzone": {
-    "options": {
-      ".prp": "integer value defining the stop zone number.  If cells have been assigned IZONE values in the GRIDDATA block, a particle terminates if it enters a cell whose IZONE value matches ISTOPZONE.  An ISTOPZONE value of zero indicates that there is no stop zone.  The default value is zero."
-    }
-  },
-  "drape": {
-    "options": {
-      ".prp": "is a text keyword to indicate that if a particle's release point is in a cell that happens to be inactive at release time, the particle is to be moved to the topmost active cell below it, if any. By default, a particle is not released into the simulation if its release point's cell is inactive at release time."
-    }
-  },
-  "dry_tracking_method": {
-    "options": {
-      ".prp": "is a string indicating how particles should behave in dry-but-active cells (as can occur with the Newton formulation).  The value can be ``DROP'', ``STOP'', or ``STAY''.  The default is ``DROP'', which passes particles vertically and instantaneously to the water table. ``STOP'' causes particles to terminate. ``STAY'' causes particles to remain stationary but active."
-    }
-  },
-  "dev_forceternary": {
-    "options": {
-      ".prp": "force use of the ternary tracking method regardless of cell type in DISV grids."
-    }
-  },
-  "release_time_tolerance": {
-    "options": {
-      ".prp": "real number indicating the tolerance within which to consider consecutive release times coincident. Coincident release times will be merged into a single release time. The default is $\\epsilon \\times 10^{11}$, where $\\epsilon$ is machine precision."
-    }
-  },
-  "release_time_frequency": {
-    "options": {
-      ".prp": "real number indicating the time frequency at which to release particles. This option can be used to schedule releases at a regular interval for the duration of the simulation, starting at the simulation start time. The release schedule is the union of this option, the RELEASETIMES block, and PERIOD block RELEASESETTING selections. If none of these are provided, a single release time is configured at the beginning of the first time step of the simulation's first stress period."
-    }
-  },
-  "nreleasepts": {
-    "dimensions": {
-      ".prp": "is the number of particle release points."
-    }
-  },
-  "nreleasetimes": {
-    "dimensions": {
-      ".prp": "is the number of particle release times specified in the RELEASETIMES block. This is not necessarily the total number of release times; release times are the union of RELEASE\\_TIME\\_FREQUENCY, RELEASETIMES block, and PERIOD block RELEASESETTING selections."
-    }
-  },
-  "fraction": {
-    "period": {
-      ".prp": "release particles after the specified fraction of the time step has elapsed. If FRACTION is not set, particles are released at the start of the specified time step(s). FRACTION must be a single value when used with ALL, FIRST, or FREQUENCY. When used with STEPS, FRACTION may be a single value or an array of the same length as STEPS. If a single FRACTION value is provided with STEPS, the fraction applies to all steps. NOTE: The FRACTION option has been removed. For fine control over release timing, specify times explicitly using the RELEASETIMES block."
-    }
-  },
-  "list": {
-    "options": {
-      ".nam": "is name of the listing file to create for this GWE model.  If not specified, then the name of the list file will be the basename of the GWE model name file and the ``.lst'' extension.  For example, if the GWE name file is called ``my.model.nam'' then the list file will be called ``my.model.lst''."
-    }
-  },
-  "name": {
-    "attributes": {
-      ".tas": "xxx"
-    }
-  },
-  "method": {
-    "attributes": {
-      ".tas": "xxx",
-      ".ts": "xxx"
-    }
-  },
-  "sfac": {
-    "attributes": {
-      ".tas": "xxx"
-    }
-  },
-  "mover": {
-    "options": {
-      ".api": "keyword to indicate that this instance of the api boundary Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.",
-      ".drn": "keyword to indicate that this instance of the Drain Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.",
-      ".wel": "keyword to indicate that this instance of the Well Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.",
-      ".lak": "keyword to indicate that this instance of the LAK Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.",
-      ".ghb": "keyword to indicate that this instance of the General-Head Boundary Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.",
-      ".sfr": "keyword to indicate that this instance of the SFR Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.",
-      ".riv": "keyword to indicate that this instance of the River Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.",
-      ".uzf": "keyword to indicate that this instance of the UZF Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.",
-      ".maw": "keyword to indicate that this instance of the MAW Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water."
-    }
-  },
-  "nrow": {
-    "dimensions": {
-      ".dis2d": "is the number of rows in the model grid.",
-      ".laktab": "integer value specifying the number of rows in the lake table. There must be NROW rows of data in the TABLE block.",
-      ".dis": "is the number of rows in the model grid.",
-      ".sfrtab": "integer value specifying the number of rows in the reach cross-section table. There must be NROW rows of data in the TABLE block."
-    }
-  },
-  "ncol": {
-    "dimensions": {
-      ".dis2d": "is the number of columns in the model grid.",
-      ".laktab": "integer value specifying the number of columns in the lake table. There must be NCOL columns of data in the TABLE block. For lakes with HORIZONTAL and/or VERTICAL CTYPE connections, NCOL must be equal to 3. For lakes with EMBEDDEDH or EMBEDDEDV CTYPE connections, NCOL must be equal to 4.",
-      ".dis": "is the number of columns in the model grid.",
-      ".sfrtab": "integer value specifying the number of columns in the reach cross-section table. There must be NCOL columns of data in the TABLE block. NCOL must be equal to 2 if MANFRACTION is not specified or 3 otherwise."
-    }
-  },
-  "delr": {
+  "latitude": {
     "griddata": {
-      ".dis2d": "is the column spacing in the row direction.",
-      ".dis": "is the column spacing in the row direction."
+      ".ncf": "cell center latitude."
     }
   },
-  "delc": {
+  "length": {
     "griddata": {
-      ".dis2d": "is the row spacing in the column direction.",
-      ".dis": "is the row spacing in the column direction."
+      ".disv1d": "length for each one-dimensional cell"
     }
   },
-  "ncf6": {
+  "length_conversion": {
     "options": {
-      ".disv": "keyword to specify that record corresponds to a netcdf configuration (NCF) file.",
-      ".dis": "keyword to specify that record corresponds to a netcdf configuration (NCF) file."
+      ".dfw": "real value that is used to convert user-specified Manning's roughness coefficients from meters to model length units. LENGTH\\_CONVERSION should be set to 3.28081, 1.0, and 100.0 when using length units (LENGTH\\_UNITS) of feet, meters, or centimeters in the simulation, respectively. LENGTH\\_CONVERSION does not need to be specified if LENGTH\\_UNITS are meters.",
+      ".lak": "real value that is used to convert outlet user-specified Manning's roughness coefficients or gravitational acceleration used to calculate outlet flows from meters to model length units. LENGTH\\_CONVERSION should be set to 3.28081, 1.0, and 100.0 when using length units (LENGTH\\_UNITS) of feet, meters, or centimeters in the simulation, respectively. LENGTH\\_CONVERSION does not need to be specified if no lake outlets are specified or LENGTH\\_UNITS are meters.",
+      ".sfr": "real value that is used to convert user-specified Manning's roughness coefficients from meters to model length units. LENGTH\\_CONVERSION should be set to 3.28081, 1.0, and 100.0 when using length units (LENGTH\\_UNITS) of feet, meters, or centimeters in the simulation, respectively. LENGTH\\_CONVERSION does not need to be specified if LENGTH\\_UNITS are meters."
     }
   },
-  "nlay": {
-    "dimensions": {
-      ".disv": "is the number of layers in the model grid.",
-      ".dis": "is the number of layers in the model grid."
-    }
-  },
-  "ncpl": {
-    "dimensions": {
-      ".disv": "is the number of cells per layer.  This is a constant value for the grid and it applies to all layers.",
-      ".ncf": "is the number of cells in a projected plane layer."
-    }
-  },
-  "top": {
-    "griddata": {
-      ".disv": "is the top elevation for each cell in the top model layer.",
-      ".dis": "is the top elevation for each cell in the top model layer.",
-      ".disu": "is the top elevation for each cell in the model grid."
-    }
-  },
-  "botm": {
-    "griddata": {
-      ".disv": "is the bottom elevation for each cell.",
-      ".dis": "is the bottom elevation for each cell."
-    }
-  },
-  "newtonoptions": {
+  "length_units": {
     "options": {
-      ".nam": "none"
-    }
-  },
-  "newton": {
-    "options": {
-      ".nam": "keyword that activates the Newton-Raphson formulation for surface water flow between connected reaches and stress packages that support calculation of Newton-Raphson terms. ",
-      ".gwfgwf": "keyword that activates the Newton-Raphson formulation for groundwater flow between connected, convertible groundwater cells. Cells will not dry when this option is used."
-    }
-  },
-  "under_relaxation": {
-    "options": {
-      ".nam": "keyword that indicates whether the surface water stage in a reach will be under-relaxed when water levels fall below the bottom of the model below any given cell. By default, Newton-Raphson UNDER\\_RELAXATION is not applied."
-    },
-    "nonlinear": {
-      ".ims": "is an optional keyword that defines the nonlinear under-relaxation schemes used. Under-relaxation is also known as dampening, and is used to reduce the size of the calculated dependent variable before proceeding to the next outer iteration.  Under-relaxation can be an effective tool for highly nonlinear models when there are large and often counteracting changes in the calculated dependent variable between successive outer iterations.  By default under-relaxation is not used.  NONE - under-relaxation is not used (default). SIMPLE - Simple under-relaxation scheme with a fixed relaxation factor (UNDER\\_RELAXATION\\_GAMMA) is used.  COOLEY - Cooley under-relaxation scheme is used.  DBD - delta-bar-delta under-relaxation is used.  Note that the under-relaxation schemes are often used in conjunction with problems that use the Newton-Raphson formulation, however, experience has indicated that they also work well for non-Newton problems, such as those with the wet/dry options of MODFLOW 6."
-    }
-  },
-  "print_option": {
-    "options": {
-      ".ims": "is a flag that controls printing of convergence information from the solver.  NONE means print nothing. SUMMARY means print only the total number of iterations and nonlinear residual reduction summaries. ALL means print linear matrix solver convergence information to the solution listing file and model specific linear matrix solver convergence information to each model listing file in addition to SUMMARY information. NONE is default if PRINT\\_OPTION is not specified.",
-      ".pts": "is a flag that controls printing of convergence information from the solver.  NONE means print nothing. SUMMARY means print only the total number of iterations and nonlinear residual reduction summaries. ALL means print linear matrix solver convergence information to the solution listing file and model specific linear matrix solver convergence information to each model listing file in addition to SUMMARY information. NONE is default if PRINT\\_OPTION is not specified."
-    }
-  },
-  "complexity": {
-    "options": {
-      ".ims": "is an optional keyword that defines default non-linear and linear solver parameters.  SIMPLE - indicates that default solver input values will be defined that work well for nearly linear models. This would be used for models that do not include nonlinear stress packages and models that are either confined or consist of a single unconfined layer that is thick enough to contain the water table within a single layer. MODERATE - indicates that default solver input values will be defined that work well for moderately nonlinear models. This would be used for models that include nonlinear stress packages and models that consist of one or more unconfined layers. The MODERATE option should be used when the SIMPLE option does not result in successful convergence.  COMPLEX - indicates that default solver input values will be defined that work well for highly nonlinear models. This would be used for models that include nonlinear stress packages and models that consist of one or more unconfined layers representing complex geology and surface-water/groundwater interaction. The COMPLEX option should be used when the MODERATE option does not result in successful convergence.  Non-linear and linear solver parameters assigned using a specified complexity can be modified in the NONLINEAR and LINEAR blocks. If the COMPLEXITY option is not specified, NONLINEAR and LINEAR variables will be assigned the simple complexity values.",
-      ".pts": "is an optional keyword that defines default non-linear and linear solver parameters.  SIMPLE - indicates that default solver input values will be defined that work well for nearly linear models. This would be used for models that do not include nonlinear stress packages and models that are either confined or consist of a single unconfined layer that is thick enough to contain the water table within a single layer. MODERATE - indicates that default solver input values will be defined that work well for moderately nonlinear models. This would be used for models that include nonlinear stress packages and models that consist of one or more unconfined layers. The MODERATE option should be used when the SIMPLE option does not result in successful convergence.  COMPLEX - indicates that default solver input values will be defined that work well for highly nonlinear models. This would be used for models that include nonlinear stress packages and models that consist of one or more unconfined layers representing complex geology and surface-water/groundwater interaction. The COMPLEX option should be used when the MODERATE option does not result in successful convergence.  Non-linear and linear solver parameters assigned using a specified complexity can be modified in the NONLINEAR and LINEAR blocks. If the COMPLEXITY option is not specified, NONLINEAR and LINEAR variables will be assigned the simple complexity values."
-    }
-  },
-  "csv_output": {
-    "options": {
-      ".ims": "keyword to specify that the record corresponds to the comma separated values solver convergence output.  The CSV\\_OUTPUT option has been deprecated and split into the CSV_OUTER_OUTPUT and CSV_INNER_OUTPUT options.  Starting with MODFLOW 6 version 6.1.1 if the CSV_OUTPUT option is specified, then it is treated as the CSV_OUTER_OUTPUT option.",
-      ".pts": "keyword to specify that the record corresponds to the comma separated values solver convergence output.  The CSV\\_OUTPUT option has been deprecated and split into the CSV_OUTER_OUTPUT and CSV_INNER_OUTPUT options.  Starting with MODFLOW 6 version 6.1.1 if the CSV_OUTPUT option is specified, then it is treated as the CSV_OUTER_OUTPUT option."
-    }
-  },
-  "csv_outer_output": {
-    "options": {
-      ".ims": "keyword to specify that the record corresponds to the comma separated values outer iteration convergence output.",
-      ".pts": "keyword to specify that the record corresponds to the comma separated values outer iteration convergence output."
-    }
-  },
-  "csv_inner_output": {
-    "options": {
-      ".ims": "keyword to specify that the record corresponds to the comma separated values solver convergence output.",
-      ".pts": "keyword to specify that the record corresponds to the comma separated values solver convergence output."
-    }
-  },
-  "no_ptc": {
-    "options": {
-      ".ims": "is a flag that is used to disable pseudo-transient continuation (PTC). Option only applies to steady-state stress periods for models using the Newton-Raphson formulation. For many problems, PTC can significantly improve convergence behavior for steady-state simulations, and for this reason it is active by default.  In some cases, however, PTC can worsen the convergence behavior, especially when the initial conditions are similar to the solution.  When the initial conditions are similar to, or exactly the same as, the solution and convergence is slow, then the NO\\_PTC FIRST option should be used to deactivate PTC for the first stress period.  The NO\\_PTC ALL option should also be used in order to compare convergence behavior with other MODFLOW versions, as PTC is only available in MODFLOW 6.",
-      ".pts": "is a flag that is used to disable pseudo-transient continuation (PTC). Option only applies to steady-state stress periods for models using the Newton-Raphson formulation. For many problems, PTC can significantly improve convergence behavior for steady-state simulations, and for this reason it is active by default.  In some cases, however, PTC can worsen the convergence behavior, especially when the initial conditions are similar to the solution.  When the initial conditions are similar to, or exactly the same as, the solution and convergence is slow, then the NO\\_PTC FIRST option should be used to deactivate PTC for the first stress period.  The NO\\_PTC ALL option should also be used in order to compare convergence behavior with other MODFLOW versions, as PTC is only available in MODFLOW 6."
-    }
-  },
-  "ats_outer_maximum_fraction": {
-    "options": {
-      ".ims": "real value defining the fraction of the maximum allowable outer iterations used with the Adaptive Time Step (ATS) capability if it is active.  If this value is set to zero by the user, then this solution will have no effect on ATS behavior.  This value must be greater than or equal to zero and less than or equal to 0.5 or the program will terminate with an error.  If it is not specified by the user, then it is assigned a default value of one third.  When the number of outer iterations for this solution is less than the product of this value and the maximum allowable outer iterations, then ATS will increase the time step length by a factor of DTADJ in the ATS input file.  When the number of outer iterations for this solution is greater than the maximum allowable outer iterations minus the product of this value and the maximum allowable outer iterations, then the ATS (if active) will decrease the time step length by a factor of 1 / DTADJ.",
-      ".pts": "real value defining the fraction of the maximum allowable outer iterations used with the Adaptive Time Step (ATS) capability if it is active.  If this value is set to zero by the user, then this solution will have no effect on ATS behavior.  This value must be greater than or equal to zero and less than or equal to 0.5 or the program will terminate with an error.  If it is not specified by the user, then it is assigned a default value of one third.  When the number of outer iterations for this solution is less than the product of this value and the maximum allowable outer iterations, then ATS will increase the time step length by a factor of DTADJ in the ATS input file.  When the number of outer iterations for this solution is greater than the maximum allowable outer iterations minus the product of this value and the maximum allowable outer iterations, then the ATS (if active) will decrease the time step length by a factor of 1 / DTADJ."
-    }
-  },
-  "outer_hclose": {
-    "nonlinear": {
-      ".ims": "real value defining the head change criterion for convergence of the outer (nonlinear) iterations, in units of length. When the maximum absolute value of the head change at all nodes during an iteration is less than or equal to OUTER\\_HCLOSE, iteration stops. Commonly, OUTER\\_HCLOSE equals 0.01.  The OUTER\\_HCLOSE option has been deprecated in favor of the more general OUTER\\_DVCLOSE (for dependent variable), however either one can be specified in order to maintain backward compatibility."
-    }
-  },
-  "outer_dvclose": {
-    "nonlinear": {
-      ".ims": "real value defining the dependent-variable (for example, head) change criterion for convergence of the outer (nonlinear) iterations, in units of the dependent-variable (for example, length for head). When the maximum absolute value of the dependent-variable change at all nodes during an iteration is less than or equal to OUTER\\_DVCLOSE, iteration stops. Commonly, OUTER\\_DVCLOSE equals 0.01. The keyword, OUTER\\_HCLOSE can be still be specified instead of OUTER\\_DVCLOSE for backward compatibility with previous versions of MODFLOW 6 but eventually OUTER\\_HCLOSE will be deprecated and specification of OUTER\\_HCLOSE will cause MODFLOW 6 to terminate with an error."
-    }
-  },
-  "outer_rclosebnd": {
-    "nonlinear": {
-      ".ims": "real value defining the residual tolerance for convergence of model packages that solve a separate equation not solved by the IMS linear solver. This value represents the maximum allowable residual between successive outer iterations at any single model package element. An example of a model package that would use OUTER\\_RCLOSEBND to evaluate convergence is the SFR package which solves a continuity equation for each reach.  The OUTER\\_RCLOSEBND option is deprecated and has no effect on simulation results as of version 6.1.1.  The keyword, OUTER\\_RCLOSEBND can be still be specified for backward compatibility with previous versions of MODFLOW 6 but eventually specification of OUTER\\_RCLOSEBND will cause MODFLOW 6 to terminate with an error."
-    }
-  },
-  "outer_maximum": {
-    "nonlinear": {
-      ".ims": "integer value defining the maximum number of outer (nonlinear) iterations -- that is, calls to the solution routine. For a linear problem OUTER\\_MAXIMUM should be 1."
-    }
-  },
-  "under_relaxation_gamma": {
-    "nonlinear": {
-      ".ims": "real value defining either the relaxation factor for the SIMPLE scheme or the history or memory term factor of the Cooley and delta-bar-delta algorithms. For the SIMPLE scheme, a value of one indicates that there is no under-relaxation and the full head change is applied.  This value can be gradually reduced from one as a way to improve convergence; for well behaved problems, using a value less than one can increase the number of outer iterations required for convergence and needlessly increase run times.  UNDER\\_RELAXATION\\_GAMMA must be greater than zero for the SIMPLE scheme or the program will terminate with an error.  For the Cooley and delta-bar-delta schemes, UNDER\\_RELAXATION\\_GAMMA is a memory term that can range between zero and one. When UNDER\\_RELAXATION\\_GAMMA is zero, only the most recent history (previous iteration value) is maintained. As UNDER\\_RELAXATION\\_GAMMA is increased, past history of iteration changes has greater influence on the memory term. The memory term is maintained as an exponential average of past changes. Retaining some past history can overcome granular behavior in the calculated function surface and therefore helps to overcome cyclic patterns of non-convergence. The value usually ranges from 0.1 to 0.3; a value of 0.2 works well for most problems. UNDER\\_RELAXATION\\_GAMMA only needs to be specified if UNDER\\_RELAXATION is not NONE."
-    }
-  },
-  "under_relaxation_theta": {
-    "nonlinear": {
-      ".ims": "real value defining the reduction factor for the learning rate (under-relaxation term) of the delta-bar-delta algorithm. The value of UNDER\\_RELAXATION\\_THETA is between zero and one. If the change in the dependent-variable (for example, head) is of opposite sign to that of the previous iteration, the under-relaxation term is reduced by a factor of UNDER\\_RELAXATION\\_THETA. The value usually ranges from 0.3 to 0.9; a value of 0.7 works well for most problems. UNDER\\_RELAXATION\\_THETA only needs to be specified if UNDER\\_RELAXATION is DBD."
-    }
-  },
-  "under_relaxation_kappa": {
-    "nonlinear": {
-      ".ims": "real value defining the increment for the learning rate (under-relaxation term) of the delta-bar-delta algorithm. The value of UNDER\\_RELAXATION\\_kappa is between zero and one. If the change in the dependent-variable (for example, head) is of the same sign to that of the previous iteration, the under-relaxation term is increased by an increment of UNDER\\_RELAXATION\\_KAPPA. The value usually ranges from 0.03 to 0.3; a value of 0.1 works well for most problems. UNDER\\_RELAXATION\\_KAPPA only needs to be specified if UNDER\\_RELAXATION is DBD."
-    }
-  },
-  "under_relaxation_momentum": {
-    "nonlinear": {
-      ".ims": "real value defining the fraction of past history changes that is added as a momentum term to the step change for a nonlinear iteration. The value of UNDER\\_RELAXATION\\_MOMENTUM is between zero and one. A large momentum term should only be used when small learning rates are expected. Small amounts of the momentum term help convergence. The value usually ranges from 0.0001 to 0.1; a value of 0.001 works well for most problems. UNDER\\_RELAXATION\\_MOMENTUM only needs to be specified if UNDER\\_RELAXATION is DBD."
-    }
-  },
-  "backtracking_number": {
-    "nonlinear": {
-      ".ims": "integer value defining the maximum number of backtracking iterations allowed for residual reduction computations. If BACKTRACKING\\_NUMBER = 0 then the backtracking iterations are omitted. The value usually ranges from 2 to 20; a value of 10 works well for most problems."
-    }
-  },
-  "backtracking_tolerance": {
-    "nonlinear": {
-      ".ims": "real value defining the tolerance for residual change that is allowed for residual reduction computations. BACKTRACKING\\_TOLERANCE should not be less than one to avoid getting stuck in local minima. A large value serves to check for extreme residual increases, while a low value serves to control step size more severely. The value usually ranges from 1.0 to 10$^6$; a value of 10$^4$ works well for most problems but lower values like 1.1 may be required for harder problems. BACKTRACKING\\_TOLERANCE only needs to be specified if BACKTRACKING\\_NUMBER is greater than zero."
-    }
-  },
-  "backtracking_reduction_factor": {
-    "nonlinear": {
-      ".ims": "real value defining the reduction in step size used for residual reduction computations. The value of BACKTRACKING\\_REDUCTION\\_FACTOR is between zero and one. The value usually ranges from 0.1 to 0.3; a value of 0.2 works well for most problems. BACKTRACKING\\_REDUCTION\\_FACTOR only needs to be specified if BACKTRACKING\\_NUMBER is greater than zero."
-    }
-  },
-  "backtracking_residual_limit": {
-    "nonlinear": {
-      ".ims": "real value defining the limit to which the residual is reduced with backtracking. If the residual is smaller than BACKTRACKING\\_RESIDUAL\\_LIMIT, then further backtracking is not performed. A value of 100 is suitable for large problems and residual reduction to smaller values may only slow down computations. BACKTRACKING\\_RESIDUAL\\_LIMIT only needs to be specified if BACKTRACKING\\_NUMBER is greater than zero."
-    }
-  },
-  "inner_maximum": {
-    "linear": {
-      ".ims": "integer value defining the maximum number of inner (linear) iterations. The number typically depends on the characteristics of the matrix solution scheme being used. For nonlinear problems, INNER\\_MAXIMUM usually ranges from 60 to 600; a value of 100 will be sufficient for most linear problems."
-    }
-  },
-  "inner_hclose": {
-    "linear": {
-      ".ims": "real value defining the head change criterion for convergence of the inner (linear) iterations, in units of length. When the maximum absolute value of the head change at all nodes during an iteration is less than or equal to INNER\\_HCLOSE, the matrix solver assumes convergence. Commonly, INNER\\_HCLOSE is set equal to or an order of magnitude less than the OUTER\\_HCLOSE value specified for the NONLINEAR block.  The INNER\\_HCLOSE keyword has been deprecated in favor of the more general INNER\\_DVCLOSE (for dependent variable), however either one can be specified in order to maintain backward compatibility."
-    }
-  },
-  "inner_dvclose": {
-    "linear": {
-      ".ims": "real value defining the dependent-variable (for example, head) change criterion for convergence of the inner (linear) iterations, in units of the dependent-variable (for example, length for head). When the maximum absolute value of the dependent-variable change at all nodes during an iteration is less than or equal to INNER\\_DVCLOSE, the matrix solver assumes convergence. Commonly, INNER\\_DVCLOSE is set equal to or an order of magnitude less than the OUTER\\_DVCLOSE value specified for the NONLINEAR block. The keyword, INNER\\_HCLOSE can be still be specified instead of INNER\\_DVCLOSE for backward compatibility with previous versions of MODFLOW 6 but eventually INNER\\_HCLOSE will be deprecated and specification of INNER\\_HCLOSE will cause MODFLOW 6 to terminate with an error."
-    }
-  },
-  "inner_rclose": {
-    "linear": {
-      ".ims": "real value that defines the flow residual tolerance for convergence of the IMS linear solver and specific flow residual criteria used. This value represents the maximum allowable residual at any single node.  Value is in units of length cubed per time, and must be consistent with \\mf length and time units. Usually a value of $1.0 \\times 10^{-1}$ is sufficient for the flow-residual criteria when meters and seconds are the defined \\mf length and time."
+      ".dis": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.",
+      ".dis2d": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.",
+      ".disu": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.",
+      ".disv": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.",
+      ".disv1d": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.",
+      ".disv2d": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''."
     }
   },
   "linear_acceleration": {
@@ -1684,80 +1174,39 @@
       ".ims": "a keyword that defines the linear acceleration method used by the default IMS linear solvers.  CG - preconditioned conjugate gradient method.  BICGSTAB - preconditioned bi-conjugate gradient stabilized method."
     }
   },
-  "relaxation_factor": {
-    "linear": {
-      ".ims": "optional real value that defines the relaxation factor used by the incomplete LU factorization preconditioners (MILU(0) and MILUT). RELAXATION\\_FACTOR is unitless and should be greater than or equal to 0.0 and less than or equal to 1.0. RELAXATION\\_FACTOR values of about 1.0 are commonly used, and experience suggests that convergence can be optimized in some cases with relax values of 0.97. A RELAXATION\\_FACTOR value of 0.0 will result in either ILU(0) or ILUT preconditioning (depending on the value specified for PRECONDITIONER\\_LEVELS and/or PRECONDITIONER\\_DROP\\_TOLERANCE). By default,  RELAXATION\\_FACTOR is zero."
-    }
-  },
-  "preconditioner_levels": {
-    "linear": {
-      ".ims": "optional integer value defining the level of fill for ILU decomposition used in the ILUT and MILUT preconditioners. Higher levels of fill provide more robustness but also require more memory. For optimal performance, it is suggested that a large level of fill be applied (7 or 8) with use of a drop tolerance. Specification of a PRECONDITIONER\\_LEVELS value greater than zero results in use of the ILUT preconditioner. By default, PRECONDITIONER\\_LEVELS is zero and the zero-fill incomplete LU factorization preconditioners (ILU(0) and MILU(0)) are used."
-    }
-  },
-  "preconditioner_drop_tolerance": {
-    "linear": {
-      ".ims": "optional real value that defines the drop tolerance used to drop preconditioner terms based on the magnitude of matrix entries in the ILUT and MILUT preconditioners. A value of $10^{-4}$ works well for most problems. By default, PRECONDITIONER\\_DROP\\_TOLERANCE is zero and the zero-fill incomplete LU factorization preconditioners (ILU(0) and MILU(0)) are used."
-    }
-  },
-  "number_orthogonalizations": {
-    "linear": {
-      ".ims": "optional integer value defining the interval used to explicitly recalculate the residual of the flow equation using the solver coefficient matrix, the latest dependent-variable (for example, head) estimates, and the right hand side. For problems that benefit from explicit recalculation of the residual, a number between 4 and 10 is appropriate. By default, NUMBER\\_ORTHOGONALIZATIONS is zero."
-    }
-  },
-  "scaling_method": {
-    "linear": {
-      ".ims": "an optional keyword that defines the matrix scaling approach used. By default, matrix scaling is not applied.  NONE - no matrix scaling applied.  DIAGONAL - symmetric matrix scaling using the POLCG preconditioner scaling method in Hill (1992).  L2NORM - symmetric matrix scaling using the L2 norm."
-    }
-  },
-  "reordering_method": {
-    "linear": {
-      ".ims": "an optional keyword that defines the matrix reordering approach used. By default, matrix reordering is not applied.  NONE - original ordering.  RCM - reverse Cuthill McKee ordering.  MD - minimum degree ordering."
-    }
-  },
-  "storagecoefficient": {
+  "linear_gwet": {
     "options": {
-      ".sto": "keyword to indicate that the SS array is read as storage coefficient rather than specific storage."
+      ".uzf": "keyword specifying that groundwater ET will be simulated using the original ET formulation of MODFLOW-2005."
     }
   },
-  "ss_confined_only": {
+  "list": {
     "options": {
-      ".sto": "keyword to indicate that compressible storage is only calculated for a convertible cell (ICONVERT>0) when the cell is under confined conditions (head greater than or equal to the top of the cell). This option has no effect on cells that are marked as being always confined (ICONVERT=0).  This option is identical to the approach used to calculate storage changes under confined conditions in MODFLOW-2005."
+      ".nam": "is name of the listing file to create for this GWE model.  If not specified, then the name of the list file will be the basename of the GWE model name file and the ``.lst'' extension.  For example, if the GWE name file is called ``my.model.nam'' then the list file will be called ``my.model.lst''."
     }
   },
-  "tvs6": {
+  "local_z": {
     "options": {
-      ".sto": "keyword to specify that record corresponds to a time-varying storage (TVS) file.  The behavior of TVS and a description of the input file is provided separately."
+      ".prp": "indicates that ``zrpt'' defines the local z coordinate of the release point within the cell, with value of 0 at the bottom and 1 at the top of the cell.  If the cell is partially saturated at release time, the top of the cell is considered to be the water table elevation (the head in the cell) rather than the top defined by the user."
     }
   },
-  "dev_oldstorageformulation": {
-    "options": {
-      ".sto": "development option flag for old storage formulation"
-    }
-  },
-  "iconvert": {
+  "longitude": {
     "griddata": {
-      ".sto": "is a flag for each cell that specifies whether or not a cell is convertible for the storage calculation. 0 indicates confined storage is used. $>$0 indicates confined storage is used when head is above cell top and a mixed formulation of unconfined and confined storage is used when head is below cell top."
+      ".ncf": "cell center longitude."
     }
   },
-  "ss": {
-    "griddata": {
-      ".sto": "is specific storage (or the storage coefficient if STORAGECOEFFICIENT is specified as an option). Specific storage values must be greater than or equal to 0. If the CSUB Package is included in the GWF model, specific storage must be zero for every cell."
-    },
+  "manning": {
     "period": {
-      ".tvs": "is the new value to be assigned as the cell's specific storage (or storage coefficient if the STORAGECOEFFICIENT STO package option is specified) from the start of the specified stress period, as per SS in the STO package.  Specific storage values must be greater than or equal to 0.  If the OPTIONS block includes a TS6 entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+      ".sfr": "real or character value that defines the Manning's roughness coefficient for the reach. MANNING must be greater than zero.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
     }
   },
-  "sy": {
+  "manningsn": {
     "griddata": {
-      ".sto": "is specific yield. Specific yield values must be greater than or equal to 0. Specific yield does not have to be specified if there are no convertible cells (ICONVERT=0 in every cell)."
-    },
-    "period": {
-      ".tvs": "is the new value to be assigned as the cell's specific yield from the start of the specified stress period, as per SY in the STO package.  Specific yield values must be greater than or equal to 0.  If the OPTIONS block includes a TS6 entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+      ".dfw": "mannings roughness coefficient"
     }
   },
-  "auxdepthname": {
+  "maw_flow_reduce_csv": {
     "options": {
-      ".drn": "name of a variable listed in AUXILIARY that defines the depth at which drainage discharge will be scaled. If a positive value is specified for the AUXDEPTHNAME AUXILIARY variable, then ELEV is the elevation at which the drain starts to discharge and ELEV + DDRN (assuming DDRN is the AUXDEPTHNAME variable) is the elevation when the drain conductance (COND) scaling factor is 1. If a negative drainage depth value is specified for DDRN, then ELEV + DDRN is the elevation at which the drain starts to discharge and ELEV is the elevation when the conductance (COND) scaling factor is 1. A linear- or cubic-scaling is used to scale the drain conductance (COND) when the Standard or Newton-Raphson Formulation is used, respectively.  This discharge scaling option is described in more detail in Chapter 3 of the Supplemental Technical Information."
+      ".maw": "keyword to specify that record corresponds to the output option in which a new record is written for each multi-aquifer well and for each time step in which the user-requested extraction or injection rate is reduced by the program."
     }
   },
   "maxats": {
@@ -1765,90 +1214,41 @@
       ".ats": "is the number of records in the subsequent perioddata block that will be used for adaptive time stepping."
     }
   },
-  "gwfmodelname1": {
-    "options": {
-      ".gwegwe": "keyword to specify name of first corresponding GWF Model.  In the simulation name file, the GWE6-GWE6 entry contains names for GWE Models (exgmnamea and exgmnameb).  The GWE Model with the name exgmnamea must correspond to the GWF Model with the name gwfmodelname1.",
-      ".gwtgwt": "keyword to specify name of first corresponding GWF Model.  In the simulation name file, the GWT6-GWT6 entry contains names for GWT Models (exgmnamea and exgmnameb).  The GWT Model with the name exgmnamea must correspond to the GWF Model with the name gwfmodelname1."
-    }
-  },
-  "gwfmodelname2": {
-    "options": {
-      ".gwegwe": "keyword to specify name of second corresponding GWF Model.  In the simulation name file, the GWE6-GWE6 entry contains names for GWE Models (exgmnamea and exgmnameb).  The GWE Model with the name exgmnameb must correspond to the GWF Model with the name gwfmodelname2.",
-      ".gwtgwt": "keyword to specify name of second corresponding GWF Model.  In the simulation name file, the GWT6-GWT6 entry contains names for GWT Models (exgmnamea and exgmnameb).  The GWT Model with the name exgmnameb must correspond to the GWF Model with the name gwfmodelname2."
-    }
-  },
-  "adv_scheme": {
-    "options": {
-      ".gwegwe": "scheme used to solve the advection term.  Can be upstream, central, or TVD.  If not specified, upstream weighting is the default weighting scheme.",
-      ".gwtgwt": "scheme used to solve the advection term.  Can be upstream, central, or TVD.  If not specified, upstream weighting is the default weighting scheme."
-    }
-  },
-  "cnd_xt3d_off": {
-    "options": {
-      ".gwegwe": "deactivate the xt3d method for the dispersive flux and use the faster and less accurate approximation for this exchange."
-    }
-  },
-  "cnd_xt3d_rhs": {
-    "options": {
-      ".gwegwe": "add xt3d dispersion terms to right-hand side, when possible, for this exchange."
-    }
-  },
-  "mve6": {
-    "options": {
-      ".gwegwe": "keyword to specify that record corresponds to an energy transport mover file."
-    }
-  },
-  "dev_interfacemodel_on": {
-    "options": {
-      ".gwegwe": "activates the interface model mechanism for calculating the coefficients at (and possibly near) the exchange. This keyword should only be used for development purposes.",
-      ".gwtgwt": "activates the interface model mechanism for calculating the coefficients at (and possibly near) the exchange. This keyword should only be used for development purposes.",
-      ".gwfgwf": "activates the interface model mechanism for calculating the coefficients at (and possibly near) the exchange. This keyword should only be used for development purposes."
-    }
-  },
-  "nexg": {
+  "maxbound": {
     "dimensions": {
-      ".gwegwe": "keyword and integer value specifying the number of GWE-GWE exchanges.",
-      ".olfgwf": "keyword and integer value specifying the number of SWF-GWF exchanges.",
-      ".gwtgwt": "keyword and integer value specifying the number of GWT-GWT exchanges.",
-      ".gwfgwf": "keyword and integer value specifying the number of GWF-GWF exchanges.",
-      ".chfgwf": "keyword and integer value specifying the number of SWF-GWF exchanges."
+      ".api": "integer value specifying the maximum number of api boundary cells that will be specified for use during any stress period.",
+      ".cdb": "integer value specifying the maximum number of critical depth boundary cells that will be specified for use during any stress period.",
+      ".chd": "integer value specifying the maximum number of constant-head cells that will be specified for use during any stress period.",
+      ".cnc": "integer value specifying the maximum number of constant concentrations cells that will be specified for use during any stress period.",
+      ".ctp": "integer value specifying the maximum number of constant temperature cells that will be specified for use during any stress period.",
+      ".drn": "integer value specifying the maximum number of drains cells that will be specified for use during any stress period.",
+      ".esl": "integer value specifying the maximum number of source cells that will be specified for use during any stress period.",
+      ".evp": "integer value specifying the maximum number of evaporation cells cells that will be specified for use during any stress period.",
+      ".evt": "integer value specifying the maximum number of evapotranspiration cells cells that will be specified for use during any stress period.",
+      ".flw": "integer value specifying the maximum number of inflow cells that will be specified for use during any stress period.",
+      ".ghb": "integer value specifying the maximum number of general-head boundary cells that will be specified for use during any stress period.",
+      ".pcp": "integer value specifying the maximum number of precipitation cells cells that will be specified for use during any stress period.",
+      ".rch": "integer value specifying the maximum number of recharge cells cells that will be specified for use during any stress period.",
+      ".riv": "integer value specifying the maximum number of rivers cells that will be specified for use during any stress period.",
+      ".spc": "integer value specifying the maximum number of spc cells that will be specified for use during any stress period.",
+      ".src": "integer value specifying the maximum number of sources cells that will be specified for use during any stress period.",
+      ".wel": "integer value specifying the maximum number of wells cells that will be specified for use during any stress period.",
+      ".zdg": "integer value specifying the maximum number of zero-depth-gradient boundary cells that will be specified for use during any stress period."
     }
   },
-  "fixed_conductance": {
+  "maxerrors": {
     "options": {
-      ".olfgwf": "keyword to indicate that the product of the bedleak and cfact input variables in the exchangedata block represents conductance.  This conductance is fixed and does not change as a function of head in the surface water and groundwater models.",
-      ".chfgwf": "keyword to indicate that the product of the bedleak and cfact input variables in the exchangedata block represents conductance.  This conductance is fixed and does not change as a function of head in the surface water and groundwater models."
+      ".nam": "maximum number of errors that will be stored and printed."
     }
   },
-  "auto_flow_reduce": {
-    "options": {
-      ".wel": "keyword and real value that defines the fraction of the cell thickness used as an interval for smoothly adjusting negative pumping rates to 0 in cells with head values less than or equal to the bottom of the cell. Negative pumping rates are adjusted to 0 or a smaller negative value when the head in the cell is equal to or less than the calculated interval above the cell bottom. AUTO\\_FLOW\\_REDUCE is set to 0.1 if the specified value is less than or equal to zero. By default, negative pumping rates are not reduced during a simulation.  This AUTO\\_FLOW\\_REDUCE option only applies to wells in model cells that are marked as ``convertible'' (ICELLTYPE /= 0) in the Node Property Flow (NPF) input file. Reduction in flow will not occur for wells in cells marked as confined (ICELLTYPE = 0)."
-    }
-  },
-  "auto_flow_reduce_csv": {
-    "options": {
-      ".wel": "keyword to specify that record corresponds to the AUTO\\_FLOW\\_REDUCE output option in which a new record is written for each well and for each time step in which the user-requested extraction rate is reduced by the program."
-    }
-  },
-  "nsections": {
+  "maxhfb": {
     "dimensions": {
-      ".cxs": "integer value specifying the number of cross sections that will be defined.  There must be NSECTIONS entries in the PACKAGEDATA block."
+      ".hfb": "integer value specifying the maximum number of horizontal flow barriers that will be entered in this input file.  The value of MAXHFB is used to allocate memory for the horizontal flow barriers."
     }
   },
-  "npoints": {
-    "dimensions": {
-      ".cxs": "integer value specifying the total number of cross-section points defined for all reaches.  There must be NPOINTS entries in the CROSSSECTIONDATA block."
-    }
-  },
-  "print_stage": {
+  "maximum_depth_change": {
     "options": {
-      ".lak": "keyword to indicate that the list of lake stages will be printed to the listing file for every stress period in which ``HEAD PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_STAGE is specified, then stages are printed for the last time step of each stress period.",
-      ".sfr": "keyword to indicate that the list of stream reach stages will be printed to the listing file for every stress period in which ``HEAD PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_STAGE is specified, then stages are printed for the last time step of each stress period."
-    }
-  },
-  "surfdep": {
-    "options": {
-      ".lak": "real value that defines the surface depression depth for VERTICAL lake-GWF connections. If specified, SURFDEP must be greater than or equal to zero. If SURFDEP is not specified, a default value of zero is used for all vertical lake-GWF connections."
+      ".sfr": "real value that defines the depth closure tolerance. By default, MAXIMUM\\_DEPTH\\_CHANGE is equal to $1 \\times 10^{-5}$. The MAXIMUM\\_STAGE\\_CHANGE would only need to be increased or decreased from the default value if the water budget error for one or more reach is too small or too large, respectively."
     }
   },
   "maximum_iterations": {
@@ -1857,402 +1257,14 @@
       ".sfr": "integer value that defines the maximum number of Streamflow Routing Newton-Raphson iterations allowed for a reach. By default, MAXIMUM\\_ITERATIONS is equal to 100. MAXIMUM\\_ITERATIONS would only need to be increased from the default value if one or more reach in a simulation has a large water budget error."
     }
   },
+  "maximum_picard_iterations": {
+    "options": {
+      ".sfr": "integer value that defines the maximum number of Streamflow Routing picard iterations allowed when solving for reach stages and flows as part of the GWF formulate step. Picard iterations are used to minimize differences in SFR package results between subsequent GWF picard (non-linear) iterations as a result of non-optimal reach numbering. If reaches are numbered in order, from upstream to downstream, MAXIMUM\\_PICARD\\_ITERATIONS can be set to 1 to reduce model run time. By default, MAXIMUM\\_PICARD\\_ITERATIONS is equal to 100."
+    }
+  },
   "maximum_stage_change": {
     "options": {
       ".lak": "real value that defines the lake stage closure tolerance. By default, MAXIMUM\\_STAGE\\_CHANGE is equal to $1 \\times 10^{-5}$. The MAXIMUM\\_STAGE\\_CHANGE would only need to be increased or decreased from the default value if the water budget error for one or more lakes is too small or too large, respectively."
-    }
-  },
-  "time_conversion": {
-    "options": {
-      ".lak": "real value that is used to convert user-specified Manning's roughness coefficients or gravitational acceleration used to calculate outlet flows from seconds to model time units. TIME\\_CONVERSION should be set to 1.0, 60.0, 3,600.0, 86,400.0, and 31,557,600.0 when using time units (TIME\\_UNITS) of seconds, minutes, hours, days, or years in the simulation, respectively. CONVTIME does not need to be specified if no lake outlets are specified or TIME\\_UNITS are seconds.",
-      ".dfw": "real value that is used to convert user-specified Manning's roughness coefficients from seconds to model time units. TIME\\_CONVERSION should be set to 1.0, 60.0, 3,600.0, 86,400.0, and 31,557,600.0 when using time units (TIME\\_UNITS) of seconds, minutes, hours, days, or years in the simulation, respectively. TIME\\_CONVERSION does not need to be specified if TIME\\_UNITS are seconds.",
-      ".sfr": "real value that is used to convert user-specified Manning's roughness coefficients from seconds to model time units. TIME\\_CONVERSION should be set to 1.0, 60.0, 3,600.0, 86,400.0, and 31,557,600.0 when using time units (TIME\\_UNITS) of seconds, minutes, hours, days, or years in the simulation, respectively. TIME\\_CONVERSION does not need to be specified if TIME\\_UNITS are seconds."
-    }
-  },
-  "length_conversion": {
-    "options": {
-      ".lak": "real value that is used to convert outlet user-specified Manning's roughness coefficients or gravitational acceleration used to calculate outlet flows from meters to model length units. LENGTH\\_CONVERSION should be set to 3.28081, 1.0, and 100.0 when using length units (LENGTH\\_UNITS) of feet, meters, or centimeters in the simulation, respectively. LENGTH\\_CONVERSION does not need to be specified if no lake outlets are specified or LENGTH\\_UNITS are meters.",
-      ".dfw": "real value that is used to convert user-specified Manning's roughness coefficients from meters to model length units. LENGTH\\_CONVERSION should be set to 3.28081, 1.0, and 100.0 when using length units (LENGTH\\_UNITS) of feet, meters, or centimeters in the simulation, respectively. LENGTH\\_CONVERSION does not need to be specified if LENGTH\\_UNITS are meters.",
-      ".sfr": "real value that is used to convert user-specified Manning's roughness coefficients from meters to model length units. LENGTH\\_CONVERSION should be set to 3.28081, 1.0, and 100.0 when using length units (LENGTH\\_UNITS) of feet, meters, or centimeters in the simulation, respectively. LENGTH\\_CONVERSION does not need to be specified if LENGTH\\_UNITS are meters."
-    }
-  },
-  "nlakes": {
-    "dimensions": {
-      ".lak": "value specifying the number of lakes that will be simulated for all stress periods."
-    }
-  },
-  "noutlets": {
-    "dimensions": {
-      ".lak": "value specifying the number of outlets that will be simulated for all stress periods. If NOUTLETS is not specified, a default value of zero is used."
-    }
-  },
-  "ntables": {
-    "dimensions": {
-      ".lak": "value specifying the number of lakes tables that will be used to define the lake stage, volume relation, and surface area. If NTABLES is not specified, a default value of zero is used."
-    }
-  },
-  "tab6": {
-    "tables": {
-      ".lak": "keyword to specify that record corresponds to a table file."
-    },
-    "crosssections": {
-      ".sfr": "keyword to specify that record corresponds to a cross-section table file."
-    },
-    "period": {
-      ".sfr": "keyword to specify that record corresponds to a cross-section table file."
-    }
-  },
-  "withdrawal": {
-    "period": {
-      ".lak": "real or character value that defines the maximum withdrawal rate $(L^3 T^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
-    }
-  },
-  "rate": {
-    "period": {
-      ".lak": "real or character value that defines the extraction rate for the lake outflow. A positive value indicates inflow and a negative value indicates outflow from the lake. RATE only applies to outlets associated with active lakes (STATUS is ACTIVE). A specified RATE is only applied if COUTTYPE for the OUTLETNO is SPECIFIED. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, the RATE for each SPECIFIED lake outlet is zero.",
-      ".evta": "is the maximum ET flux rate ($LT^{-1}$).",
-      ".mwt": "real or character value that defines the injection solute concentration $(ML^{-3})$ for the well. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      ".maw": "is the volumetric pumping rate for the multi-aquifer well. A positive value indicates recharge and a negative value indicates discharge (pumping). RATE only applies to active (STATUS is ACTIVE) multi-aquifer wells. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, the RATE for each multi-aquifer well is zero.",
-      ".mwe": "real or character value that defines the injection temperature $(e.g.,\\:^{\\circ}C\\:or\\:^{\\circ}F)$ for the well. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
-    }
-  },
-  "invert": {
-    "period": {
-      ".lak": "real or character value that defines the invert elevation for the lake outlet. A specified INVERT value is only used for active lakes if COUTTYPE for lake outlet OUTLETNO is not SPECIFIED. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
-    }
-  },
-  "rough": {
-    "period": {
-      ".lak": "real value that defines the roughness coefficient for the lake outlet. Any value can be specified if COUTTYPE is not MANNING. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
-    }
-  },
-  "slope": {
-    "period": {
-      ".lak": "real or character value that defines the bed slope for the lake outlet. A specified SLOPE value is only used for active lakes if COUTTYPE for lake outlet OUTLETNO is MANNING. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
-    }
-  },
-  "ext-inflow": {
-    "period": {
-      ".lkt": "real or character value that defines the concentration of external inflow $(ML^{-3})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      ".lke": "real or character value that defines the temperature of external inflow for the lake.  Users are free to use whatever temperature scale they want, which might include negative temperatures.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
-    }
-  },
-  "dsp_xt3d_off": {
-    "options": {
-      ".gwtgwt": "deactivate the xt3d method for the dispersive flux and use the faster and less accurate approximation for this exchange."
-    }
-  },
-  "dsp_xt3d_rhs": {
-    "options": {
-      ".gwtgwt": "add xt3d dispersion terms to right-hand side, when possible, for this exchange."
-    }
-  },
-  "mvt6": {
-    "options": {
-      ".gwtgwt": "keyword to specify that record corresponds to a transport mover file."
-    }
-  },
-  "names": {
-    "attributes": {
-      ".ts": "xxx"
-    }
-  },
-  "methods": {
-    "attributes": {
-      ".ts": "xxx"
-    }
-  },
-  "sfacs": {
-    "attributes": {
-      ".ts": "xxx"
-    }
-  },
-  "timeseries": {
-    "timeseries": {
-      ".ts": "xxx"
-    }
-  },
-  "wkt": {
-    "options": {
-      ".ncf": "is the coordinate reference system (CRS) well-known text (WKT) string."
-    }
-  },
-  "deflate": {
-    "options": {
-      ".ncf": "is the variable deflate level (0=min, 9=max) in the netcdf file. Defining this parameter activates per-variable compression at the level specified."
-    }
-  },
-  "shuffle": {
-    "options": {
-      ".ncf": "is the keyword used to turn on the netcdf variable shuffle filter when the deflate option is also set. The shuffle filter has the effect of storing the first byte of all of a variable's values in a chunk contiguously, followed by all the second bytes, etc. This can be an optimization for compression with certain types of data."
-    }
-  },
-  "chunk_time": {
-    "options": {
-      ".ncf": "is the keyword used to provide a data chunk size for the time dimension in a NETCDF\\_MESH2D or NETCDF\\_STRUCTURED output file. Must be used in combination with the the chunk\\_face parameter (NETCDF\\_MESH2D) or the chunk\\_z, chunk\\_y, and chunk\\_x parameter set (NETCDF\\_STRUCTURED) to have an effect."
-    }
-  },
-  "chunk_face": {
-    "options": {
-      ".ncf": "is the keyword used to provide a data chunk size for the face dimension in a NETCDF\\_MESH2D output file. Must be used in combination with the the chunk\\_time parameter to have an effect."
-    }
-  },
-  "chunk_z": {
-    "options": {
-      ".ncf": "is the keyword used to provide a data chunk size for the z dimension in a NETCDF\\_STRUCTURED output file. Must be used in combination with the the chunk\\_time, chunk\\_x and chunk\\_y parameter set to have an effect."
-    }
-  },
-  "chunk_y": {
-    "options": {
-      ".ncf": "is the keyword used to provide a data chunk size for the y dimension in a NETCDF\\_STRUCTURED output file. Must be used in combination with the the chunk\\_time, chunk\\_x and chunk\\_z parameter set to have an effect."
-    }
-  },
-  "chunk_x": {
-    "options": {
-      ".ncf": "is the keyword used to provide a data chunk size for the x dimension in a NETCDF\\_STRUCTURED output file. Must be used in combination with the the chunk\\_time, chunk\\_y and chunk\\_z parameter set to have an effect."
-    }
-  },
-  "modflow6_attr_off": {
-    "options": {
-      ".ncf": "is the keyword used to turn off internal input tagging in the model netcdf file. Tagging adds internal modflow 6 attribute(s) to variables which facilitate identification. Currently this applies to gridded arrays."
-    }
-  },
-  "latitude": {
-    "griddata": {
-      ".ncf": "cell center latitude."
-    }
-  },
-  "longitude": {
-    "griddata": {
-      ".ncf": "cell center longitude."
-    }
-  },
-  "fixed_cell": {
-    "options": {
-      ".evta": "indicates that evapotranspiration will not be reassigned to a cell underlying the cell specified in the list if the specified cell is inactive.",
-      ".rcha": "indicates that recharge will not be reassigned to a cell underlying the cell specified in the list if the specified cell is inactive.",
-      ".rch": "indicates that recharge will not be reassigned to a cell underlying the cell specified in the list if the specified cell is inactive.",
-      ".evt": "indicates that evapotranspiration will not be reassigned to a cell underlying the cell specified in the list if the specified cell is inactive."
-    }
-  },
-  "ievt": {
-    "period": {
-      ".evta": "IEVT is the layer number that defines the layer in each vertical column where evapotranspiration is applied. If IEVT is omitted, evapotranspiration by default is applied to cells in layer 1.  If IEVT is specified, it must be specified as the first variable in the PERIOD block or MODFLOW will terminate with an error."
-    }
-  },
-  "surface": {
-    "period": {
-      ".evta": "is the elevation of the ET surface ($L$)."
-    }
-  },
-  "depth": {
-    "period": {
-      ".evta": "is the ET extinction depth ($L$)."
-    }
-  },
-  "aux": {
-    "period": {
-      ".evta": "is an array of values for auxiliary variable AUX(IAUX), where iaux is a value from 1 to NAUX, and AUX(IAUX) must be listed as part of the auxiliary variables.  A separate array can be specified for each auxiliary variable.  If an array is not specified for an auxiliary variable, then a value of zero is assigned.  If the value specified here for the auxiliary variable is the same as auxmultname, then the evapotranspiration rate will be multiplied by this array.",
-      ".rcha": "is an array of values for auxiliary variable aux(iaux), where iaux is a value from 1 to naux, and aux(iaux) must be listed as part of the auxiliary variables.  A separate array can be specified for each auxiliary variable.  If an array is not specified for an auxiliary variable, then a value of zero is assigned.  If the value specified here for the auxiliary variable is the same as auxmultname, then the recharge array will be multiplied by this array."
-    }
-  },
-  "track_release": {
-    "options": {
-      ".oc": "keyword to indicate that particle tracking output is to be written when a particle is released"
-    }
-  },
-  "track_exit": {
-    "options": {
-      ".oc": "keyword to indicate that particle tracking output is to be written when a particle exits a feature (a model, cell, or subcell)"
-    }
-  },
-  "track_timestep": {
-    "options": {
-      ".oc": "keyword to indicate that particle tracking output is to be written at the end of each time step"
-    }
-  },
-  "track_terminate": {
-    "options": {
-      ".oc": "keyword to indicate that particle tracking output is to be written when a particle terminates for any reason"
-    }
-  },
-  "track_weaksink": {
-    "options": {
-      ".oc": "keyword to indicate that particle tracking output is to be written when a particle exits a weak sink (a cell which removes some but not all inflow from adjacent cells)"
-    }
-  },
-  "track_usertime": {
-    "options": {
-      ".oc": "keyword to indicate that particle tracking output is to be written at user-specified times, provided as double precision values in the TRACKTIMES block."
-    }
-  },
-  "ntracktimes": {
-    "dimensions": {
-      ".oc": "is the number of user-specified particle tracking times in the TRACKTIMES block."
-    }
-  },
-  "irch": {
-    "period": {
-      ".rcha": "IRCH is the layer number that defines the layer in each vertical column where recharge is applied. If IRCH is omitted, recharge by default is applied to cells in layer 1.  IRCH can only be used if READASARRAYS is specified in the OPTIONS block.  If IRCH is specified, it must be specified as the first variable in the PERIOD block or MODFLOW will terminate with an error."
-    }
-  },
-  "recharge": {
-    "period": {
-      ".rcha": "is the recharge flux rate ($LT^{-1}$).  This rate is multiplied inside the program by the surface area of the cell to calculate the volumetric recharge rate. The recharge array may be defined by a time-array series (see the ``Using Time-Array Series in a Package'' section)."
-    }
-  },
-  "first_order_decay": {
-    "options": {
-      ".mst": "is a text keyword to indicate that first-order decay will occur.  Use of this keyword requires that DECAY and DECAY\\_SORBED (if sorption is active) are specified in the GRIDDATA block.",
-      ".ist": "is a text keyword to indicate that first-order decay will occur.  Use of this keyword requires that DECAY and DECAY\\_SORBED (if sorption is active) are specified in the GRIDDATA block."
-    }
-  },
-  "zero_order_decay": {
-    "options": {
-      ".mst": "is a text keyword to indicate that zero-order decay will occur.  Use of this keyword requires that DECAY and DECAY\\_SORBED (if sorption is active) are specified in the GRIDDATA block.",
-      ".ist": "is a text keyword to indicate that zero-order decay will occur.  Use of this keyword requires that DECAY and DECAY\\_SORBED (if sorption is active) are specified in the GRIDDATA block."
-    }
-  },
-  "sorption": {
-    "options": {
-      ".mst": "is a text keyword to indicate that sorption will be activated.  Valid sorption options include LINEAR, FREUNDLICH, and LANGMUIR.  Use of this keyword requires that BULK\\_DENSITY and DISTCOEF are specified in the GRIDDATA block.  If sorption is specified as FREUNDLICH or LANGMUIR then SP2 is also required in the GRIDDATA block.",
-      ".ist": "is a text keyword to indicate that sorption will be activated.  Valid sorption options include LINEAR, FREUNDLICH, and LANGMUIR.  Use of this keyword requires that BULK\\_DENSITY and DISTCOEF are specified in the GRIDDATA block.  If sorption is specified as FREUNDLICH or LANGMUIR then SP2 is also required in the GRIDDATA block.  The sorption option must be consistent with the sorption option specified in the MST Package or the program will terminate with an error."
-    }
-  },
-  "sorbate": {
-    "options": {
-      ".mst": "keyword to specify that record corresponds to sorbate concentration.",
-      ".ist": "keyword to specify that record corresponds to immobile sorbate concentration."
-    }
-  },
-  "decay": {
-    "griddata": {
-      ".mst": "is the rate coefficient for first or zero-order decay for the aqueous phase of the mobile domain.  A negative value indicates solute production.  The dimensions of decay for first-order decay is one over time.  The dimensions of decay for zero-order decay is mass per length cubed per time.  decay will have no effect on simulation results unless either first- or zero-order decay is specified in the options block.",
-      ".ist": "is the rate coefficient for first or zero-order decay for the aqueous phase of the immobile domain.  A negative value indicates solute production.  The dimensions of decay for first-order decay is one over time.  The dimensions of decay for zero-order decay is mass per length cubed per time.  Decay will have no effect on simulation results unless either first- or zero-order decay is specified in the options block."
-    }
-  },
-  "decay_sorbed": {
-    "griddata": {
-      ".mst": "is the rate coefficient for first or zero-order decay for the sorbed phase of the mobile domain.  A negative value indicates solute production.  The dimensions of decay\\_sorbed for first-order decay is one over time.  The dimensions of decay\\_sorbed for zero-order decay is mass of solute per mass of aquifer per time.  If decay\\_sorbed is not specified and both decay and sorption are active, then the program will terminate with an error.  decay\\_sorbed will have no effect on simulation results unless the SORPTION keyword and either first- or zero-order decay are specified in the options block.",
-      ".ist": "is the rate coefficient for first or zero-order decay for the sorbed phase of the immobile domain.  A negative value indicates solute production.  The dimensions of decay\\_sorbed for first-order decay is one over time.  The dimensions of decay\\_sorbed for zero-order decay is mass of solute per mass of aquifer per time.  If decay\\_sorbed is not specified and both decay and sorption are active, then the program will terminate with an error.  decay\\_sorbed will have no effect on simulation results unless the SORPTION keyword and either first- or zero-order decay are specified in the options block."
-    }
-  },
-  "bulk_density": {
-    "griddata": {
-      ".mst": "is the bulk density of the aquifer in mass per length cubed.  bulk\\_density is not required unless the SORPTION keyword is specified.  Bulk density is defined as the mobile domain solid mass per mobile domain volume.  Additional information on bulk density is included in the MODFLOW 6 Supplemental Technical Information document.",
-      ".ist": "is the bulk density of this immobile domain in mass per length cubed.  Bulk density is defined as the immobile domain solid mass per volume of the immobile domain.  bulk\\_density is not required unless the SORPTION keyword is specified in the options block.  If the SORPTION keyword is not specified in the options block, bulk\\_density will have no effect on simulation results.  "
-    }
-  },
-  "distcoef": {
-    "griddata": {
-      ".mst": "is the distribution coefficient for the equilibrium-controlled linear sorption isotherm in dimensions of length cubed per mass.  If the Freunchlich isotherm is specified, then discoef is the Freundlich constant.  If the Langmuir isotherm is specified, then distcoef is the Langmuir constant.  distcoef is not required unless the SORPTION keyword is specified.",
-      ".ist": "is the distribution coefficient for the equilibrium-controlled linear sorption isotherm in dimensions of length cubed per mass.  distcoef is not required unless the SORPTION keyword is specified in the options block.  If the SORPTION keyword is not specified in the options block, distcoef will have no effect on simulation results. "
-    }
-  },
-  "sp2": {
-    "griddata": {
-      ".mst": "is the exponent for the Freundlich isotherm and the sorption capacity for the Langmuir isotherm.  sp2 is not required unless the SORPTION keyword is specified in the options block.  If the SORPTION keyword is not specified in the options block, sp2 will have no effect on simulation results. ",
-      ".ist": "is the exponent for the Freundlich isotherm and the sorption capacity for the Langmuir isotherm.  sp2 is not required unless the SORPTION keyword is specified in the options block and sorption is specified as FREUNDLICH or LANGMUIR. If the SORPTION keyword is not specified in the options block, or if sorption is specified as LINEAR, sp2 will have no effect on simulation results. "
-    }
-  },
-  "hhformulation_rhs": {
-    "options": {
-      ".buy": "use the variable-density hydraulic head formulation and add off-diagonal terms to the right-hand.  This option will prevent the BUY Package from adding asymmetric terms to the flow matrix."
-    }
-  },
-  "denseref": {
-    "options": {
-      ".buy": "fluid reference density used in the equation of state.  This value is set to 1000. if not specified as an option."
-    }
-  },
-  "density": {
-    "options": {
-      ".buy": "keyword to specify that record corresponds to density."
-    }
-  },
-  "dev_efh_formulation": {
-    "options": {
-      ".buy": "use the variable-density equivalent freshwater head formulation instead of the hydraulic head head formulation.  This dev option has only been implemented for confined aquifer conditions and should generally not be used."
-    }
-  },
-  "nrhospecies": {
-    "dimensions": {
-      ".buy": "number of species used in density equation of state.  This value must be one or greater if the BUY package is activated.  "
-    }
-  },
-  "cell_averaging": {
-    "options": {
-      ".gwfgwf": "is a keyword and text keyword to indicate the method that will be used for calculating the conductance for horizontal cell connections.  The text value for CELL\\_AVERAGING can be ``HARMONIC'', ``LOGARITHMIC'', or ``AMT-LMK'', which means ``arithmetic-mean thickness and logarithmic-mean hydraulic conductivity''. If the user does not specify a value for CELL\\_AVERAGING, then the harmonic-mean method will be used."
-    }
-  },
-  "gnc6": {
-    "options": {
-      ".gwfgwf": "keyword to specify that record corresponds to a ghost-node correction file."
-    }
-  },
-  "mvr6": {
-    "options": {
-      ".gwfgwf": "keyword to specify that record corresponds to a mover file."
-    }
-  },
-  "diffc": {
-    "griddata": {
-      ".dsp": "effective molecular diffusion coefficient."
-    }
-  },
-  "zero_order_decay_water": {
-    "options": {
-      ".est": "is a text keyword to indicate that zero-order decay will occur in the aqueous phase. That is, decay occurs in the water and is a rate per volume of water only, not per volume of aquifer (i.e., grid cell).  Use of this keyword requires that DECAY\\_WATER is specified in the GRIDDATA block."
-    }
-  },
-  "zero_order_decay_solid": {
-    "options": {
-      ".est": "is a text keyword to indicate that zero-order decay will occur in the solid phase. That is, decay occurs in the solid and is a rate per mass (not volume) of solid only.  Use of this keyword requires that DECAY\\_SOLID is specified in the GRIDDATA block."
-    }
-  },
-  "density_water": {
-    "options": {
-      ".est": "density of water used by calculations related to heat storage and conduction.  This value is set to 1,000 kg/m3 if no overriding value is specified.  A user-specified value should be provided for models that use units other than kilograms and meters or if it is necessary to use a value other than the default."
-    }
-  },
-  "heat_capacity_water": {
-    "options": {
-      ".est": "heat capacity of water used by calculations related to heat storage and conduction.  This value is set to 4,184 J/kg/C if no overriding value is specified.  A user-specified value should be provided for models that use units other than kilograms, joules, and degrees Celsius or it is necessary to use a value other than the default."
-    }
-  },
-  "latent_heat_vaporization": {
-    "options": {
-      ".est": "latent heat of vaporization is the amount of energy that is required to convert a given quantity of liquid into a gas and is associated with evaporative cooling.  While the EST package does not simulate evaporation, multiple other packages in a GWE simulation may.  To avoid having to specify the latent heat of vaporization in multiple packages, it is specified in a single location and accessed wherever it is needed.  For example, evaporation may occur from the surface of streams or lakes and the energy consumed by the change in phase would be needed in both the SFE and LKE packages.  This value is set to 2,453,500 J/kg if no overriding value is specified.  A user-specified value should be provided for models that use units other than joules and kilograms or if it is necessary to use a value other than the default."
-    }
-  },
-  "decay_water": {
-    "griddata": {
-      ".est": "is the rate coefficient for zero-order decay for the aqueous phase of the mobile domain.  A negative value indicates heat (energy) production.  The dimensions of zero-order decay in the aqueous phase are energy per length cubed (volume of water) per time.  Zero-order decay in the aqueous phase will have no effect on simulation results unless ZERO\\_ORDER\\_DECAY\\_WATER is specified in the options block."
-    }
-  },
-  "decay_solid": {
-    "griddata": {
-      ".est": "is the rate coefficient for zero-order decay for the solid phase.  A negative value indicates heat (energy) production. The dimensions of zero-order decay in the solid phase are energy per mass of solid per time. Zero-order decay in the solid phase will have no effect on simulation results unless ZERO\\_ORDER\\_DECAY\\_SOLID is specified in the options block."
-    }
-  },
-  "heat_capacity_solid": {
-    "griddata": {
-      ".est": "is the mass-based heat capacity of dry solids (aquifer material). For example, units of J/kg/C may be used (or equivalent)."
-    }
-  },
-  "density_solid": {
-    "griddata": {
-      ".est": "is a user-specified value of the density of aquifer material not considering the voids. Value will remain fixed for the entire simulation.  For example, if working in SI units, values may be entered as kilograms per cubic meter. "
-    }
-  },
-  "length": {
-    "griddata": {
-      ".disv1d": "length for each one-dimensional cell"
-    }
-  },
-  "modelnames": {
-    "options": {
-      ".mvr": "keyword to indicate that all package names will be preceded by the model name for the package.  Model names are required when the Mover Package is used with a GWF-GWF Exchange.  The MODELNAME keyword should not be used for a Mover Package that is for a single GWF Model."
     }
   },
   "maxmvr": {
@@ -2265,232 +1277,118 @@
       ".mvr": "integer value specifying the number of unique packages that are included in this water mover input file."
     }
   },
-  "central_in_space": {
-    "options": {
-      ".dfw": "keyword to indicate conductance should be calculated using central-in-space weighting instead of the default upstream weighting approach.  This option should be used with caution as it does not work well unless all of the stream reaches are saturated.  With this option, there is no way for water to flow into a dry reach from connected reaches."
-    }
-  },
-  "save_velocity": {
-    "options": {
-      ".dfw": "keyword to indicate that x, y, and z components of velocity will be calculated at cell centers and written to the budget file, which is specified with ``BUDGET SAVE FILE'' in Output Control.  If this option is activated, then additional information may be required in the discretization packages and the GWF Exchange package (if GWF models are coupled).  Specifically, ANGLDEGX must be specified in the CONNECTIONDATA block of the DISU Package; ANGLDEGX must also be specified for the GWF Exchange as an auxiliary variable."
-    }
-  },
-  "dev_swr_conductance": {
-    "options": {
-      ".dfw": "use the conductance formulation in the Surface Water Routing (SWR) Process for MODFLOW-2005."
-    }
-  },
-  "manningsn": {
-    "griddata": {
-      ".dfw": "mannings roughness coefficient"
-    }
-  },
-  "idcxs": {
-    "griddata": {
-      ".dfw": "integer value indication the cross section identifier in the Cross Section Package that applies to the reach.  If not provided then reach will be treated as hydraulically wide."
-    }
-  },
-  "explicit": {
-    "options": {
-      ".gnc": "keyword to indicate that the ghost node correction is applied in an explicit manner on the right-hand side of the matrix.  The explicit approach will likely require additional outer iterations.  If the keyword is not specified, then the correction will be applied in an implicit manner on the left-hand side.  The implicit approach will likely converge better, but may require additional memory.  If the EXPLICIT keyword is not specified, then the BICGSTAB linear acceleration option should be specified within the LINEAR block of the Sparse Matrix Solver."
-    }
-  },
-  "numgnc": {
+  "maxsig0": {
     "dimensions": {
-      ".gnc": "is the number of GNC entries."
+      ".csub": "is the maximum number of cells that can have a specified stress offset.  More than 1 stress offset can be assigned to a GWF cell. By default, MAXSIG0 is 0."
     }
   },
-  "numalphaj": {
+  "memory_print_option": {
+    "options": {
+      ".nam": "is a flag that controls printing of detailed memory manager usage to the end of the simulation list file.  NONE means do not print detailed information. SUMMARY means print only the total memory for each simulation component. ALL means print information for each variable stored in the memory manager. NONE is default if MEMORY\\_PRINT\\_OPTION is not specified."
+    }
+  },
+  "method": {
+    "attributes": {
+      ".tas": "xxx",
+      ".ts": "xxx"
+    }
+  },
+  "methods": {
+    "attributes": {
+      ".ts": "xxx"
+    }
+  },
+  "mixed": {
+    "fileinput": {
+      ".ssm": "keyword to specify that these stress package boundaries will have the mixed condition.  The MIXED condition is described in the SOURCES block for AUXMIXED.  The MIXED condition allows for water to be withdrawn at a concentration that is less than the cell concentration.  It is intended primarily for representing evapotranspiration."
+    }
+  },
+  "modelnames": {
+    "options": {
+      ".mvr": "keyword to indicate that all package names will be preceded by the model name for the package.  Model names are required when the Mover Package is used with a GWF-GWF Exchange.  The MODELNAME keyword should not be used for a Mover Package that is for a single GWF Model."
+    }
+  },
+  "models": {
+    "models": {
+      ".nam": "is the list of model types, model name files, and model names."
+    }
+  },
+  "modflow6_attr_off": {
+    "options": {
+      ".ncf": "is the keyword used to turn off internal input tagging in the model netcdf file. Tagging adds internal modflow 6 attribute(s) to variables which facilitate identification. Currently this applies to gridded arrays."
+    }
+  },
+  "mover": {
+    "options": {
+      ".api": "keyword to indicate that this instance of the api boundary Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.",
+      ".drn": "keyword to indicate that this instance of the Drain Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.",
+      ".ghb": "keyword to indicate that this instance of the General-Head Boundary Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.",
+      ".lak": "keyword to indicate that this instance of the LAK Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.",
+      ".maw": "keyword to indicate that this instance of the MAW Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.",
+      ".riv": "keyword to indicate that this instance of the River Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.",
+      ".sfr": "keyword to indicate that this instance of the SFR Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.",
+      ".uzf": "keyword to indicate that this instance of the UZF Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.",
+      ".wel": "keyword to indicate that this instance of the Well Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water."
+    }
+  },
+  "mve6": {
+    "options": {
+      ".gwegwe": "keyword to specify that record corresponds to an energy transport mover file."
+    }
+  },
+  "mvr6": {
+    "options": {
+      ".gwfgwf": "keyword to specify that record corresponds to a mover file."
+    }
+  },
+  "mvt6": {
+    "options": {
+      ".gwtgwt": "keyword to specify that record corresponds to a transport mover file."
+    }
+  },
+  "mxiter": {
+    "solutiongroup": {
+      ".nam": "is the maximum number of outer iterations for this solution group.  The default value is 1.  If there is only one solution in the solution group, then MXITER must be 1."
+    }
+  },
+  "name": {
+    "attributes": {
+      ".tas": "xxx"
+    }
+  },
+  "names": {
+    "attributes": {
+      ".ts": "xxx"
+    }
+  },
+  "ncf6": {
+    "options": {
+      ".dis": "keyword to specify that record corresponds to a netcdf configuration (NCF) file.",
+      ".disv": "keyword to specify that record corresponds to a netcdf configuration (NCF) file."
+    }
+  },
+  "ncol": {
     "dimensions": {
-      ".gnc": "is the number of contributing factors."
+      ".dis": "is the number of columns in the model grid.",
+      ".dis2d": "is the number of columns in the model grid.",
+      ".laktab": "integer value specifying the number of columns in the lake table. There must be NCOL columns of data in the TABLE block. For lakes with HORIZONTAL and/or VERTICAL CTYPE connections, NCOL must be equal to 3. For lakes with EMBEDDEDH or EMBEDDEDV CTYPE connections, NCOL must be equal to 4.",
+      ".sfrtab": "integer value specifying the number of columns in the reach cross-section table. There must be NCOL columns of data in the TABLE block. NCOL must be equal to 2 if MANFRACTION is not specified or 3 otherwise."
     }
   },
-  "binary": {
-    "continuous": {
-      ".obs": "an optional keyword used to indicate that the output file should be written in binary (unformatted) form."
-    }
-  },
-  "vertical_offset_tolerance": {
-    "options": {
-      ".disu": "checks are performed to ensure that the top of a cell is not higher than the bottom of an overlying cell.  This option can be used to specify the tolerance that is used for checking.  If top of a cell is above the bottom of an overlying cell by a value less than this tolerance, then the program will not terminate with an error.  The default value is zero.  This option should generally not be used."
-    }
-  },
-  "nja": {
+  "ncpl": {
     "dimensions": {
-      ".disu": "is the sum of the number of connections and NODES.  When calculating the total number of connections, the connection between cell n and cell m is considered to be different from the connection between cell m and cell n.  Thus, NJA is equal to the total number of connections, including n to m and m to n, and the total number of cells."
+      ".disv": "is the number of cells per layer.  This is a constant value for the grid and it applies to all layers.",
+      ".ncf": "is the number of cells in a projected plane layer."
     }
   },
-  "bot": {
-    "griddata": {
-      ".disu": "is the bottom elevation for each cell."
-    }
-  },
-  "area": {
-    "griddata": {
-      ".disu": "is the cell surface area (in plan view)."
-    }
-  },
-  "iac": {
-    "connectiondata": {
-      ".disu": "is the number of connections (plus 1) for each cell.  The sum of all the entries in IAC must be equal to NJA."
-    }
-  },
-  "ja": {
-    "connectiondata": {
-      ".disu": "is a list of cell number (n) followed by its connecting cell numbers (m) for each of the m cells connected to cell n. The number of values to provide for cell n is IAC(n).  This list is sequentially provided for the first to the last cell. The first value in the list must be cell n itself, and the remaining cells must be listed in an increasing order (sorted from lowest number to highest).  Note that the cell and its connections are only supplied for the GWE cells and their connections to the other GWE cells.  Also note that the JA list input may be divided such that every node and its connectivity list can be on a separate line for ease in readability of the file. To further ease readability of the file, the node number of the cell whose connectivity is subsequently listed, may be expressed as a negative number, the sign of which is subsequently converted to positive by the code."
-    }
-  },
-  "ihc": {
-    "connectiondata": {
-      ".disu": "is an index array indicating the direction between node n and all of its m connections.  If IHC = 0 then cell n and cell m are connected in the vertical direction.  Cell n overlies cell m if the cell number for n is less than m; cell m overlies cell n if the cell number for m is less than n.  If IHC = 1 then cell n and cell m are connected in the horizontal direction.  If IHC = 2 then cell n and cell m are connected in the horizontal direction, and the connection is vertically staggered.  A vertically staggered connection is one in which a cell is horizontally connected to more than one cell in a horizontal connection."
-    }
-  },
-  "cl12": {
-    "connectiondata": {
-      ".disu": "is the array containing connection lengths between the center of cell n and the shared face with each adjacent m cell."
-    }
-  },
-  "hwva": {
-    "connectiondata": {
-      ".disu": "is a symmetric array of size NJA.  For horizontal connections, entries in HWVA are the horizontal width perpendicular to flow.  For vertical connections, entries in HWVA are the vertical area for flow.  Thus, values in the HWVA array contain dimensions of both length and area.  Entries in the HWVA array have a one-to-one correspondence with the connections specified in the JA array.  Likewise, there is a one-to-one correspondence between entries in the HWVA array and entries in the IHC array, which specifies the connection type (horizontal or vertical).  Entries in the HWVA array must be symmetric; the program will terminate with an error if the value for HWVA for an n to m connection does not equal the value for HWVA for the corresponding n to m connection."
-    }
-  },
-  "angldegx": {
-    "connectiondata": {
-      ".disu": "is the angle (in degrees) between the horizontal x-axis and the outward normal to the face between a cell and its connecting cells. The angle varies between zero and 360.0 degrees, where zero degrees points in the positive x-axis direction, and 90 degrees points in the positive y-axis direction.  ANGLDEGX is only needed if horizontal anisotropy is specified in the NPF Package, if the XT3D option is used in the NPF Package, or if the SAVE\\_SPECIFIC\\_DISCHARGE option is specified in the NPF Package.  ANGLDEGX does not need to be specified if these conditions are not met.  ANGLDEGX is of size NJA; values specified for vertical connections and for the diagonal position are not used.  Note that ANGLDEGX is read in degrees, which is different from MODFLOW-USG, which reads a similar variable (ANGLEX) in radians."
-    }
-  },
-  "disable_storage_change_integration": {
+  "ndelaycells": {
     "options": {
-      ".tvs": "keyword that deactivates inclusion of storage derivative terms in the STO package matrix formulation.  In the absence of this keyword (the default), the groundwater storage formulation will be modified to correctly adjust heads based on transient variations in stored water volumes arising from changes to SS and SY properties."
+      ".csub": "number of nodes used to discretize delay interbeds. If not specified, then a default value of 19 is assigned."
     }
   },
-  "storage": {
+  "netcdf": {
     "options": {
-      ".sfr": "keyword that activates storage contributions to the stream-flow routing package continuity equation."
-    }
-  },
-  "maximum_picard_iterations": {
-    "options": {
-      ".sfr": "integer value that defines the maximum number of Streamflow Routing picard iterations allowed when solving for reach stages and flows as part of the GWF formulate step. Picard iterations are used to minimize differences in SFR package results between subsequent GWF picard (non-linear) iterations as a result of non-optimal reach numbering. If reaches are numbered in order, from upstream to downstream, MAXIMUM\\_PICARD\\_ITERATIONS can be set to 1 to reduce model run time. By default, MAXIMUM\\_PICARD\\_ITERATIONS is equal to 100."
-    }
-  },
-  "maximum_depth_change": {
-    "options": {
-      ".sfr": "real value that defines the depth closure tolerance. By default, MAXIMUM\\_DEPTH\\_CHANGE is equal to $1 \\times 10^{-5}$. The MAXIMUM\\_STAGE\\_CHANGE would only need to be increased or decreased from the default value if the water budget error for one or more reach is too small or too large, respectively."
-    }
-  },
-  "unit_conversion": {
-    "options": {
-      ".sfr": "real value that is used to convert user-specified Manning's roughness coefficients from seconds per meters$^{1/3}$ to model length and time units. A constant of 1.486 is used for flow units of cubic feet per second, and a constant of 1.0 is used for units of cubic meters per second. The constant must be multiplied by 86,400 when using time units of days in the simulation."
-    }
-  },
-  "dev_storage_weight": {
-    "options": {
-      ".sfr": "real number value that defines the time weighting factor used to calculate the change in channel storage. STORAGE\\_WEIGHT must have a value between 0.5 and 1. Default STORAGE\\_WEIGHT value is 1."
-    }
-  },
-  "nreaches": {
-    "dimensions": {
-      ".sfr": "integer value specifying the number of stream reaches.  There must be NREACHES entries in the PACKAGEDATA block."
-    }
-  },
-  "bedk": {
-    "period": {
-      ".sfr": "real or character value that defines the hydraulic conductivity of the reach streambed. BEDK can be any positive value if the reach is not connected to an underlying GWF cell. Otherwise, BEDK must be greater than zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
-    }
-  },
-  "manning": {
-    "period": {
-      ".sfr": "real or character value that defines the Manning's roughness coefficient for the reach. MANNING must be greater than zero.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
-    }
-  },
-  "diversion": {
-    "period": {
-      ".sfr": "keyword to indicate diversion record."
-    }
-  },
-  "upstream_fraction": {
-    "period": {
-      ".sfr": "real value that defines the fraction of upstream flow (USTRF) from each upstream reach that is applied as upstream inflow to the reach. The sum of all USTRF values for all reaches connected to the same upstream reach must be equal to one."
-    }
-  },
-  "cross_section": {
-    "period": {
-      ".sfr": "keyword to specify that record corresponds to a reach cross-section."
-    }
-  },
-  "ats_percel": {
-    "options": {
-      ".adv": "fractional cell distance submitted by the ADV Package to the adaptive time stepping (ATS) package.  If ATS\\_PERCEL is specified and the ATS Package is active, a time step calculation will be made for each cell based on flow through the cell and cell properties.  The largest time step will be calculated such that the advective fractional cell distance (ATS\\_PERCEL) is not exceeded for any active cell in the grid.  This time-step constraint will be submitted to the ATS Package, perhaps with constraints submitted by other packages, in the calculation of the time step.  ATS\\_PERCEL must be greater than zero.  If a value of zero is specified for ATS\\_PERCEL the program will automatically reset it to an internal no data value to indicate that time steps should not be subject to this constraint."
-    }
-  },
-  "water_content": {
-    "options": {
-      ".uzf": "keyword to specify that record corresponds to unsaturated zone water contents."
-    }
-  },
-  "simulate_et": {
-    "options": {
-      ".uzf": "keyword specifying that ET in the unsaturated (UZF) and saturated zones (GWF) will be simulated. ET can be simulated in the UZF cell and not the GWF cell by omitting keywords LINEAR\\_GWET and SQUARE\\_GWET."
-    }
-  },
-  "linear_gwet": {
-    "options": {
-      ".uzf": "keyword specifying that groundwater ET will be simulated using the original ET formulation of MODFLOW-2005."
-    }
-  },
-  "square_gwet": {
-    "options": {
-      ".uzf": "keyword specifying that groundwater ET will be simulated by assuming a constant ET rate for groundwater levels between land surface (TOP) and land surface minus the ET extinction depth (TOP-EXTDP). Groundwater ET is smoothly reduced from the PET rate to zero over a nominal interval at TOP-EXTDP."
-    }
-  },
-  "simulate_gwseep": {
-    "options": {
-      ".uzf": "keyword specifying that groundwater discharge (GWSEEP) to land surface will be simulated. Groundwater discharge is nonzero when groundwater head is greater than land surface.  This option is no longer recommended; a better approach is to use the Drain Package with discharge scaling as a way to handle seepage to land surface.  The Drain Package with discharge scaling is described in Chapter 3 of the Supplemental Technical Information. "
-    }
-  },
-  "unsat_etwc": {
-    "options": {
-      ".uzf": "keyword specifying that ET in the unsaturated zone will be simulated as a function of the specified PET rate while the water content (THETA) is greater than the ET extinction water content (EXTWC)."
-    }
-  },
-  "unsat_etae": {
-    "options": {
-      ".uzf": "keyword specifying that ET in the unsaturated zone will be simulated using a capillary pressure based formulation. Capillary pressure is calculated using the Brooks-Corey retention function."
-    }
-  },
-  "nuzfcells": {
-    "dimensions": {
-      ".uzf": "is the number of UZF cells.  More than one UZF cell can be assigned to a GWF cell; however, only one GWF cell can be assigned to a single UZF cell. If more than one UZF cell is assigned to a GWF cell, then an auxiliary variable should be used to reduce the surface area of the UZF cell with the AUXMULTNAME option."
-    }
-  },
-  "ntrailwaves": {
-    "dimensions": {
-      ".uzf": "is the number of trailing waves.  A recommended value of 7 can be used for NTRAILWAVES.  This value can be increased to lower mass balance error in the unsaturated zone."
-    }
-  },
-  "nwavesets": {
-    "dimensions": {
-      ".uzf": "is the number of wave sets.  A recommended value of 40 can be used for NWAVESETS.  This value can be increased if more waves are required to resolve variations in water content within the unsaturated zone."
-    }
-  },
-  "cim": {
-    "options": {
-      ".ist": "keyword to specify that record corresponds to immobile concentration."
-    },
-    "griddata": {
-      ".ist": "initial concentration of the immobile domain in mass per length cubed.  If CIM is not specified, then it is assumed to be zero."
-    }
-  },
-  "volfrac": {
-    "griddata": {
-      ".ist": "fraction of the cell volume that consists of this immobile domain.  The sum of all immobile domain volume fractions must be less than one."
-    }
-  },
-  "zetaim": {
-    "griddata": {
-      ".ist": "mass transfer rate coefficient between the mobile and immobile domains, in dimensions of per time."
+      ".nam": "keyword to specify that record corresponds to a netcdf input file."
     }
   },
   "netcdf_mesh2d": {
@@ -2503,44 +1401,45 @@
       ".nam": "keyword to specify that record corresponds to a structured netcdf file."
     }
   },
-  "netcdf": {
+  "newton": {
     "options": {
-      ".nam": "keyword to specify that record corresponds to a netcdf input file."
+      ".gwfgwf": "keyword that activates the Newton-Raphson formulation for groundwater flow between connected, convertible groundwater cells. Cells will not dry when this option is used.",
+      ".nam": "keyword that activates the Newton-Raphson formulation for surface water flow between connected reaches and stress packages that support calculation of Newton-Raphson terms. "
     }
   },
-  "print_head": {
+  "newtonoptions": {
     "options": {
-      ".maw": "keyword to indicate that the list of multi-aquifer well heads will be printed to the listing file for every stress period in which ``HEAD PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_HEAD is specified, then heads are printed for the last time step of each stress period."
+      ".nam": "none"
     }
   },
-  "no_well_storage": {
-    "options": {
-      ".maw": "keyword that deactivates inclusion of well storage contributions to the multi-aquifer well package continuity equation."
+  "nexg": {
+    "dimensions": {
+      ".chfgwf": "keyword and integer value specifying the number of SWF-GWF exchanges.",
+      ".gwegwe": "keyword and integer value specifying the number of GWE-GWE exchanges.",
+      ".gwfgwf": "keyword and integer value specifying the number of GWF-GWF exchanges.",
+      ".gwtgwt": "keyword and integer value specifying the number of GWT-GWT exchanges.",
+      ".olfgwf": "keyword and integer value specifying the number of SWF-GWF exchanges."
     }
   },
-  "flow_correction": {
-    "options": {
-      ".maw": "keyword that activates flow corrections in cases where the head in a multi-aquifer well is below the bottom of the screen for a connection or the head in a convertible cell connected to a multi-aquifer well is below the cell bottom. When flow corrections are activated, unit head gradients are used to calculate the flow between a multi-aquifer well and a connected GWF cell. By default, flow corrections are not made."
+  "ninterbeds": {
+    "dimensions": {
+      ".csub": "is the number of CSUB interbed systems.  More than 1 CSUB interbed systems can be assigned to a GWF cell; however, only 1 GWF cell can be assigned to a single CSUB interbed system."
     }
   },
-  "flowing_wells": {
-    "options": {
-      ".maw": "keyword that activates the flowing wells option for the multi-aquifer well package."
+  "nja": {
+    "dimensions": {
+      ".disu": "is the sum of the number of connections and NODES.  When calculating the total number of connections, the connection between cell n and cell m is considered to be different from the connection between cell m and cell n.  Thus, NJA is equal to the total number of connections, including n to m and m to n, and the total number of cells."
     }
   },
-  "shutdown_theta": {
-    "options": {
-      ".maw": "value that defines the weight applied to discharge rate for wells that limit the water level in a discharging well (defined using the HEAD\\_LIMIT keyword in the stress period data). SHUTDOWN\\_THETA is used to control discharge rate oscillations when the flow rate from the aquifer is less than the specified flow rate from the aquifer to the well. Values range between 0.0 and 1.0, and larger values increase the weight (decrease under-relaxation) applied to the well discharge rate. The HEAD\\_LIMIT option has been included to facilitate backward compatibility with previous versions of MODFLOW but use of the RATE\\_SCALING option instead of the HEAD\\_LIMIT option is recommended. By default, SHUTDOWN\\_THETA is 0.7."
+  "nlakes": {
+    "dimensions": {
+      ".lak": "value specifying the number of lakes that will be simulated for all stress periods."
     }
   },
-  "shutdown_kappa": {
-    "options": {
-      ".maw": "value that defines the weight applied to discharge rate for wells that limit the water level in a discharging well (defined using the HEAD\\_LIMIT keyword in the stress period data). SHUTDOWN\\_KAPPA is used to control discharge rate oscillations when the flow rate from the aquifer is less than the specified flow rate from the aquifer to the well. Values range between 0.0 and 1.0, and larger values increase the weight applied to the well discharge rate. The HEAD\\_LIMIT option has been included to facilitate backward compatibility with previous versions of MODFLOW but use of the RATE\\_SCALING option instead of the HEAD\\_LIMIT option is recommended. By default, SHUTDOWN\\_KAPPA is 0.0001."
-    }
-  },
-  "maw_flow_reduce_csv": {
-    "options": {
-      ".maw": "keyword to specify that record corresponds to the output option in which a new record is written for each multi-aquifer well and for each time step in which the user-requested extraction or injection rate is reduced by the program."
+  "nlay": {
+    "dimensions": {
+      ".dis": "is the number of layers in the model grid.",
+      ".disv": "is the number of layers in the model grid."
     }
   },
   "nmawwells": {
@@ -2548,39 +1447,85 @@
       ".maw": "integer value specifying the number of multi-aquifer wells that will be simulated for all stress periods."
     }
   },
-  "flowing_well": {
-    "period": {
-      ".maw": "keyword to indicate the well is a flowing well.  The FLOWING\\_WELL option can be used to simulate flowing wells when the simulated well head exceeds the specified drainage elevation."
-    }
-  },
-  "well_head": {
-    "period": {
-      ".maw": "is the head in the multi-aquifer well. WELL\\_HEAD is only applied to constant head (STATUS is CONSTANT) and inactive (STATUS is INACTIVE) multi-aquifer wells. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. The program will terminate with an error if WELL\\_HEAD is less than the bottom of the well."
-    }
-  },
-  "head_limit": {
-    "period": {
-      ".maw": "is the limiting water level (head) in the well, which is the minimum of the well RATE or the well inflow rate from the aquifer. HEAD\\_LIMIT can be applied to extraction wells (RATE $<$ 0) or injection wells (RATE $>$ 0). HEAD\\_LIMIT can be deactivated by specifying the text string `OFF'. The HEAD\\_LIMIT option is based on the HEAD\\_LIMIT functionality available in the MNW2~\\citep{konikow2009} package for MODFLOW-2005. The HEAD\\_LIMIT option has been included to facilitate backward compatibility with previous versions of MODFLOW but use of the RATE\\_SCALING option instead of the HEAD\\_LIMIT option is recommended. By default, HEAD\\_LIMIT is `OFF'."
-    }
-  },
-  "shut_off": {
-    "period": {
-      ".maw": "keyword for activating well shut off capability.  Subsequent values define the minimum and maximum pumping rate that a well must exceed to shutoff or reactivate a well, respectively, during a stress period. SHUT\\_OFF is only applied to injection wells (RATE$<0$) and if HEAD\\_LIMIT is specified (not set to `OFF').  If HEAD\\_LIMIT is specified, SHUT\\_OFF can be deactivated by specifying a minimum value equal to zero. The SHUT\\_OFF option is based on the SHUT\\_OFF functionality available in the MNW2~\\citep{konikow2009} package for MODFLOW-2005. The SHUT\\_OFF option has been included to facilitate backward compatibility with previous versions of MODFLOW but use of the RATE\\_SCALING option instead of the SHUT\\_OFF option is recommended. By default, SHUT\\_OFF is not used."
-    }
-  },
-  "rate_scaling": {
-    "period": {
-      ".maw": "activate rate scaling.  If RATE\\_SCALING is specified, both PUMP\\_ELEVATION and SCALING\\_LENGTH must be specified. RATE\\_SCALING cannot be used with HEAD\\_LIMIT.  RATE\\_SCALING can be used for extraction or injection wells.  For extraction wells, the extraction rate will start to decrease once the head in the well lowers to a level equal to the pump elevation plus the scaling length.  If the head in the well drops below the pump elevation, then the extraction rate is calculated to be zero.  For an injection well, the injection rate will begin to decrease once the head in the well rises above the specified pump elevation.  If the head in the well rises above the pump elevation plus the scaling length, then the injection rate will be set to zero."
-    }
-  },
-  "mixed": {
-    "fileinput": {
-      ".ssm": "keyword to specify that these stress package boundaries will have the mixed condition.  The MIXED condition is described in the SOURCES block for AUXMIXED.  The MIXED condition allows for water to be withdrawn at a concentration that is less than the cell concentration.  It is intended primarily for representing evapotranspiration."
-    }
-  },
-  "surf_rate_specified": {
+  "no_ptc": {
     "options": {
-      ".evt": "indicates that the proportion of the evapotranspiration rate at the ET surface will be specified as PETM0 in list input."
+      ".ims": "is a flag that is used to disable pseudo-transient continuation (PTC). Option only applies to steady-state stress periods for models using the Newton-Raphson formulation. For many problems, PTC can significantly improve convergence behavior for steady-state simulations, and for this reason it is active by default.  In some cases, however, PTC can worsen the convergence behavior, especially when the initial conditions are similar to the solution.  When the initial conditions are similar to, or exactly the same as, the solution and convergence is slow, then the NO\\_PTC FIRST option should be used to deactivate PTC for the first stress period.  The NO\\_PTC ALL option should also be used in order to compare convergence behavior with other MODFLOW versions, as PTC is only available in MODFLOW 6.",
+      ".pts": "is a flag that is used to disable pseudo-transient continuation (PTC). Option only applies to steady-state stress periods for models using the Newton-Raphson formulation. For many problems, PTC can significantly improve convergence behavior for steady-state simulations, and for this reason it is active by default.  In some cases, however, PTC can worsen the convergence behavior, especially when the initial conditions are similar to the solution.  When the initial conditions are similar to, or exactly the same as, the solution and convergence is slow, then the NO\\_PTC FIRST option should be used to deactivate PTC for the first stress period.  The NO\\_PTC ALL option should also be used in order to compare convergence behavior with other MODFLOW versions, as PTC is only available in MODFLOW 6."
+    }
+  },
+  "no_well_storage": {
+    "options": {
+      ".maw": "keyword that deactivates inclusion of well storage contributions to the multi-aquifer well package continuity equation."
+    }
+  },
+  "nocheck": {
+    "options": {
+      ".nam": "keyword flag to indicate that the model input check routines should not be called prior to each time step. Checks are performed by default."
+    }
+  },
+  "nodes": {
+    "dimensions": {
+      ".disu": "is the number of cells in the model grid.",
+      ".disv1d": "is the number of linear cells.",
+      ".disv2d": "is the number of cells per layer.  This is a constant value for the grid and it applies to all layers."
+    }
+  },
+  "nogrb": {
+    "options": {
+      ".dis": "keyword to deactivate writing of the binary grid file.",
+      ".dis2d": "keyword to deactivate writing of the binary grid file.",
+      ".disu": "keyword to deactivate writing of the binary grid file.",
+      ".disv": "keyword to deactivate writing of the binary grid file.",
+      ".disv1d": "keyword to deactivate writing of the binary grid file.",
+      ".disv2d": "keyword to deactivate writing of the binary grid file."
+    }
+  },
+  "noutlets": {
+    "dimensions": {
+      ".lak": "value specifying the number of outlets that will be simulated for all stress periods. If NOUTLETS is not specified, a default value of zero is used."
+    }
+  },
+  "nper": {
+    "dimensions": {
+      ".tdis": "is the number of stress periods for the simulation."
+    }
+  },
+  "npoints": {
+    "dimensions": {
+      ".cxs": "integer value specifying the total number of cross-section points defined for all reaches.  There must be NPOINTS entries in the CROSSSECTIONDATA block."
+    }
+  },
+  "nreaches": {
+    "dimensions": {
+      ".sfr": "integer value specifying the number of stream reaches.  There must be NREACHES entries in the PACKAGEDATA block."
+    }
+  },
+  "nreleasepts": {
+    "dimensions": {
+      ".prp": "is the number of particle release points."
+    }
+  },
+  "nreleasetimes": {
+    "dimensions": {
+      ".prp": "is the number of particle release times specified in the RELEASETIMES block. This is not necessarily the total number of release times; release times are the union of RELEASE\\_TIME\\_FREQUENCY, RELEASETIMES block, and PERIOD block RELEASESETTING selections."
+    }
+  },
+  "nrhospecies": {
+    "dimensions": {
+      ".buy": "number of species used in density equation of state.  This value must be one or greater if the BUY package is activated.  "
+    }
+  },
+  "nrow": {
+    "dimensions": {
+      ".dis": "is the number of rows in the model grid.",
+      ".dis2d": "is the number of rows in the model grid.",
+      ".laktab": "integer value specifying the number of rows in the lake table. There must be NROW rows of data in the TABLE block.",
+      ".sfrtab": "integer value specifying the number of rows in the reach cross-section table. There must be NROW rows of data in the TABLE block."
+    }
+  },
+  "nsections": {
+    "dimensions": {
+      ".cxs": "integer value specifying the number of cross sections that will be defined.  There must be NSECTIONS entries in the PACKAGEDATA block."
     }
   },
   "nseg": {
@@ -2588,9 +1533,603 @@
       ".evt": "number of ET segments.  Default is one.  When NSEG is greater than 1, the PXDP and PETM arrays must be of size NSEG - 1 and be listed in order from the uppermost segment down. Values for PXDP must be listed first followed by the values for PETM.  PXDP defines the extinction-depth proportion at the bottom of a segment. PETM defines the proportion of the maximum ET flux rate at the bottom of a segment."
     }
   },
-  "time_units": {
+  "ntables": {
+    "dimensions": {
+      ".lak": "value specifying the number of lakes tables that will be used to define the lake stage, volume relation, and surface area. If NTABLES is not specified, a default value of zero is used."
+    }
+  },
+  "ntracktimes": {
+    "dimensions": {
+      ".oc": "is the number of user-specified particle tracking times in the TRACKTIMES block."
+    }
+  },
+  "ntrailwaves": {
+    "dimensions": {
+      ".uzf": "is the number of trailing waves.  A recommended value of 7 can be used for NTRAILWAVES.  This value can be increased to lower mass balance error in the unsaturated zone."
+    }
+  },
+  "numalphaj": {
+    "dimensions": {
+      ".gnc": "is the number of contributing factors."
+    }
+  },
+  "number_orthogonalizations": {
+    "linear": {
+      ".ims": "optional integer value defining the interval used to explicitly recalculate the residual of the flow equation using the solver coefficient matrix, the latest dependent-variable (for example, head) estimates, and the right hand side. For problems that benefit from explicit recalculation of the residual, a number between 4 and 10 is appropriate. By default, NUMBER\\_ORTHOGONALIZATIONS is zero."
+    }
+  },
+  "numgnc": {
+    "dimensions": {
+      ".gnc": "is the number of GNC entries."
+    }
+  },
+  "nuzfcells": {
+    "dimensions": {
+      ".uzf": "is the number of UZF cells.  More than one UZF cell can be assigned to a GWF cell; however, only one GWF cell can be assigned to a single UZF cell. If more than one UZF cell is assigned to a GWF cell, then an auxiliary variable should be used to reduce the surface area of the UZF cell with the AUXMULTNAME option."
+    }
+  },
+  "nvert": {
+    "dimensions": {
+      ".disu": "is the total number of (x, y) vertex pairs used to define the plan-view shape of each cell in the model grid.  If NVERT is not specified or is specified as zero, then the VERTICES and CELL2D blocks below are not read.  NVERT and the accompanying VERTICES and CELL2D blocks should be specified for most simulations.  If the XT3D or SAVE\\_SPECIFIC\\_DISCHARGE options are specified in the NPF Package, then this information is required.",
+      ".disv": "is the total number of (x, y) vertex pairs used to characterize the horizontal configuration of the model grid.",
+      ".disv1d": "is the total number of (x, y, z) vertex pairs used to characterize the model grid.",
+      ".disv2d": "is the total number of (x, y) vertex pairs used to characterize the horizontal configuration of the model grid."
+    }
+  },
+  "nviscspecies": {
+    "dimensions": {
+      ".vsc": "number of species used in the viscosity equation of state.  If either concentrations or temperature (or both) are used to update viscosity then then nrhospecies needs to be at least one."
+    }
+  },
+  "nwavesets": {
+    "dimensions": {
+      ".uzf": "is the number of wave sets.  A recommended value of 40 can be used for NWAVESETS.  This value can be increased if more waves are required to resolve variations in water content within the unsaturated zone."
+    }
+  },
+  "obs6": {
     "options": {
-      ".tdis": "is the time units of the simulation.  This is a text string that is used as a label within model output files.  Values for time\\_units may be ``unknown'',  ``seconds'', ``minutes'', ``hours'', ``days'', or ``years''.  The default time unit is ``unknown''."
+      ".api": "keyword to specify that record corresponds to an observations file.",
+      ".cdb": "keyword to specify that record corresponds to an observations file.",
+      ".chd": "keyword to specify that record corresponds to an observations file.",
+      ".chfgwf": "keyword to specify that record corresponds to an observations file.",
+      ".cnc": "keyword to specify that record corresponds to an observations file.",
+      ".csub": "keyword to specify that record corresponds to an observations file.",
+      ".ctp": "keyword to specify that record corresponds to an observations file.",
+      ".dfw": "keyword to specify that record corresponds to an observations file.",
+      ".drn": "keyword to specify that record corresponds to an observations file.",
+      ".esl": "keyword to specify that record corresponds to an observations file.",
+      ".evp": "keyword to specify that record corresponds to an observations file.",
+      ".evt": "keyword to specify that record corresponds to an observations file.",
+      ".evta": "keyword to specify that record corresponds to an observations file.",
+      ".flw": "keyword to specify that record corresponds to an observations file.",
+      ".ghb": "keyword to specify that record corresponds to an observations file.",
+      ".gwegwe": "keyword to specify that record corresponds to an observations file.",
+      ".gwfgwf": "keyword to specify that record corresponds to an observations file.",
+      ".gwtgwt": "keyword to specify that record corresponds to an observations file.",
+      ".lak": "keyword to specify that record corresponds to an observations file.",
+      ".lke": "keyword to specify that record corresponds to an observations file.",
+      ".lkt": "keyword to specify that record corresponds to an observations file.",
+      ".maw": "keyword to specify that record corresponds to an observations file.",
+      ".mwe": "keyword to specify that record corresponds to an observations file.",
+      ".mwt": "keyword to specify that record corresponds to an observations file.",
+      ".olfgwf": "keyword to specify that record corresponds to an observations file.",
+      ".pcp": "keyword to specify that record corresponds to an observations file.",
+      ".rch": "keyword to specify that record corresponds to an observations file.",
+      ".rcha": "keyword to specify that record corresponds to an observations file.",
+      ".riv": "keyword to specify that record corresponds to an observations file.",
+      ".sfe": "keyword to specify that record corresponds to an observations file.",
+      ".sfr": "keyword to specify that record corresponds to an observations file.",
+      ".sft": "keyword to specify that record corresponds to an observations file.",
+      ".src": "keyword to specify that record corresponds to an observations file.",
+      ".uze": "keyword to specify that record corresponds to an observations file.",
+      ".uzf": "keyword to specify that record corresponds to an observations file.",
+      ".uzt": "keyword to specify that record corresponds to an observations file.",
+      ".wel": "keyword to specify that record corresponds to an observations file.",
+      ".zdg": "keyword to specify that record corresponds to an observations file."
+    }
+  },
+  "outer_dvclose": {
+    "nonlinear": {
+      ".ims": "real value defining the dependent-variable (for example, head) change criterion for convergence of the outer (nonlinear) iterations, in units of the dependent-variable (for example, length for head). When the maximum absolute value of the dependent-variable change at all nodes during an iteration is less than or equal to OUTER\\_DVCLOSE, iteration stops. Commonly, OUTER\\_DVCLOSE equals 0.01. The keyword, OUTER\\_HCLOSE can be still be specified instead of OUTER\\_DVCLOSE for backward compatibility with previous versions of MODFLOW 6 but eventually OUTER\\_HCLOSE will be deprecated and specification of OUTER\\_HCLOSE will cause MODFLOW 6 to terminate with an error."
+    }
+  },
+  "outer_hclose": {
+    "nonlinear": {
+      ".ims": "real value defining the head change criterion for convergence of the outer (nonlinear) iterations, in units of length. When the maximum absolute value of the head change at all nodes during an iteration is less than or equal to OUTER\\_HCLOSE, iteration stops. Commonly, OUTER\\_HCLOSE equals 0.01.  The OUTER\\_HCLOSE option has been deprecated in favor of the more general OUTER\\_DVCLOSE (for dependent variable), however either one can be specified in order to maintain backward compatibility."
+    }
+  },
+  "outer_maximum": {
+    "nonlinear": {
+      ".ims": "integer value defining the maximum number of outer (nonlinear) iterations -- that is, calls to the solution routine. For a linear problem OUTER\\_MAXIMUM should be 1."
+    }
+  },
+  "outer_rclosebnd": {
+    "nonlinear": {
+      ".ims": "real value defining the residual tolerance for convergence of model packages that solve a separate equation not solved by the IMS linear solver. This value represents the maximum allowable residual between successive outer iterations at any single model package element. An example of a model package that would use OUTER\\_RCLOSEBND to evaluate convergence is the SFR package which solves a continuity equation for each reach.  The OUTER\\_RCLOSEBND option is deprecated and has no effect on simulation results as of version 6.1.1.  The keyword, OUTER\\_RCLOSEBND can be still be specified for backward compatibility with previous versions of MODFLOW 6 but eventually specification of OUTER\\_RCLOSEBND will cause MODFLOW 6 to terminate with an error."
+    }
+  },
+  "package_convergence": {
+    "options": {
+      ".csub": "keyword to specify that record corresponds to the package convergence comma spaced values file. Package convergence data is for delay interbeds. A warning message will be issued if package convergence data is requested but delay interbeds are not included in the package.",
+      ".lak": "keyword to specify that record corresponds to the package convergence comma spaced values file.",
+      ".sfr": "keyword to specify that record corresponds to the package convergence comma spaced values file.",
+      ".uzf": "keyword to specify that record corresponds to the package convergence comma spaced values file."
+    }
+  },
+  "partitions": {
+    "partitions": {
+      ".hpc": "is the list of zero-based partition numbers."
+    }
+  },
+  "perched": {
+    "options": {
+      ".npf": "keyword to indicate that when a cell is overlying a dewatered convertible cell, the head difference used in Darcy's Law is equal to the head in the overlying cell minus the bottom elevation of the overlying cell.  If not specified, then the default is to use the head difference between the two cells."
+    }
+  },
+  "porosity": {
+    "griddata": {
+      ".est": "is the mobile domain porosity, defined as the mobile domain pore volume per mobile domain volume.  The GWE model does not support the concept of an immobile domain in the context of heat transport. ",
+      ".ist": "porosity of the immobile domain specified as the immobile domain pore volume per immobile domain volume.",
+      ".mip": "is the aquifer porosity.",
+      ".mst": "is the mobile domain porosity, defined as the mobile domain pore volume per mobile domain volume.  Additional information on porosity within the context of mobile and immobile domain transport simulations is included in the MODFLOW 6 Supplemental Technical Information document. "
+    }
+  },
+  "preconditioner_drop_tolerance": {
+    "linear": {
+      ".ims": "optional real value that defines the drop tolerance used to drop preconditioner terms based on the magnitude of matrix entries in the ILUT and MILUT preconditioners. A value of $10^{-4}$ works well for most problems. By default, PRECONDITIONER\\_DROP\\_TOLERANCE is zero and the zero-fill incomplete LU factorization preconditioners (ILU(0) and MILU(0)) are used."
+    }
+  },
+  "preconditioner_levels": {
+    "linear": {
+      ".ims": "optional integer value defining the level of fill for ILU decomposition used in the ILUT and MILUT preconditioners. Higher levels of fill provide more robustness but also require more memory. For optimal performance, it is suggested that a large level of fill be applied (7 or 8) with use of a drop tolerance. Specification of a PRECONDITIONER\\_LEVELS value greater than zero results in use of the ILUT preconditioner. By default, PRECONDITIONER\\_LEVELS is zero and the zero-fill incomplete LU factorization preconditioners (ILU(0) and MILU(0)) are used."
+    }
+  },
+  "print": {
+    "period": {
+      ".oc": "keyword to indicate that information will be printed this stress period."
+    }
+  },
+  "print_concentration": {
+    "options": {
+      ".lkt": "keyword to indicate that the list of lake concentration will be printed to the listing file for every stress period in which ``CONCENTRATION PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_CONCENTRATION is specified, then concentration are printed for the last time step of each stress period.",
+      ".mwt": "keyword to indicate that the list of well concentration will be printed to the listing file for every stress period in which ``CONCENTRATION PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_CONCENTRATION is specified, then concentration are printed for the last time step of each stress period.",
+      ".sft": "keyword to indicate that the list of reach concentration will be printed to the listing file for every stress period in which ``CONCENTRATION PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_CONCENTRATION is specified, then concentration are printed for the last time step of each stress period.",
+      ".uzt": "keyword to indicate that the list of UZF cell concentration will be printed to the listing file for every stress period in which ``CONCENTRATION PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_CONCENTRATION is specified, then concentration are printed for the last time step of each stress period."
+    }
+  },
+  "print_flows": {
+    "options": {
+      ".api": "keyword to indicate that the list of api boundary flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".cdb": "keyword to indicate that the list of critical depth boundary flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".chd": "keyword to indicate that the list of constant-head flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".chfgwf": "keyword to indicate that the list of exchange flow rates will be printed to the listing file for every stress period in which ``SAVE BUDGET'' is specified in Output Control.",
+      ".cnc": "keyword to indicate that the list of constant concentration flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".ctp": "keyword to indicate that the list of constant temperature flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".dfw": "keyword to indicate that calculated flows between cells will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control. If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.  This option can produce extremely large list files because all cell-by-cell flows are printed.  It should only be used with the DFW Package for models that have a small number of cells.",
+      ".drn": "keyword to indicate that the list of drain flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".esl": "keyword to indicate that the list of energy source loading flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".evp": "keyword to indicate that the list of evaporation flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".evt": "keyword to indicate that the list of evapotranspiration flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".evta": "keyword to indicate that the list of evapotranspiration flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".flw": "keyword to indicate that the list of inflow flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".ghb": "keyword to indicate that the list of general-head boundary flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".gnc": "keyword to indicate that the list of GNC flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".gwegwe": "keyword to indicate that the list of exchange flow rates will be printed to the listing file for every stress period in which ``SAVE BUDGET'' is specified in Output Control.",
+      ".gwfgwf": "keyword to indicate that the list of exchange flow rates will be printed to the listing file for every stress period in which ``SAVE BUDGET'' is specified in Output Control.",
+      ".gwtgwt": "keyword to indicate that the list of exchange flow rates will be printed to the listing file for every stress period in which ``SAVE BUDGET'' is specified in Output Control.",
+      ".lak": "keyword to indicate that the list of lake flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".lke": "keyword to indicate that the list of lake flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".lkt": "keyword to indicate that the list of lake flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".maw": "keyword to indicate that the list of multi-aquifer well flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".mve": "keyword to indicate that the list of lake flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".mvr": "keyword to indicate that the list of MVR flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".mvt": "keyword to indicate that the list of lake flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".mwe": "keyword to indicate that the list of well flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".mwt": "keyword to indicate that the list of well flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".nam": "keyword to indicate that the list of all model package flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".npf": "keyword to indicate that calculated flows between cells will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control. If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.  This option can produce extremely large list files because all cell-by-cell flows are printed.  It should only be used with the NPF Package for models that have a small number of cells.",
+      ".olfgwf": "keyword to indicate that the list of exchange flow rates will be printed to the listing file for every stress period in which ``SAVE BUDGET'' is specified in Output Control.",
+      ".pcp": "keyword to indicate that the list of precipitation flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".rch": "keyword to indicate that the list of recharge flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".rcha": "keyword to indicate that the list of recharge flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".riv": "keyword to indicate that the list of river flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".sfe": "keyword to indicate that the list of reach flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".sfr": "keyword to indicate that the list of stream reach flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".sft": "keyword to indicate that the list of reach flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".src": "keyword to indicate that the list of mass source flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".ssm": "keyword to indicate that the list of SSM flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".uze": "keyword to indicate that the list of unsaturated zone flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".uzf": "keyword to indicate that the list of UZF flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".uzt": "keyword to indicate that the list of unsaturated zone flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".wel": "keyword to indicate that the list of well flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      ".zdg": "keyword to indicate that the list of zero-depth-gradient boundary flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period."
+    }
+  },
+  "print_format": {
+    "options": {
+      ".ist": "keyword to specify format for printing to the listing file.",
+      ".oc": "keyword to specify format for printing to the listing file."
+    }
+  },
+  "print_head": {
+    "options": {
+      ".maw": "keyword to indicate that the list of multi-aquifer well heads will be printed to the listing file for every stress period in which ``HEAD PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_HEAD is specified, then heads are printed for the last time step of each stress period."
+    }
+  },
+  "print_input": {
+    "options": {
+      ".api": "keyword to indicate that the list of api boundary information will be written to the listing file immediately after it is read.",
+      ".cdb": "keyword to indicate that the list of critical depth boundary information will be written to the listing file immediately after it is read.",
+      ".chd": "keyword to indicate that the list of constant-head information will be written to the listing file immediately after it is read.",
+      ".chfgwf": "keyword to indicate that the list of exchange entries will be echoed to the listing file immediately after it is read.",
+      ".cnc": "keyword to indicate that the list of constant concentration information will be written to the listing file immediately after it is read.",
+      ".csub": "keyword to indicate that the list of CSUB information will be written to the listing file immediately after it is read.",
+      ".ctp": "keyword to indicate that the list of constant temperature information will be written to the listing file immediately after it is read.",
+      ".cxs": "keyword to indicate that the list of stream reach information will be written to the listing file immediately after it is read.",
+      ".drn": "keyword to indicate that the list of drain information will be written to the listing file immediately after it is read.",
+      ".esl": "keyword to indicate that the list of energy source loading information will be written to the listing file immediately after it is read.",
+      ".evp": "keyword to indicate that the list of evaporation information will be written to the listing file immediately after it is read.",
+      ".evt": "keyword to indicate that the list of evapotranspiration information will be written to the listing file immediately after it is read.",
+      ".evta": "keyword to indicate that the list of evapotranspiration information will be written to the listing file immediately after it is read.",
+      ".flw": "keyword to indicate that the list of inflow information will be written to the listing file immediately after it is read.",
+      ".ghb": "keyword to indicate that the list of general-head boundary information will be written to the listing file immediately after it is read.",
+      ".gnc": "keyword to indicate that the list of GNC information will be written to the listing file immediately after it is read.",
+      ".gwegwe": "keyword to indicate that the list of exchange entries will be echoed to the listing file immediately after it is read.",
+      ".gwfgwf": "keyword to indicate that the list of exchange entries will be echoed to the listing file immediately after it is read.",
+      ".gwtgwt": "keyword to indicate that the list of exchange entries will be echoed to the listing file immediately after it is read.",
+      ".hfb": "keyword to indicate that the list of horizontal flow barriers will be written to the listing file immediately after it is read.",
+      ".lak": "keyword to indicate that the list of lake information will be written to the listing file immediately after it is read.",
+      ".lke": "keyword to indicate that the list of lake information will be written to the listing file immediately after it is read.",
+      ".lkt": "keyword to indicate that the list of lake information will be written to the listing file immediately after it is read.",
+      ".maw": "keyword to indicate that the list of multi-aquifer well information will be written to the listing file immediately after it is read.",
+      ".mve": "keyword to indicate that the list of mover information will be written to the listing file immediately after it is read.",
+      ".mvr": "keyword to indicate that the list of MVR information will be written to the listing file immediately after it is read.",
+      ".mvt": "keyword to indicate that the list of mover information will be written to the listing file immediately after it is read.",
+      ".mwe": "keyword to indicate that the list of well information will be written to the listing file immediately after it is read.",
+      ".mwt": "keyword to indicate that the list of well information will be written to the listing file immediately after it is read.",
+      ".nam": "keyword to indicate that the list of all model stress package information will be written to the listing file immediately after it is read.",
+      ".obs": "keyword to indicate that the list of observation information will be written to the listing file immediately after it is read.",
+      ".olfgwf": "keyword to indicate that the list of exchange entries will be echoed to the listing file immediately after it is read.",
+      ".pcp": "keyword to indicate that the list of precipitation information will be written to the listing file immediately after it is read.",
+      ".prp": "keyword to indicate that the list of all model stress package information will be written to the listing file immediately after it is read.",
+      ".rch": "keyword to indicate that the list of recharge information will be written to the listing file immediately after it is read.",
+      ".rcha": "keyword to indicate that the list of recharge information will be written to the listing file immediately after it is read.",
+      ".riv": "keyword to indicate that the list of river information will be written to the listing file immediately after it is read.",
+      ".sfe": "keyword to indicate that the list of reach information will be written to the listing file immediately after it is read.",
+      ".sfr": "keyword to indicate that the list of stream reach information will be written to the listing file immediately after it is read.",
+      ".sft": "keyword to indicate that the list of reach information will be written to the listing file immediately after it is read.",
+      ".spc": "keyword to indicate that the list of spc information will be written to the listing file immediately after it is read.",
+      ".spca": "keyword to indicate that the list of spc information will be written to the listing file immediately after it is read.",
+      ".src": "keyword to indicate that the list of mass source information will be written to the listing file immediately after it is read.",
+      ".tvk": "keyword to indicate that information for each change to the hydraulic conductivity in a cell will be written to the model listing file.",
+      ".tvs": "keyword to indicate that information for each change to a storage property in a cell will be written to the model listing file.",
+      ".uze": "keyword to indicate that the list of unsaturated zone flow information will be written to the listing file immediately after it is read.",
+      ".uzf": "keyword to indicate that the list of UZF information will be written to the listing file immediately after it is read.",
+      ".uzt": "keyword to indicate that the list of unsaturated zone flow information will be written to the listing file immediately after it is read.",
+      ".wel": "keyword to indicate that the list of well information will be written to the listing file immediately after it is read.",
+      ".zdg": "keyword to indicate that the list of zero-depth-gradient boundary information will be written to the listing file immediately after it is read."
+    }
+  },
+  "print_option": {
+    "options": {
+      ".ims": "is a flag that controls printing of convergence information from the solver.  NONE means print nothing. SUMMARY means print only the total number of iterations and nonlinear residual reduction summaries. ALL means print linear matrix solver convergence information to the solution listing file and model specific linear matrix solver convergence information to each model listing file in addition to SUMMARY information. NONE is default if PRINT\\_OPTION is not specified.",
+      ".pts": "is a flag that controls printing of convergence information from the solver.  NONE means print nothing. SUMMARY means print only the total number of iterations and nonlinear residual reduction summaries. ALL means print linear matrix solver convergence information to the solution listing file and model specific linear matrix solver convergence information to each model listing file in addition to SUMMARY information. NONE is default if PRINT\\_OPTION is not specified."
+    }
+  },
+  "print_stage": {
+    "options": {
+      ".lak": "keyword to indicate that the list of lake stages will be printed to the listing file for every stress period in which ``HEAD PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_STAGE is specified, then stages are printed for the last time step of each stress period.",
+      ".sfr": "keyword to indicate that the list of stream reach stages will be printed to the listing file for every stress period in which ``HEAD PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_STAGE is specified, then stages are printed for the last time step of each stress period."
+    }
+  },
+  "print_table": {
+    "options": {
+      ".hpc": "keyword to indicate that the partition table will be printed to the listing file."
+    }
+  },
+  "print_temperature": {
+    "options": {
+      ".lke": "keyword to indicate that the list of lake temperature will be printed to the listing file for every stress period in which ``TEMPERATURE PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_TEMPERATURE is specified, then temperature are printed for the last time step of each stress period.",
+      ".mwe": "keyword to indicate that the list of well temperature will be printed to the listing file for every stress period in which ``TEMPERATURE PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_TEMPERATURE is specified, then temperature are printed for the last time step of each stress period.",
+      ".sfe": "keyword to indicate that the list of reach temperatures will be printed to the listing file for every stress period in which ``TEMPERATURE PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_TEMPERATURE is specified, then temperatures are printed for the last time step of each stress period.",
+      ".uze": "keyword to indicate that the list of UZF cell temperatures will be printed to the listing file for every stress period in which ``TEMPERATURE PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_TEMPERATURE is specified, then temperatures are printed for the last time step of each stress period."
+    }
+  },
+  "profile_option": {
+    "options": {
+      ".nam": "is a flag that controls performance profiling and reporting.  NONE disables profiling. SUMMARY means to measure and print a coarse performance profile. DETAIL means collect and print information with the highest resolution available. NONE is default if PROFILE\\_OPTION is not specified."
+    }
+  },
+  "qoutflow": {
+    "options": {
+      ".oc": "keyword to specify that record corresponds to qoutflow."
+    }
+  },
+  "rainfall": {
+    "period": {
+      ".lak": "real or character value that defines the rainfall rate $(LT^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      ".lke": "real or character value that defines the rainfall temperature for the lake. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      ".lkt": "real or character value that defines the rainfall solute concentration $(ML^{-3})$ for the lake. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      ".sfe": "real or character value that defines the rainfall temperature $(e.g.,\\:^{\\circ}C\\:or\\:^{\\circ}F)$ for the reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      ".sfr": "real or character value that defines the  volumetric rate per unit area of water added by precipitation directly on the streamflow routing reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, rainfall  rates are zero for each reach.",
+      ".sft": "real or character value that defines the rainfall solute concentration $(ML^{-3})$ for the reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+    }
+  },
+  "rate": {
+    "period": {
+      ".evta": "is the maximum ET flux rate ($LT^{-1}$).",
+      ".lak": "real or character value that defines the extraction rate for the lake outflow. A positive value indicates inflow and a negative value indicates outflow from the lake. RATE only applies to outlets associated with active lakes (STATUS is ACTIVE). A specified RATE is only applied if COUTTYPE for the OUTLETNO is SPECIFIED. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, the RATE for each SPECIFIED lake outlet is zero.",
+      ".maw": "is the volumetric pumping rate for the multi-aquifer well. A positive value indicates recharge and a negative value indicates discharge (pumping). RATE only applies to active (STATUS is ACTIVE) multi-aquifer wells. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, the RATE for each multi-aquifer well is zero.",
+      ".mwe": "real or character value that defines the injection temperature $(e.g.,\\:^{\\circ}C\\:or\\:^{\\circ}F)$ for the well. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      ".mwt": "real or character value that defines the injection solute concentration $(ML^{-3})$ for the well. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+    }
+  },
+  "rate_scaling": {
+    "period": {
+      ".maw": "activate rate scaling.  If RATE\\_SCALING is specified, both PUMP\\_ELEVATION and SCALING\\_LENGTH must be specified. RATE\\_SCALING cannot be used with HEAD\\_LIMIT.  RATE\\_SCALING can be used for extraction or injection wells.  For extraction wells, the extraction rate will start to decrease once the head in the well lowers to a level equal to the pump elevation plus the scaling length.  If the head in the well drops below the pump elevation, then the extraction rate is calculated to be zero.  For an injection well, the injection rate will begin to decrease once the head in the well rises above the specified pump elevation.  If the head in the well rises above the pump elevation plus the scaling length, then the injection rate will be set to zero."
+    }
+  },
+  "readasarrays": {
+    "options": {
+      ".evta": "indicates that array-based input will be used for the Evapotranspiration Package.  This keyword must be specified to use array-based input.  When READASARRAYS is specified, values must be provided for every cell within a model layer, even those cells that have an IDOMAIN value less than one.  Values assigned to cells with IDOMAIN values less than one are not used and have no effect on simulation results.",
+      ".rcha": "indicates that array-based input will be used for the Recharge Package.  This keyword must be specified to use array-based input.  When READASARRAYS is specified, values must be provided for every cell within a model layer, even those cells that have an IDOMAIN value less than one.  Values assigned to cells with IDOMAIN values less than one are not used and have no effect on simulation results. ",
+      ".spca": "indicates that array-based input will be used for the SPC Package.  This keyword must be specified to use array-based input.  When READASARRAYS is specified, values must be provided for every cell within a model layer, even those cells that have an IDOMAIN value less than one.  Values assigned to cells with IDOMAIN values less than one are not used and have no effect on simulation results."
+    }
+  },
+  "recharge": {
+    "period": {
+      ".rcha": "is the recharge flux rate ($LT^{-1}$).  This rate is multiplied inside the program by the surface area of the cell to calculate the volumetric recharge rate. The recharge array may be defined by a time-array series (see the ``Using Time-Array Series in a Package'' section)."
+    }
+  },
+  "relaxation_factor": {
+    "linear": {
+      ".ims": "optional real value that defines the relaxation factor used by the incomplete LU factorization preconditioners (MILU(0) and MILUT). RELAXATION\\_FACTOR is unitless and should be greater than or equal to 0.0 and less than or equal to 1.0. RELAXATION\\_FACTOR values of about 1.0 are commonly used, and experience suggests that convergence can be optimized in some cases with relax values of 0.97. A RELAXATION\\_FACTOR value of 0.0 will result in either ILU(0) or ILUT preconditioning (depending on the value specified for PRECONDITIONER\\_LEVELS and/or PRECONDITIONER\\_DROP\\_TOLERANCE). By default,  RELAXATION\\_FACTOR is zero."
+    }
+  },
+  "release_time_frequency": {
+    "options": {
+      ".prp": "real number indicating the time frequency at which to release particles. This option can be used to schedule releases at a regular interval for the duration of the simulation, starting at the simulation start time. The release schedule is the union of this option, the RELEASETIMES block, and PERIOD block RELEASESETTING selections. If none of these are provided, a single release time is configured at the beginning of the first time step of the simulation's first stress period."
+    }
+  },
+  "release_time_tolerance": {
+    "options": {
+      ".prp": "real number indicating the tolerance within which to consider consecutive release times coincident. Coincident release times will be merged into a single release time. The default is $\\epsilon \\times 10^{11}$, where $\\epsilon$ is machine precision."
+    }
+  },
+  "reordering_method": {
+    "linear": {
+      ".ims": "an optional keyword that defines the matrix reordering approach used. By default, matrix reordering is not applied.  NONE - original ordering.  RCM - reverse Cuthill McKee ordering.  MD - minimum degree ordering."
+    }
+  },
+  "retfactor": {
+    "griddata": {
+      ".mip": "is a real value by which velocity is divided within a given cell.  RETFACTOR can be used to account for solute retardation, i.e., the apparent effect of linear sorption on the velocity of particles that track solute advection.  RETFACTOR may be assigned any real value.  A RETFACTOR value greater than 1 represents particle retardation (slowing), and a value of 1 represents no retardation.  The effect of specifying a RETFACTOR value for each cell is the same as the effect of directly multiplying the POROSITY in each cell by the proposed RETFACTOR value for each cell.  RETFACTOR allows conceptual isolation of effects such as retardation from the effect of porosity.  The default value is 1."
+    }
+  },
+  "rewet": {
+    "options": {
+      ".npf": "activates model rewetting.  Rewetting is off by default."
+    }
+  },
+  "rhs": {
+    "options": {
+      ".npf": "If the RHS keyword is also included, then the XT3D additional terms will be added to the right-hand side.  If the RHS keyword is excluded, then the XT3D terms will be put into the coefficient matrix."
+    }
+  },
+  "rough": {
+    "period": {
+      ".lak": "real value that defines the roughness coefficient for the lake outlet. Any value can be specified if COUTTYPE is not MANNING. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+    }
+  },
+  "runoff": {
+    "period": {
+      ".lak": "real or character value that defines the runoff rate $(L^3 T^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      ".lkt": "real or character value that defines the concentration of runoff $(ML^{-3})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      ".sfe": "real or character value that defines the temperature of runoff $(e.g.,\\:^{\\circ}C\\:or\\:^{\\circ}F)$ for the reach.  Users are free to use whatever temperature scale they want, which might include negative temperatures.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      ".sfr": "real or character value that defines the volumetric rate of diffuse overland runoff that enters the streamflow routing reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. If the volumetric runoff rate for a reach is negative and exceeds inflows to the reach (upstream and specified inflows, and rainfall but excluding groundwater leakage into the reach) the volumetric runoff rate is limited to inflows to the reach and the volumetric evaporation rate for the reach is set to zero. By default, runoff rates are zero for each reach.",
+      ".sft": "real or character value that defines the concentration of runoff $(ML^{-3})$ for the reach. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+    }
+  },
+  "save": {
+    "period": {
+      ".oc": "keyword to indicate that information will be saved this stress period."
+    }
+  },
+  "save_flows": {
+    "options": {
+      ".api": "keyword to indicate that api boundary flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".cdb": "keyword to indicate that critical depth boundary flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".chd": "keyword to indicate that constant-head flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".cnc": "keyword to indicate that constant concentration flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".csub": "keyword to indicate that cell-by-cell flow terms will be written to the file specified with ``BUDGET SAVE FILE'' in Output Control.",
+      ".ctp": "keyword to indicate that constant temperature flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".dfw": "keyword to indicate that budget flow terms will be written to the file specified with ``BUDGET SAVE FILE'' in Output Control.",
+      ".drn": "keyword to indicate that drain flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".esl": "keyword to indicate that energy source loading flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".est": "keyword to indicate that EST flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".evp": "keyword to indicate that evaporation flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".evt": "keyword to indicate that evapotranspiration flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".evta": "keyword to indicate that evapotranspiration flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".flw": "keyword to indicate that inflow flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".fmi": "keyword to indicate that FMI flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".ghb": "keyword to indicate that general-head boundary flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".gwegwe": "keyword to indicate that cell-by-cell flow terms will be written to the budget file for each model provided that the Output Control for the models are set up with the ``BUDGET SAVE FILE'' option.",
+      ".gwfgwf": "keyword to indicate that cell-by-cell flow terms will be written to the budget file for each model provided that the Output Control for the models are set up with the ``BUDGET SAVE FILE'' option.",
+      ".gwtgwt": "keyword to indicate that cell-by-cell flow terms will be written to the budget file for each model provided that the Output Control for the models are set up with the ``BUDGET SAVE FILE'' option.",
+      ".ist": "keyword to indicate that IST flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".lak": "keyword to indicate that lake flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".lke": "keyword to indicate that lake flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".lkt": "keyword to indicate that lake flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".maw": "keyword to indicate that multi-aquifer well flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".mst": "keyword to indicate that MST flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".mve": "keyword to indicate that lake flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".mvt": "keyword to indicate that lake flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".mwe": "keyword to indicate that well flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".mwt": "keyword to indicate that well flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".nam": "keyword to indicate that all model package flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".npf": "keyword to indicate that budget flow terms will be written to the file specified with ``BUDGET SAVE FILE'' in Output Control.",
+      ".pcp": "keyword to indicate that precipitation flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".rch": "keyword to indicate that recharge flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".rcha": "keyword to indicate that recharge flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".riv": "keyword to indicate that river flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".sfe": "keyword to indicate that reach flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".sfr": "keyword to indicate that stream reach flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".sft": "keyword to indicate that reach flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".src": "keyword to indicate that mass source flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".ssm": "keyword to indicate that SSM flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".sto": "keyword to indicate that cell-by-cell flow terms will be written to the file specified with ``BUDGET SAVE FILE'' in Output Control.",
+      ".uze": "keyword to indicate that unsaturated zone flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".uzf": "keyword to indicate that UZF flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".uzt": "keyword to indicate that unsaturated zone flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".wel": "keyword to indicate that well flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      ".zdg": "keyword to indicate that zero-depth-gradient boundary flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control."
+    }
+  },
+  "save_saturation": {
+    "options": {
+      ".npf": "keyword to indicate that cell saturation will be written to the budget file, which is specified with ``BUDGET SAVE FILE'' in Output Control.  Saturation will be saved to the budget file as an auxiliary variable saved with the DATA-SAT text label.  Saturation is a cell variable that ranges from zero to one and can be used by post processing programs to determine how much of a cell volume is saturated.  If ICELLTYPE is 0, then saturation is always one."
+    }
+  },
+  "save_specific_discharge": {
+    "options": {
+      ".npf": "keyword to indicate that x, y, and z components of specific discharge will be calculated at cell centers and written to the budget file, which is specified with ``BUDGET SAVE FILE'' in Output Control.  If this option is activated, then additional information may be required in the discretization packages and the GWF Exchange package (if GWF models are coupled).  Specifically, ANGLDEGX must be specified in the CONNECTIONDATA block of the DISU Package; ANGLDEGX must also be specified for the GWF Exchange as an auxiliary variable."
+    }
+  },
+  "save_velocity": {
+    "options": {
+      ".dfw": "keyword to indicate that x, y, and z components of velocity will be calculated at cell centers and written to the budget file, which is specified with ``BUDGET SAVE FILE'' in Output Control.  If this option is activated, then additional information may be required in the discretization packages and the GWF Exchange package (if GWF models are coupled).  Specifically, ANGLDEGX must be specified in the CONNECTIONDATA block of the DISU Package; ANGLDEGX must also be specified for the GWF Exchange as an auxiliary variable."
+    }
+  },
+  "scaling_method": {
+    "linear": {
+      ".ims": "an optional keyword that defines the matrix scaling approach used. By default, matrix scaling is not applied.  NONE - no matrix scaling applied.  DIAGONAL - symmetric matrix scaling using the POLCG preconditioner scaling method in Hill (1992).  L2NORM - symmetric matrix scaling using the L2 norm."
+    }
+  },
+  "scheme": {
+    "options": {
+      ".adv": "scheme used to solve the advection term.  Can be upstream, central, or TVD.  If not specified, upstream weighting is the default weighting scheme."
+    }
+  },
+  "sfac": {
+    "attributes": {
+      ".tas": "xxx"
+    }
+  },
+  "sfacs": {
+    "attributes": {
+      ".ts": "xxx"
+    }
+  },
+  "sgm": {
+    "griddata": {
+      ".csub": "is the specific gravity of moist or unsaturated sediments.  If not specified, then a default value of 1.7 is assigned."
+    }
+  },
+  "sgs": {
+    "griddata": {
+      ".csub": "is the specific gravity of saturated sediments. If not specified, then a default value of 2.0 is assigned."
+    }
+  },
+  "shuffle": {
+    "options": {
+      ".ncf": "is the keyword used to turn on the netcdf variable shuffle filter when the deflate option is also set. The shuffle filter has the effect of storing the first byte of all of a variable's values in a chunk contiguously, followed by all the second bytes, etc. This can be an optimization for compression with certain types of data."
+    }
+  },
+  "shut_off": {
+    "period": {
+      ".maw": "keyword for activating well shut off capability.  Subsequent values define the minimum and maximum pumping rate that a well must exceed to shutoff or reactivate a well, respectively, during a stress period. SHUT\\_OFF is only applied to injection wells (RATE$<0$) and if HEAD\\_LIMIT is specified (not set to `OFF').  If HEAD\\_LIMIT is specified, SHUT\\_OFF can be deactivated by specifying a minimum value equal to zero. The SHUT\\_OFF option is based on the SHUT\\_OFF functionality available in the MNW2~\\citep{konikow2009} package for MODFLOW-2005. The SHUT\\_OFF option has been included to facilitate backward compatibility with previous versions of MODFLOW but use of the RATE\\_SCALING option instead of the SHUT\\_OFF option is recommended. By default, SHUT\\_OFF is not used."
+    }
+  },
+  "shutdown_kappa": {
+    "options": {
+      ".maw": "value that defines the weight applied to discharge rate for wells that limit the water level in a discharging well (defined using the HEAD\\_LIMIT keyword in the stress period data). SHUTDOWN\\_KAPPA is used to control discharge rate oscillations when the flow rate from the aquifer is less than the specified flow rate from the aquifer to the well. Values range between 0.0 and 1.0, and larger values increase the weight applied to the well discharge rate. The HEAD\\_LIMIT option has been included to facilitate backward compatibility with previous versions of MODFLOW but use of the RATE\\_SCALING option instead of the HEAD\\_LIMIT option is recommended. By default, SHUTDOWN\\_KAPPA is 0.0001."
+    }
+  },
+  "shutdown_theta": {
+    "options": {
+      ".maw": "value that defines the weight applied to discharge rate for wells that limit the water level in a discharging well (defined using the HEAD\\_LIMIT keyword in the stress period data). SHUTDOWN\\_THETA is used to control discharge rate oscillations when the flow rate from the aquifer is less than the specified flow rate from the aquifer to the well. Values range between 0.0 and 1.0, and larger values increase the weight (decrease under-relaxation) applied to the well discharge rate. The HEAD\\_LIMIT option has been included to facilitate backward compatibility with previous versions of MODFLOW but use of the RATE\\_SCALING option instead of the HEAD\\_LIMIT option is recommended. By default, SHUTDOWN\\_THETA is 0.7."
+    }
+  },
+  "simulate_et": {
+    "options": {
+      ".uzf": "keyword specifying that ET in the unsaturated (UZF) and saturated zones (GWF) will be simulated. ET can be simulated in the UZF cell and not the GWF cell by omitting keywords LINEAR\\_GWET and SQUARE\\_GWET."
+    }
+  },
+  "simulate_gwseep": {
+    "options": {
+      ".uzf": "keyword specifying that groundwater discharge (GWSEEP) to land surface will be simulated. Groundwater discharge is nonzero when groundwater head is greater than land surface.  This option is no longer recommended; a better approach is to use the Drain Package with discharge scaling as a way to handle seepage to land surface.  The Drain Package with discharge scaling is described in Chapter 3 of the Supplemental Technical Information. "
+    }
+  },
+  "slope": {
+    "period": {
+      ".lak": "real or character value that defines the bed slope for the lake outlet. A specified SLOPE value is only used for active lakes if COUTTYPE for lake outlet OUTLETNO is MANNING. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+    }
+  },
+  "solutiongroup": {
+    "solutiongroup": {
+      ".nam": "is the list of solution types and models in the solution."
+    }
+  },
+  "sorbate": {
+    "options": {
+      ".ist": "keyword to specify that record corresponds to immobile sorbate concentration.",
+      ".mst": "keyword to specify that record corresponds to sorbate concentration."
+    }
+  },
+  "sorption": {
+    "options": {
+      ".ist": "is a text keyword to indicate that sorption will be activated.  Valid sorption options include LINEAR, FREUNDLICH, and LANGMUIR.  Use of this keyword requires that BULK\\_DENSITY and DISTCOEF are specified in the GRIDDATA block.  If sorption is specified as FREUNDLICH or LANGMUIR then SP2 is also required in the GRIDDATA block.  The sorption option must be consistent with the sorption option specified in the MST Package or the program will terminate with an error.",
+      ".mst": "is a text keyword to indicate that sorption will be activated.  Valid sorption options include LINEAR, FREUNDLICH, and LANGMUIR.  Use of this keyword requires that BULK\\_DENSITY and DISTCOEF are specified in the GRIDDATA block.  If sorption is specified as FREUNDLICH or LANGMUIR then SP2 is also required in the GRIDDATA block."
+    }
+  },
+  "sp2": {
+    "griddata": {
+      ".ist": "is the exponent for the Freundlich isotherm and the sorption capacity for the Langmuir isotherm.  sp2 is not required unless the SORPTION keyword is specified in the options block and sorption is specified as FREUNDLICH or LANGMUIR. If the SORPTION keyword is not specified in the options block, or if sorption is specified as LINEAR, sp2 will have no effect on simulation results. ",
+      ".mst": "is the exponent for the Freundlich isotherm and the sorption capacity for the Langmuir isotherm.  sp2 is not required unless the SORPTION keyword is specified in the options block.  If the SORPTION keyword is not specified in the options block, sp2 will have no effect on simulation results. "
+    }
+  },
+  "specified_initial_delay_head": {
+    "options": {
+      ".csub": "keyword to indicate that absolute initial delay bed head will be specified for interbeds defined in the PACKAGEDATA block. If SPECIFIED\\_INITIAL\\_DELAY\\_HEAD and SPECIFIED\\_INITIAL\\_INTERBED\\_STATE are not specified then delay bed head values specified in the PACKAGEDATA block are relative to simulated values if the first stress period is steady-state or initial GWF heads if the first stress period is transient."
+    }
+  },
+  "specified_initial_interbed_state": {
+    "options": {
+      ".csub": "keyword to indicate that absolute preconsolidation stresses (heads) and delay bed heads will be specified for interbeds defined in the PACKAGEDATA block. The SPECIFIED\\_INITIAL\\_INTERBED\\_STATE option is equivalent to specifying the SPECIFIED\\_INITIAL\\_PRECONSOLITATION\\_STRESS and SPECIFIED\\_INITIAL\\_DELAY\\_HEAD. If SPECIFIED\\_INITIAL\\_INTERBED\\_STATE is not specified then preconsolidation stress (head) and delay bed head values specified in the PACKAGEDATA block are relative to simulated values of the first stress period if steady-state or initial stresses and GWF heads if the first stress period is transient."
+    }
+  },
+  "specified_initial_preconsolidation_stress": {
+    "options": {
+      ".csub": "keyword to indicate that absolute preconsolidation stresses (heads) will be specified for interbeds defined in the PACKAGEDATA block. If SPECIFIED\\_INITIAL\\_PRECONSOLITATION\\_STRESS and SPECIFIED\\_INITIAL\\_INTERBED\\_STATE are not specified then preconsolidation stress (head) values specified in the PACKAGEDATA block are relative to simulated values if the first stress period is steady-state or initial stresses (heads) if the first stress period is transient."
+    }
+  },
+  "square_gwet": {
+    "options": {
+      ".uzf": "keyword specifying that groundwater ET will be simulated by assuming a constant ET rate for groundwater levels between land surface (TOP) and land surface minus the ET extinction depth (TOP-EXTDP). Groundwater ET is smoothly reduced from the PET rate to zero over a nominal interval at TOP-EXTDP."
+    }
+  },
+  "ss": {
+    "griddata": {
+      ".sto": "is specific storage (or the storage coefficient if STORAGECOEFFICIENT is specified as an option). Specific storage values must be greater than or equal to 0. If the CSUB Package is included in the GWF model, specific storage must be zero for every cell."
+    },
+    "period": {
+      ".tvs": "is the new value to be assigned as the cell's specific storage (or storage coefficient if the STORAGECOEFFICIENT STO package option is specified) from the start of the specified stress period, as per SS in the STO package.  Specific storage values must be greater than or equal to 0.  If the OPTIONS block includes a TS6 entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+    }
+  },
+  "ss_confined_only": {
+    "options": {
+      ".sto": "keyword to indicate that compressible storage is only calculated for a convertible cell (ICONVERT>0) when the cell is under confined conditions (head greater than or equal to the top of the cell). This option has no effect on cells that are marked as being always confined (ICONVERT=0).  This option is identical to the approach used to calculate storage changes under confined conditions in MODFLOW-2005."
+    }
+  },
+  "stage": {
+    "options": {
+      ".lak": "keyword to specify that record corresponds to stage.",
+      ".oc": "keyword to specify that record corresponds to stage.",
+      ".sfr": "keyword to specify that record corresponds to stage."
+    },
+    "period": {
+      ".lak": "real or character value that defines the stage for the lake. The specified STAGE is only applied if the lake is a constant stage lake. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      ".sfr": "real or character value that defines the stage for the reach. The specified STAGE is only applied if the reach uses the simple routing option. If STAGE is not specified for reaches that use the simple routing option, the specified stage is set to the top of the reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
     }
   },
   "start_date_time": {
@@ -2598,14 +2137,475 @@
       ".tdis": "is the starting date and time of the simulation.  This is a text string that is used as a label within the simulation list file.  The value has no effect on the simulation.  The recommended format for the starting date and time is described at https://www.w3.org/TR/NOTE-datetime."
     }
   },
-  "ats6": {
-    "options": {
-      ".tdis": "keyword to specify that record corresponds to an adaptive time step (ATS) input file.  The behavior of ATS and a description of the input file is provided separately."
+  "status": {
+    "period": {
+      ".lak": "keyword option to define lake status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE.",
+      ".lke": "keyword option to define lake status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that temperature will be calculated for the lake.  If a lake is inactive, then there will be no energy fluxes into or out of the lake and the inactive value will be written for the lake temperature.  If a lake is constant, then the temperature for the lake will be fixed at the user specified value.",
+      ".lkt": "keyword option to define lake status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that concentration will be calculated for the lake.  If a lake is inactive, then there will be no solute mass fluxes into or out of the lake and the inactive value will be written for the lake concentration.  If a lake is constant, then the concentration for the lake will be fixed at the user specified value.",
+      ".maw": "keyword option to define well status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE.",
+      ".mwe": "keyword option to define well status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that temperature will be calculated for the well.  If a well is inactive, then there will be no solute mass fluxes into or out of the well and the inactive value will be written for the well temperature.  If a well is constant, then the temperature for the well will be fixed at the user specified value.",
+      ".mwt": "keyword option to define well status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that concentration will be calculated for the well.  If a well is inactive, then there will be no solute mass fluxes into or out of the well and the inactive value will be written for the well concentration.  If a well is constant, then the concentration for the well will be fixed at the user specified value.",
+      ".sfe": "keyword option to define reach status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that temperature will be calculated for the reach.  If a reach is inactive, then there will be no energy fluxes into or out of the reach and the inactive value will be written for the reach temperature.  If a reach is constant, then the temperature for the reach will be fixed at the user specified value.",
+      ".sfr": "keyword option to define stream reach status.  STATUS can be ACTIVE, INACTIVE, or SIMPLE. The SIMPLE STATUS option simulates streamflow using a user-specified stage for a reach or a stage set to the top of the reach (depth = 0). In cases where the simulated leakage calculated using the specified stage exceeds the sum of inflows to the reach, the stage is set to the top of the reach and leakage is set equal to the sum of inflows. Upstream fractions should be changed using the UPSTREAM\\_FRACTION SFRSETTING if the status for one or more reaches is changed to ACTIVE or INACTIVE. For example, if one of two downstream connections for a reach is inactivated, the upstream fraction for the active and inactive downstream reach should be changed to 1.0 and 0.0, respectively, to ensure that the active reach receives all of the downstream outflow from the upstream reach. By default, STATUS is ACTIVE.",
+      ".sft": "keyword option to define reach status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that concentration will be calculated for the reach.  If a reach is inactive, then there will be no solute mass fluxes into or out of the reach and the inactive value will be written for the reach concentration.  If a reach is constant, then the concentration for the reach will be fixed at the user specified value.",
+      ".uze": "keyword option to define UZF cell status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that temperature will be calculated for the UZF cell.  If a UZF cell is inactive, then there will be no energy fluxes into or out of the UZF cell and the inactive value will be written for the UZF cell temperature.  If a UZF cell is constant, then the temperature for the UZF cell will be fixed at the user specified value.",
+      ".uzt": "keyword option to define UZF cell status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that concentration will be calculated for the UZF cell.  If a UZF cell is inactive, then there will be no solute mass fluxes into or out of the UZF cell and the inactive value will be written for the UZF cell concentration.  If a UZF cell is constant, then the concentration for the UZF cell will be fixed at the user specified value."
     }
   },
-  "nper": {
-    "dimensions": {
-      ".tdis": "is the number of stress periods for the simulation."
+  "steady-state": {
+    "period": {
+      ".sto": "keyword to indicate that stress period IPER is steady-state. Steady-state conditions will apply until the TRANSIENT keyword is specified in a subsequent BEGIN PERIOD block."
+    }
+  },
+  "steps": {
+    "period": {
+      ".oc": "save for each step specified in STEPS. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
+      ".prp": "release at the start of each step specified in STEPS. This option may be used in conjunction with other RELEASESETTING options."
+    }
+  },
+  "stop_at_weak_sink": {
+    "options": {
+      ".prp": "is a text keyword to indicate that a particle is to terminate when it enters a cell that is a weak sink.  By default, particles are allowed to pass though cells that are weak sinks."
+    }
+  },
+  "stoptime": {
+    "options": {
+      ".prp": "real value defining the maximum simulation time to which particles in the package can be tracked.  Particles that have not terminated earlier due to another termination condition will terminate when simulation time STOPTIME is reached.  If the last stress period in the simulation consists of more than one time step, particles will not be tracked past the ending time of the last stress period, regardless of STOPTIME.  If the EXTEND\\_TRACKING option is enabled and the last stress period in the simulation is steady-state, the simulation ending time will not limit the time to which particles can be tracked, but STOPTIME and STOPTRAVELTIME will continue to apply.  If STOPTIME and STOPTRAVELTIME are both provided, particles will be stopped if either is reached."
+    }
+  },
+  "stoptraveltime": {
+    "options": {
+      ".prp": "real value defining the maximum travel time over which particles in the model can be tracked.  Particles that have not terminated earlier due to another termination condition will terminate when their travel time reaches STOPTRAVELTIME.  If the last stress period in the simulation consists of more than one time step, particles will not be tracked past the ending time of the last stress period, regardless of STOPTRAVELTIME.  If the EXTEND\\_TRACKING option is enabled and the last stress period in the simulation is steady-state, the simulation ending time will not limit the time to which particles can be tracked, but STOPTIME and STOPTRAVELTIME will continue to apply.  If STOPTIME and STOPTRAVELTIME are both provided, particles will be stopped if either is reached."
+    }
+  },
+  "storage": {
+    "options": {
+      ".sfr": "keyword that activates storage contributions to the stream-flow routing package continuity equation."
+    }
+  },
+  "storagecoefficient": {
+    "options": {
+      ".sto": "keyword to indicate that the SS array is read as storage coefficient rather than specific storage."
+    }
+  },
+  "strain_csv_coarse": {
+    "options": {
+      ".csub": "keyword to specify the record that corresponds to final coarse-grained material strain output."
+    }
+  },
+  "strain_csv_interbed": {
+    "options": {
+      ".csub": "keyword to specify the record that corresponds to final interbed strain output."
+    }
+  },
+  "strt": {
+    "griddata": {
+      ".ic": "is the initial (starting) concentration---that is, concentration at the beginning of the GWT Model simulation.  STRT must be specified for all GWT Model simulations. One value is read for every model cell."
+    }
+  },
+  "surf_rate_specified": {
+    "options": {
+      ".evt": "indicates that the proportion of the evapotranspiration rate at the ET surface will be specified as PETM0 in list input."
+    }
+  },
+  "surface": {
+    "period": {
+      ".evta": "is the elevation of the ET surface ($L$)."
+    }
+  },
+  "surfdep": {
+    "options": {
+      ".lak": "real value that defines the surface depression depth for VERTICAL lake-GWF connections. If specified, SURFDEP must be greater than or equal to zero. If SURFDEP is not specified, a default value of zero is used for all vertical lake-GWF connections."
+    }
+  },
+  "sy": {
+    "griddata": {
+      ".sto": "is specific yield. Specific yield values must be greater than or equal to 0. Specific yield does not have to be specified if there are no convertible cells (ICONVERT=0 in every cell)."
+    },
+    "period": {
+      ".tvs": "is the new value to be assigned as the cell's specific yield from the start of the specified stress period, as per SY in the STO package.  Specific yield values must be greater than or equal to 0.  If the OPTIONS block includes a TS6 entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+    }
+  },
+  "tab6": {
+    "crosssections": {
+      ".sfr": "keyword to specify that record corresponds to a cross-section table file."
+    },
+    "period": {
+      ".sfr": "keyword to specify that record corresponds to a cross-section table file."
+    },
+    "tables": {
+      ".lak": "keyword to specify that record corresponds to a table file."
+    }
+  },
+  "tas6": {
+    "options": {
+      ".evta": "keyword to specify that record corresponds to a time-array-series file.",
+      ".rcha": "keyword to specify that record corresponds to a time-array-series file.",
+      ".spca": "keyword to specify that record corresponds to a time-array-series file."
+    }
+  },
+  "tdis6": {
+    "timing": {
+      ".nam": "is the name of the Temporal Discretization (TDIS) Input File."
+    }
+  },
+  "temperature": {
+    "options": {
+      ".lke": "keyword to specify that record corresponds to temperature.",
+      ".mwe": "keyword to specify that record corresponds to temperature.",
+      ".oc": "keyword to specify that record corresponds to temperature.",
+      ".sfe": "keyword to specify that record corresponds to temperature.",
+      ".uze": "keyword to specify that record corresponds to temperature."
+    },
+    "period": {
+      ".lke": "real or character value that defines the temperature for the lake. The specified TEMPERATURE is only applied if the lake is a constant temperature lake. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      ".mwe": "real or character value that defines the temperature for the well. The specified TEMPERATURE is only applied if the well is a constant temperature well. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      ".sfe": "real or character value that defines the temperature for the reach. The specified TEMPERATURE is only applied if the reach is a constant temperature reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      ".spc": "is the user-supplied boundary temperature. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, the TEMPERATURE for each boundary feature is zero.",
+      ".spca": "is the temperature of the associated Recharge or Evapotranspiration stress package.  The temperature array may be defined by a time-array series (see the \"Using Time-Array Series in a Package\" section).",
+      ".uze": "real or character value that defines the temperature for the unsaturated zone flow cell. The specified TEMPERATURE is only applied if the unsaturated zone flow cell is a constant temperature cell. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+    }
+  },
+  "temperature_species_name": {
+    "options": {
+      ".vsc": "string used to identify the auxspeciesname in PACKAGEDATA that corresponds to the temperature species.  There can be only one occurrence of this temperature species name in the PACKAGEDATA block or the program will terminate with an error.  This value has no effect if viscosity does not depend on temperature."
+    }
+  },
+  "thermal_a2": {
+    "options": {
+      ".vsc": "is an empirical parameter specified by the user for calculating viscosity using a nonlinear formulation.  If A2 is not specified, a default value of 10.0 is assigned (Voss, 1984). "
+    }
+  },
+  "thermal_a3": {
+    "options": {
+      ".vsc": "is an empirical parameter specified by the user for calculating viscosity using a nonlinear formulation.  If A3 is not specified, a default value of 248.37 is assigned (Voss, 1984). "
+    }
+  },
+  "thermal_a4": {
+    "options": {
+      ".vsc": "is an empirical parameter specified by the user for calculating viscosity using a nonlinear formulation.  If A4 is not specified, a default value of 133.15 is assigned (Voss, 1984). "
+    }
+  },
+  "thermal_formulation": {
+    "options": {
+      ".vsc": "may be used for specifying which viscosity formulation to use for the temperature species. Can be either LINEAR or NONLINEAR. The LINEAR viscosity formulation is the default."
+    }
+  },
+  "thickstrt": {
+    "options": {
+      ".npf": "indicates that cells having a negative ICELLTYPE are confined, and their cell thickness for conductance calculations will be computed as STRT-BOT rather than TOP-BOT.  This option should be used with caution as it only affects conductance calculations in the NPF Package."
+    }
+  },
+  "time_conversion": {
+    "options": {
+      ".dfw": "real value that is used to convert user-specified Manning's roughness coefficients from seconds to model time units. TIME\\_CONVERSION should be set to 1.0, 60.0, 3,600.0, 86,400.0, and 31,557,600.0 when using time units (TIME\\_UNITS) of seconds, minutes, hours, days, or years in the simulation, respectively. TIME\\_CONVERSION does not need to be specified if TIME\\_UNITS are seconds.",
+      ".lak": "real value that is used to convert user-specified Manning's roughness coefficients or gravitational acceleration used to calculate outlet flows from seconds to model time units. TIME\\_CONVERSION should be set to 1.0, 60.0, 3,600.0, 86,400.0, and 31,557,600.0 when using time units (TIME\\_UNITS) of seconds, minutes, hours, days, or years in the simulation, respectively. CONVTIME does not need to be specified if no lake outlets are specified or TIME\\_UNITS are seconds.",
+      ".sfr": "real value that is used to convert user-specified Manning's roughness coefficients from seconds to model time units. TIME\\_CONVERSION should be set to 1.0, 60.0, 3,600.0, 86,400.0, and 31,557,600.0 when using time units (TIME\\_UNITS) of seconds, minutes, hours, days, or years in the simulation, respectively. TIME\\_CONVERSION does not need to be specified if TIME\\_UNITS are seconds."
+    }
+  },
+  "time_units": {
+    "options": {
+      ".tdis": "is the time units of the simulation.  This is a text string that is used as a label within model output files.  Values for time\\_units may be ``unknown'',  ``seconds'', ``minutes'', ``hours'', ``days'', or ``years''.  The default time unit is ``unknown''."
+    }
+  },
+  "timeseries": {
+    "timeseries": {
+      ".ts": "xxx"
+    }
+  },
+  "top": {
+    "griddata": {
+      ".dis": "is the top elevation for each cell in the top model layer.",
+      ".disu": "is the top elevation for each cell in the model grid.",
+      ".disv": "is the top elevation for each cell in the top model layer."
+    }
+  },
+  "track": {
+    "options": {
+      ".oc": "keyword to specify that record corresponds to a binary track file.  Each PRT Model's OC Package may have only one binary track output file.",
+      ".prp": "keyword to specify that record corresponds to a binary track output file.  Each PRP Package may have a distinct binary track output file."
+    }
+  },
+  "track_exit": {
+    "options": {
+      ".oc": "keyword to indicate that particle tracking output is to be written when a particle exits a feature (a model, cell, or subcell)"
+    }
+  },
+  "track_release": {
+    "options": {
+      ".oc": "keyword to indicate that particle tracking output is to be written when a particle is released"
+    }
+  },
+  "track_terminate": {
+    "options": {
+      ".oc": "keyword to indicate that particle tracking output is to be written when a particle terminates for any reason"
+    }
+  },
+  "track_timestep": {
+    "options": {
+      ".oc": "keyword to indicate that particle tracking output is to be written at the end of each time step"
+    }
+  },
+  "track_usertime": {
+    "options": {
+      ".oc": "keyword to indicate that particle tracking output is to be written at user-specified times, provided as double precision values in the TRACKTIMES block."
+    }
+  },
+  "track_weaksink": {
+    "options": {
+      ".oc": "keyword to indicate that particle tracking output is to be written when a particle exits a weak sink (a cell which removes some but not all inflow from adjacent cells)"
+    }
+  },
+  "trackcsv": {
+    "options": {
+      ".oc": "keyword to specify that record corresponds to a CSV track file.  Each PRT Model's OC Package may have only one CSV track file.",
+      ".prp": "keyword to specify that record corresponds to a CSV track output file.  Each PRP Package may have a distinct CSV track output file."
+    }
+  },
+  "transient": {
+    "period": {
+      ".sto": "keyword to indicate that stress period IPER is transient. Transient conditions will apply until the STEADY-STATE keyword is specified in a subsequent BEGIN PERIOD block."
+    }
+  },
+  "ts6": {
+    "options": {
+      ".chd": "keyword to specify that record corresponds to a time-series file.",
+      ".cnc": "keyword to specify that record corresponds to a time-series file.",
+      ".csub": "keyword to specify that record corresponds to a time-series file.",
+      ".ctp": "keyword to specify that record corresponds to a time-series file.",
+      ".drn": "keyword to specify that record corresponds to a time-series file.",
+      ".esl": "keyword to specify that record corresponds to a time-series file.",
+      ".evp": "keyword to specify that record corresponds to a time-series file.",
+      ".evt": "keyword to specify that record corresponds to a time-series file.",
+      ".flw": "keyword to specify that record corresponds to a time-series file.",
+      ".ghb": "keyword to specify that record corresponds to a time-series file.",
+      ".lak": "keyword to specify that record corresponds to a time-series file.",
+      ".lke": "keyword to specify that record corresponds to a time-series file.",
+      ".lkt": "keyword to specify that record corresponds to a time-series file.",
+      ".maw": "keyword to specify that record corresponds to a time-series file.",
+      ".mwe": "keyword to specify that record corresponds to a time-series file.",
+      ".mwt": "keyword to specify that record corresponds to a time-series file.",
+      ".pcp": "keyword to specify that record corresponds to a time-series file.",
+      ".rch": "keyword to specify that record corresponds to a time-series file.",
+      ".riv": "keyword to specify that record corresponds to a time-series file.",
+      ".sfe": "keyword to specify that record corresponds to a time-series file.",
+      ".sfr": "keyword to specify that record corresponds to a time-series file.",
+      ".sft": "keyword to specify that record corresponds to a time-series file.",
+      ".spc": "keyword to specify that record corresponds to a time-series file.",
+      ".src": "keyword to specify that record corresponds to a time-series file.",
+      ".tvk": "keyword to specify that record corresponds to a time-series file.",
+      ".tvs": "keyword to specify that record corresponds to a time-series file.",
+      ".uze": "keyword to specify that record corresponds to a time-series file.",
+      ".uzf": "keyword to specify that record corresponds to a time-series file.",
+      ".uzt": "keyword to specify that record corresponds to a time-series file.",
+      ".wel": "keyword to specify that record corresponds to a time-series file.",
+      ".zdg": "keyword to specify that record corresponds to a time-series file."
+    }
+  },
+  "tvk6": {
+    "options": {
+      ".npf": "keyword to specify that record corresponds to a time-varying hydraulic conductivity (TVK) file.  The behavior of TVK and a description of the input file is provided separately."
+    }
+  },
+  "tvs6": {
+    "options": {
+      ".sto": "keyword to specify that record corresponds to a time-varying storage (TVS) file.  The behavior of TVS and a description of the input file is provided separately."
+    }
+  },
+  "under_relaxation": {
+    "nonlinear": {
+      ".ims": "is an optional keyword that defines the nonlinear under-relaxation schemes used. Under-relaxation is also known as dampening, and is used to reduce the size of the calculated dependent variable before proceeding to the next outer iteration.  Under-relaxation can be an effective tool for highly nonlinear models when there are large and often counteracting changes in the calculated dependent variable between successive outer iterations.  By default under-relaxation is not used.  NONE - under-relaxation is not used (default). SIMPLE - Simple under-relaxation scheme with a fixed relaxation factor (UNDER\\_RELAXATION\\_GAMMA) is used.  COOLEY - Cooley under-relaxation scheme is used.  DBD - delta-bar-delta under-relaxation is used.  Note that the under-relaxation schemes are often used in conjunction with problems that use the Newton-Raphson formulation, however, experience has indicated that they also work well for non-Newton problems, such as those with the wet/dry options of MODFLOW 6."
+    },
+    "options": {
+      ".nam": "keyword that indicates whether the surface water stage in a reach will be under-relaxed when water levels fall below the bottom of the model below any given cell. By default, Newton-Raphson UNDER\\_RELAXATION is not applied."
+    }
+  },
+  "under_relaxation_gamma": {
+    "nonlinear": {
+      ".ims": "real value defining either the relaxation factor for the SIMPLE scheme or the history or memory term factor of the Cooley and delta-bar-delta algorithms. For the SIMPLE scheme, a value of one indicates that there is no under-relaxation and the full head change is applied.  This value can be gradually reduced from one as a way to improve convergence; for well behaved problems, using a value less than one can increase the number of outer iterations required for convergence and needlessly increase run times.  UNDER\\_RELAXATION\\_GAMMA must be greater than zero for the SIMPLE scheme or the program will terminate with an error.  For the Cooley and delta-bar-delta schemes, UNDER\\_RELAXATION\\_GAMMA is a memory term that can range between zero and one. When UNDER\\_RELAXATION\\_GAMMA is zero, only the most recent history (previous iteration value) is maintained. As UNDER\\_RELAXATION\\_GAMMA is increased, past history of iteration changes has greater influence on the memory term. The memory term is maintained as an exponential average of past changes. Retaining some past history can overcome granular behavior in the calculated function surface and therefore helps to overcome cyclic patterns of non-convergence. The value usually ranges from 0.1 to 0.3; a value of 0.2 works well for most problems. UNDER\\_RELAXATION\\_GAMMA only needs to be specified if UNDER\\_RELAXATION is not NONE."
+    }
+  },
+  "under_relaxation_kappa": {
+    "nonlinear": {
+      ".ims": "real value defining the increment for the learning rate (under-relaxation term) of the delta-bar-delta algorithm. The value of UNDER\\_RELAXATION\\_kappa is between zero and one. If the change in the dependent-variable (for example, head) is of the same sign to that of the previous iteration, the under-relaxation term is increased by an increment of UNDER\\_RELAXATION\\_KAPPA. The value usually ranges from 0.03 to 0.3; a value of 0.1 works well for most problems. UNDER\\_RELAXATION\\_KAPPA only needs to be specified if UNDER\\_RELAXATION is DBD."
+    }
+  },
+  "under_relaxation_momentum": {
+    "nonlinear": {
+      ".ims": "real value defining the fraction of past history changes that is added as a momentum term to the step change for a nonlinear iteration. The value of UNDER\\_RELAXATION\\_MOMENTUM is between zero and one. A large momentum term should only be used when small learning rates are expected. Small amounts of the momentum term help convergence. The value usually ranges from 0.0001 to 0.1; a value of 0.001 works well for most problems. UNDER\\_RELAXATION\\_MOMENTUM only needs to be specified if UNDER\\_RELAXATION is DBD."
+    }
+  },
+  "under_relaxation_theta": {
+    "nonlinear": {
+      ".ims": "real value defining the reduction factor for the learning rate (under-relaxation term) of the delta-bar-delta algorithm. The value of UNDER\\_RELAXATION\\_THETA is between zero and one. If the change in the dependent-variable (for example, head) is of opposite sign to that of the previous iteration, the under-relaxation term is reduced by a factor of UNDER\\_RELAXATION\\_THETA. The value usually ranges from 0.3 to 0.9; a value of 0.7 works well for most problems. UNDER\\_RELAXATION\\_THETA only needs to be specified if UNDER\\_RELAXATION is DBD."
+    }
+  },
+  "unit_conversion": {
+    "options": {
+      ".sfr": "real value that is used to convert user-specified Manning's roughness coefficients from seconds per meters$^{1/3}$ to model length and time units. A constant of 1.486 is used for flow units of cubic feet per second, and a constant of 1.0 is used for units of cubic meters per second. The constant must be multiplied by 86,400 when using time units of days in the simulation."
+    }
+  },
+  "unsat_etae": {
+    "options": {
+      ".uzf": "keyword specifying that ET in the unsaturated zone will be simulated using a capillary pressure based formulation. Capillary pressure is calculated using the Brooks-Corey retention function."
+    }
+  },
+  "unsat_etwc": {
+    "options": {
+      ".uzf": "keyword specifying that ET in the unsaturated zone will be simulated as a function of the specified PET rate while the water content (THETA) is greater than the ET extinction water content (EXTWC)."
+    }
+  },
+  "update_material_properties": {
+    "options": {
+      ".csub": "keyword to indicate that the thickness and void ratio of coarse-grained and interbed sediments (delay and no-delay) will vary during the simulation. If not specified, the thickness and void ratio of coarse-grained and interbed sediments will not vary during the simulation."
+    }
+  },
+  "upstream_fraction": {
+    "period": {
+      ".sfr": "real value that defines the fraction of upstream flow (USTRF) from each upstream reach that is applied as upstream inflow to the reach. The sum of all USTRF values for all reaches connected to the same upstream reach must be equal to one."
+    }
+  },
+  "uzet": {
+    "period": {
+      ".uze": "real or character value that states what fraction of the simulated unsaturated zone evapotranspiration is associated with evaporation.  The evaporative losses from the unsaturated zone moisture content will have an evaporative cooling effect on the GWE cell from which the evaporation originated. If this value is larger than 1, then it will be reset to 1.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      ".uzt": "real or character value that defines the concentration of unsaturated zone evapotranspiration water $(ML^{-3})$ for the UZF cell. If this concentration value is larger than the simulated concentration in the UZF cell, then the unsaturated zone ET water will be removed at the same concentration as the UZF cell.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+    }
+  },
+  "variablecv": {
+    "options": {
+      ".gwfgwf": "keyword to indicate that the vertical conductance will be calculated using the saturated thickness and properties of the overlying cell and the thickness and properties of the underlying cell.  If the DEWATERED keyword is also specified, then the vertical conductance is calculated using only the saturated thickness and properties of the overlying cell if the head in the underlying cell is below its top.  If these keywords are not specified, then the default condition is to calculate the vertical conductance at the start of the simulation using the initial head and the cell properties.  The vertical conductance remains constant for the entire simulation.",
+      ".npf": "keyword to indicate that the vertical conductance will be calculated using the saturated thickness and properties of the overlying cell and the thickness and properties of the underlying cell.  If the DEWATERED keyword is also specified, then the vertical conductance is calculated using only the saturated thickness and properties of the overlying cell if the head in the underlying cell is below its top.  If these keywords are not specified, then the default condition is to calculate the vertical conductance at the start of the simulation using the initial head and the cell properties.  The vertical conductance remains constant for the entire simulation."
+    }
+  },
+  "vertical_offset_tolerance": {
+    "options": {
+      ".disu": "checks are performed to ensure that the top of a cell is not higher than the bottom of an overlying cell.  This option can be used to specify the tolerance that is used for checking.  If top of a cell is above the bottom of an overlying cell by a value less than this tolerance, then the program will not terminate with an error.  The default value is zero.  This option should generally not be used."
+    }
+  },
+  "viscosity": {
+    "options": {
+      ".vsc": "keyword to specify that record corresponds to viscosity."
+    }
+  },
+  "viscref": {
+    "options": {
+      ".vsc": "fluid reference viscosity used in the equation of state.  This value is set to 1.0 if not specified as an option."
+    }
+  },
+  "volfrac": {
+    "griddata": {
+      ".ist": "fraction of the cell volume that consists of this immobile domain.  The sum of all immobile domain volume fractions must be less than one."
+    }
+  },
+  "water_content": {
+    "options": {
+      ".uzf": "keyword to specify that record corresponds to unsaturated zone water contents."
+    }
+  },
+  "well_head": {
+    "period": {
+      ".maw": "is the head in the multi-aquifer well. WELL\\_HEAD is only applied to constant head (STATUS is CONSTANT) and inactive (STATUS is INACTIVE) multi-aquifer wells. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. The program will terminate with an error if WELL\\_HEAD is less than the bottom of the well."
+    }
+  },
+  "wetdry": {
+    "griddata": {
+      ".npf": "is a combination of the wetting threshold and a flag to indicate which neighboring cells can cause a cell to become wet. If WETDRY $<$ 0, only a cell below a dry cell can cause the cell to become wet. If WETDRY $>$ 0, the cell below a dry cell and horizontally adjacent cells can cause a cell to become wet. If WETDRY is 0, the cell cannot be wetted. The absolute value of WETDRY is the wetting threshold. When the sum of BOT and the absolute value of WETDRY at a dry cell is equaled or exceeded by the head at an adjacent cell, the cell is wetted.  WETDRY must be specified if ``REWET'' is specified in the OPTIONS block.  If ``REWET'' is not specified in the options block, then WETDRY can be entered, and memory will be allocated for it, even though it is not used."
+    }
+  },
+  "wetfct": {
+    "options": {
+      ".npf": "is a keyword and factor that is included in the calculation of the head that is initially established at a cell when that cell is converted from dry to wet."
+    }
+  },
+  "width": {
+    "griddata": {
+      ".disv1d": "real value that defines the width for each one-dimensional cell. WIDTH must be greater than zero.  If the Cross Section (CXS) Package is used, then the WIDTH value will be multiplied by the specified cross section x-fraction values."
+    },
+    "options": {
+      ".ist": "width for writing each number.",
+      ".oc": "width for writing each number."
+    },
+    "period": {
+      ".lak": "real or character value that defines the width of the lake outlet. A specified WIDTH value is only used for active lakes if COUTTYPE for lake outlet OUTLETNO is not SPECIFIED. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+    }
+  },
+  "withdrawal": {
+    "period": {
+      ".lak": "real or character value that defines the maximum withdrawal rate $(L^3 T^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+    }
+  },
+  "wkt": {
+    "options": {
+      ".ncf": "is the coordinate reference system (CRS) well-known text (WKT) string."
+    }
+  },
+  "xorigin": {
+    "options": {
+      ".dis": "x-position of the lower-left corner of the model grid.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      ".dis2d": "x-position of the lower-left corner of the model grid.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      ".disu": "x-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      ".disv": "x-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      ".disv1d": "x-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      ".disv2d": "x-position of the lower-left corner of the model grid.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space."
+    }
+  },
+  "xt3d": {
+    "options": {
+      ".gwfgwf": "keyword that activates the XT3D formulation between the cells connected with this GWF-GWF Exchange.",
+      ".npf": "keyword indicating that the XT3D formulation will be used.  If the RHS keyword is also included, then the XT3D additional terms will be added to the right-hand side.  If the RHS keyword is excluded, then the XT3D terms will be put into the coefficient matrix.  Use of XT3D will substantially increase the computational effort, but will result in improved accuracy for anisotropic conductivity fields and for unstructured grids in which the CVFD requirement is violated.  XT3D requires additional information about the shapes of grid cells.  If XT3D is active and the DISU Package is used, then the user will need to provide in the DISU Package the angldegx array in the CONNECTIONDATA block and the VERTICES and CELL2D blocks."
+    }
+  },
+  "xt3d_off": {
+    "options": {
+      ".cnd": "deactivate the xt3d method and use the faster and less accurate approximation.  This option may provide a fast and accurate solution under some circumstances, such as when flow aligns with the model grid, there is no mechanical dispersion, or when the longitudinal and transverse dispersivities are equal.  This option may also be used to assess the computational demand of the XT3D approach by noting the run time differences with and without this option on.",
+      ".dsp": "deactivate the xt3d method and use the faster and less accurate approximation.  This option may provide a fast and accurate solution under some circumstances, such as when flow aligns with the model grid, there is no mechanical dispersion, or when the longitudinal and transverse dispersivities are equal.  This option may also be used to assess the computational demand of the XT3D approach by noting the run time differences with and without this option on."
+    }
+  },
+  "xt3d_rhs": {
+    "options": {
+      ".cnd": "add xt3d terms to right-hand side, when possible.  This option uses less memory, but may require more iterations.",
+      ".dsp": "add xt3d terms to right-hand side, when possible.  This option uses less memory, but may require more iterations."
+    }
+  },
+  "xt3doptions": {
+    "options": {
+      ".npf": "none"
+    }
+  },
+  "yorigin": {
+    "options": {
+      ".dis": "y-position of the lower-left corner of the model grid.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      ".dis2d": "y-position of the lower-left corner of the model grid.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      ".disu": "y-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      ".disv": "y-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      ".disv1d": "y-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      ".disv2d": "y-position of the lower-left corner of the model grid.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space."
+    }
+  },
+  "zdisplacement": {
+    "options": {
+      ".csub": "keyword to specify that record corresponds to the z-displacement binary file."
+    }
+  },
+  "zero_order_decay": {
+    "options": {
+      ".ist": "is a text keyword to indicate that zero-order decay will occur.  Use of this keyword requires that DECAY and DECAY\\_SORBED (if sorption is active) are specified in the GRIDDATA block.",
+      ".mst": "is a text keyword to indicate that zero-order decay will occur.  Use of this keyword requires that DECAY and DECAY\\_SORBED (if sorption is active) are specified in the GRIDDATA block."
+    }
+  },
+  "zero_order_decay_solid": {
+    "options": {
+      ".est": "is a text keyword to indicate that zero-order decay will occur in the solid phase. That is, decay occurs in the solid and is a rate per mass (not volume) of solid only.  Use of this keyword requires that DECAY\\_SOLID is specified in the GRIDDATA block."
+    }
+  },
+  "zero_order_decay_water": {
+    "options": {
+      ".est": "is a text keyword to indicate that zero-order decay will occur in the aqueous phase. That is, decay occurs in the water and is a rate per volume of water only, not per volume of aquifer (i.e., grid cell).  Use of this keyword requires that DECAY\\_WATER is specified in the GRIDDATA block."
+    }
+  },
+  "zetaim": {
+    "griddata": {
+      ".ist": "mass transfer rate coefficient between the mobile and immobile domains, in dimensions of per time."
     }
   }
 }

--- a/src/providers/hover.json
+++ b/src/providers/hover.json
@@ -1,2611 +1,3116 @@
 {
   "adv_scheme": {
     "options": {
-      ".gwegwe": "scheme used to solve the advection term.  Can be upstream, central, or TVD.  If not specified, upstream weighting is the default weighting scheme.",
-      ".gwtgwt": "scheme used to solve the advection term.  Can be upstream, central, or TVD.  If not specified, upstream weighting is the default weighting scheme."
+      "exg-gwegwe": "scheme used to solve the advection term.  Can be upstream, central, or TVD.  If not specified, upstream weighting is the default weighting scheme.",
+      "exg-gwtgwt": "scheme used to solve the advection term.  Can be upstream, central, or TVD.  If not specified, upstream weighting is the default weighting scheme."
     }
   },
   "alh": {
     "griddata": {
-      ".cnd": "longitudinal dispersivity in horizontal direction.  If flow is strictly horizontal, then this is the longitudinal dispersivity that will be used.  If flow is not strictly horizontal or strictly vertical, then the longitudinal dispersivity is a function of both ALH and ALV.  If mechanical dispersion is represented (by specifying any dispersivity values) then this array is required.",
-      ".dsp": "longitudinal dispersivity in horizontal direction.  If flow is strictly horizontal, then this is the longitudinal dispersivity that will be used.  If flow is not strictly horizontal or strictly vertical, then the longitudinal dispersivity is a function of both ALH and ALV.  If mechanical dispersion is represented (by specifying any dispersivity values) then this array is required."
+      "gwe-cnd": "longitudinal dispersivity in horizontal direction.  If flow is strictly horizontal, then this is the longitudinal dispersivity that will be used.  If flow is not strictly horizontal or strictly vertical, then the longitudinal dispersivity is a function of both ALH and ALV.  If mechanical dispersion is represented (by specifying any dispersivity values) then this array is required.",
+      "gwt-dsp": "longitudinal dispersivity in horizontal direction.  If flow is strictly horizontal, then this is the longitudinal dispersivity that will be used.  If flow is not strictly horizontal or strictly vertical, then the longitudinal dispersivity is a function of both ALH and ALV.  If mechanical dispersion is represented (by specifying any dispersivity values) then this array is required."
     }
   },
   "all": {
     "period": {
-      ".oc": "keyword to indicate save for all time steps in period.",
-      ".prp": "keyword to indicate release at the start of all time steps in the period."
+      "chf-oc": "keyword to indicate save for all time steps in period.",
+      "gwe-oc": "keyword to indicate save for all time steps in period.",
+      "gwf-oc": "keyword to indicate save for all time steps in period.",
+      "gwt-oc": "keyword to indicate save for all time steps in period.",
+      "olf-oc": "keyword to indicate save for all time steps in period.",
+      "prt-oc": "keyword to indicate save for all time steps in period.",
+      "prt-prp": "keyword to indicate release at the start of all time steps in the period.",
+      "swf-oc": "keyword to indicate save for all time steps in period."
     }
   },
   "alternative_cell_averaging": {
     "options": {
-      ".npf": "is a text keyword to indicate that an alternative method will be used for calculating the conductance for horizontal cell connections.  The text value for ALTERNATIVE\\_CELL\\_AVERAGING can be ``LOGARITHMIC'', ``AMT-LMK'', or ``AMT-HMK''.  ``AMT-LMK'' signifies that the conductance will be calculated using arithmetic-mean thickness and logarithmic-mean hydraulic conductivity.  ``AMT-HMK'' signifies that the conductance will be calculated using arithmetic-mean thickness and harmonic-mean hydraulic conductivity. If the user does not specify a value for ALTERNATIVE\\_CELL\\_AVERAGING, then the harmonic-mean method will be used.  This option cannot be used if the XT3D option is invoked."
+      "gwf-npf": "is a text keyword to indicate that an alternative method will be used for calculating the conductance for horizontal cell connections.  The text value for ALTERNATIVE\\_CELL\\_AVERAGING can be ``LOGARITHMIC'', ``AMT-LMK'', or ``AMT-HMK''.  ``AMT-LMK'' signifies that the conductance will be calculated using arithmetic-mean thickness and logarithmic-mean hydraulic conductivity.  ``AMT-HMK'' signifies that the conductance will be calculated using arithmetic-mean thickness and harmonic-mean hydraulic conductivity. If the user does not specify a value for ALTERNATIVE\\_CELL\\_AVERAGING, then the harmonic-mean method will be used.  This option cannot be used if the XT3D option is invoked."
     }
   },
   "alv": {
     "griddata": {
-      ".cnd": "longitudinal dispersivity in vertical direction.  If flow is strictly vertical, then this is the longitudinal dispsersivity value that will be used.  If flow is not strictly horizontal or strictly vertical, then the longitudinal dispersivity is a function of both ALH and ALV.  If this value is not specified and mechanical dispersion is represented, then this array is set equal to ALH.",
-      ".dsp": "longitudinal dispersivity in vertical direction.  If flow is strictly vertical, then this is the longitudinal dispsersivity value that will be used.  If flow is not strictly horizontal or strictly vertical, then the longitudinal dispersivity is a function of both ALH and ALV.  If this value is not specified and mechanical dispersion is represented, then this array is set equal to ALH."
+      "gwe-cnd": "longitudinal dispersivity in vertical direction.  If flow is strictly vertical, then this is the longitudinal dispsersivity value that will be used.  If flow is not strictly horizontal or strictly vertical, then the longitudinal dispersivity is a function of both ALH and ALV.  If this value is not specified and mechanical dispersion is represented, then this array is set equal to ALH.",
+      "gwt-dsp": "longitudinal dispersivity in vertical direction.  If flow is strictly vertical, then this is the longitudinal dispsersivity value that will be used.  If flow is not strictly horizontal or strictly vertical, then the longitudinal dispersivity is a function of both ALH and ALV.  If this value is not specified and mechanical dispersion is represented, then this array is set equal to ALH."
     }
   },
   "angldegx": {
     "connectiondata": {
-      ".disu": "is the angle (in degrees) between the horizontal x-axis and the outward normal to the face between a cell and its connecting cells. The angle varies between zero and 360.0 degrees, where zero degrees points in the positive x-axis direction, and 90 degrees points in the positive y-axis direction.  ANGLDEGX is only needed if horizontal anisotropy is specified in the NPF Package, if the XT3D option is used in the NPF Package, or if the SAVE\\_SPECIFIC\\_DISCHARGE option is specified in the NPF Package.  ANGLDEGX does not need to be specified if these conditions are not met.  ANGLDEGX is of size NJA; values specified for vertical connections and for the diagonal position are not used.  Note that ANGLDEGX is read in degrees, which is different from MODFLOW-USG, which reads a similar variable (ANGLEX) in radians."
+      "gwe-disu": "is the angle (in degrees) between the horizontal x-axis and the outward normal to the face between a cell and its connecting cells. The angle varies between zero and 360.0 degrees, where zero degrees points in the positive x-axis direction, and 90 degrees points in the positive y-axis direction.  ANGLDEGX is only needed if horizontal anisotropy is specified in the NPF Package, if the XT3D option is used in the NPF Package, or if the SAVE\\_SPECIFIC\\_DISCHARGE option is specified in the NPF Package.  ANGLDEGX does not need to be specified if these conditions are not met.  ANGLDEGX is of size NJA; values specified for vertical connections and for the diagonal position are not used.  Note that ANGLDEGX is read in degrees, which is different from MODFLOW-USG, which reads a similar variable (ANGLEX) in radians.",
+      "gwf-disu": "is the angle (in degrees) between the horizontal x-axis and the outward normal to the face between a cell and its connecting cells. The angle varies between zero and 360.0 degrees, where zero degrees points in the positive x-axis direction, and 90 degrees points in the positive y-axis direction.  ANGLDEGX is only needed if horizontal anisotropy is specified in the NPF Package, if the XT3D option is used in the NPF Package, or if the SAVE\\_SPECIFIC\\_DISCHARGE option is specified in the NPF Package.  ANGLDEGX does not need to be specified if these conditions are not met.  ANGLDEGX is of size NJA; values specified for vertical connections and for the diagonal position are not used.  Note that ANGLDEGX is read in degrees, which is different from MODFLOW-USG, which reads a similar variable (ANGLEX) in radians.",
+      "gwt-disu": "is the angle (in degrees) between the horizontal x-axis and the outward normal to the face between a cell and its connecting cells. The angle varies between zero and 360.0 degrees, where zero degrees points in the positive x-axis direction, and 90 degrees points in the positive y-axis direction.  ANGLDEGX is only needed if horizontal anisotropy is specified in the NPF Package, if the XT3D option is used in the NPF Package, or if the SAVE\\_SPECIFIC\\_DISCHARGE option is specified in the NPF Package.  ANGLDEGX does not need to be specified if these conditions are not met.  ANGLDEGX is of size NJA; values specified for vertical connections and for the diagonal position are not used.  Note that ANGLDEGX is read in degrees, which is different from MODFLOW-USG, which reads a similar variable (ANGLEX) in radians."
     }
   },
   "angle1": {
     "griddata": {
-      ".npf": "is a rotation angle of the hydraulic conductivity tensor in degrees. The angle represents the first of three sequential rotations of the hydraulic conductivity ellipsoid. With the K11, K22, and K33 axes of the ellipsoid initially aligned with the x, y, and z coordinate axes, respectively, ANGLE1 rotates the ellipsoid about its K33 axis (within the x - y plane). A positive value represents counter-clockwise rotation when viewed from any point on the positive K33 axis, looking toward the center of the ellipsoid. A value of zero indicates that the K11 axis lies within the x - z plane. If ANGLE1 is not specified, default values of zero are assigned to ANGLE1, ANGLE2, and ANGLE3, in which case the K11, K22, and K33 axes are aligned with the x, y, and z axes, respectively."
+      "gwf-npf": "is a rotation angle of the hydraulic conductivity tensor in degrees. The angle represents the first of three sequential rotations of the hydraulic conductivity ellipsoid. With the K11, K22, and K33 axes of the ellipsoid initially aligned with the x, y, and z coordinate axes, respectively, ANGLE1 rotates the ellipsoid about its K33 axis (within the x - y plane). A positive value represents counter-clockwise rotation when viewed from any point on the positive K33 axis, looking toward the center of the ellipsoid. A value of zero indicates that the K11 axis lies within the x - z plane. If ANGLE1 is not specified, default values of zero are assigned to ANGLE1, ANGLE2, and ANGLE3, in which case the K11, K22, and K33 axes are aligned with the x, y, and z axes, respectively."
     }
   },
   "angle2": {
     "griddata": {
-      ".npf": "is a rotation angle of the hydraulic conductivity tensor in degrees. The angle represents the second of three sequential rotations of the hydraulic conductivity ellipsoid. Following the rotation by ANGLE1 described above, ANGLE2 rotates the ellipsoid about its K22 axis (out of the x - y plane). An array can be specified for ANGLE2 only if ANGLE1 is also specified. A positive value of ANGLE2 represents clockwise rotation when viewed from any point on the positive K22 axis, looking toward the center of the ellipsoid. A value of zero indicates that the K11 axis lies within the x - y plane. If ANGLE2 is not specified, default values of zero are assigned to ANGLE2 and ANGLE3; connections that are not user-designated as vertical are assumed to be strictly horizontal (that is, to have no z component to their orientation); and connection lengths are based on horizontal distances."
+      "gwf-npf": "is a rotation angle of the hydraulic conductivity tensor in degrees. The angle represents the second of three sequential rotations of the hydraulic conductivity ellipsoid. Following the rotation by ANGLE1 described above, ANGLE2 rotates the ellipsoid about its K22 axis (out of the x - y plane). An array can be specified for ANGLE2 only if ANGLE1 is also specified. A positive value of ANGLE2 represents clockwise rotation when viewed from any point on the positive K22 axis, looking toward the center of the ellipsoid. A value of zero indicates that the K11 axis lies within the x - y plane. If ANGLE2 is not specified, default values of zero are assigned to ANGLE2 and ANGLE3; connections that are not user-designated as vertical are assumed to be strictly horizontal (that is, to have no z component to their orientation); and connection lengths are based on horizontal distances."
     }
   },
   "angle3": {
     "griddata": {
-      ".npf": "is a rotation angle of the hydraulic conductivity tensor in degrees. The angle represents the third of three sequential rotations of the hydraulic conductivity ellipsoid. Following the rotations by ANGLE1 and ANGLE2 described above, ANGLE3 rotates the ellipsoid about its K11 axis. An array can be specified for ANGLE3 only if ANGLE1 and ANGLE2 are also specified. An array must be specified for ANGLE3 if ANGLE2 is specified. A positive value of ANGLE3 represents clockwise rotation when viewed from any point on the positive K11 axis, looking toward the center of the ellipsoid. A value of zero indicates that the K22 axis lies within the x - y plane."
+      "gwf-npf": "is a rotation angle of the hydraulic conductivity tensor in degrees. The angle represents the third of three sequential rotations of the hydraulic conductivity ellipsoid. Following the rotations by ANGLE1 and ANGLE2 described above, ANGLE3 rotates the ellipsoid about its K11 axis. An array can be specified for ANGLE3 only if ANGLE1 and ANGLE2 are also specified. An array must be specified for ANGLE3 if ANGLE2 is specified. A positive value of ANGLE3 represents clockwise rotation when viewed from any point on the positive K11 axis, looking toward the center of the ellipsoid. A value of zero indicates that the K22 axis lies within the x - y plane."
     }
   },
   "angrot": {
     "options": {
-      ".dis": "counter-clockwise rotation angle (in degrees) of the lower-left corner of the model grid.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      ".dis2d": "counter-clockwise rotation angle (in degrees) of the lower-left corner of the model grid.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      ".disu": "counter-clockwise rotation angle (in degrees) of the model grid coordinate system relative to a real-world coordinate system.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      ".disv": "counter-clockwise rotation angle (in degrees) of the model grid coordinate system relative to a real-world coordinate system.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      ".disv1d": "counter-clockwise rotation angle (in degrees) of the model grid coordinate system relative to a real-world coordinate system.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      ".disv2d": "counter-clockwise rotation angle (in degrees) of the lower-left corner of the model grid.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space."
+      "chf-disv1d": "counter-clockwise rotation angle (in degrees) of the model grid coordinate system relative to a real-world coordinate system.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      "gwe-dis": "counter-clockwise rotation angle (in degrees) of the lower-left corner of the model grid.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      "gwe-disu": "counter-clockwise rotation angle (in degrees) of the model grid coordinate system relative to a real-world coordinate system.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      "gwe-disv": "counter-clockwise rotation angle (in degrees) of the model grid coordinate system relative to a real-world coordinate system.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      "gwf-dis": "counter-clockwise rotation angle (in degrees) of the lower-left corner of the model grid.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      "gwf-disu": "counter-clockwise rotation angle (in degrees) of the model grid coordinate system relative to a real-world coordinate system.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      "gwf-disv": "counter-clockwise rotation angle (in degrees) of the model grid coordinate system relative to a real-world coordinate system.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      "gwt-dis": "counter-clockwise rotation angle (in degrees) of the lower-left corner of the model grid.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      "gwt-disu": "counter-clockwise rotation angle (in degrees) of the model grid coordinate system relative to a real-world coordinate system.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      "gwt-disv": "counter-clockwise rotation angle (in degrees) of the model grid coordinate system relative to a real-world coordinate system.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      "olf-dis2d": "counter-clockwise rotation angle (in degrees) of the lower-left corner of the model grid.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      "olf-disv1d": "counter-clockwise rotation angle (in degrees) of the model grid coordinate system relative to a real-world coordinate system.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      "olf-disv2d": "counter-clockwise rotation angle (in degrees) of the lower-left corner of the model grid.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      "prt-dis": "counter-clockwise rotation angle (in degrees) of the lower-left corner of the model grid.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      "prt-disv": "counter-clockwise rotation angle (in degrees) of the model grid coordinate system relative to a real-world coordinate system.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      "swf-dis2d": "counter-clockwise rotation angle (in degrees) of the lower-left corner of the model grid.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      "swf-disv1d": "counter-clockwise rotation angle (in degrees) of the model grid coordinate system relative to a real-world coordinate system.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      "swf-disv2d": "counter-clockwise rotation angle (in degrees) of the lower-left corner of the model grid.  If not specified, then a default value of 0.0 is assigned.  The value for ANGROT does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space."
     }
   },
   "area": {
     "griddata": {
-      ".disu": "is the cell surface area (in plan view)."
+      "gwe-disu": "is the cell surface area (in plan view).",
+      "gwf-disu": "is the cell surface area (in plan view).",
+      "gwt-disu": "is the cell surface area (in plan view)."
     }
   },
   "ath1": {
     "griddata": {
-      ".cnd": "transverse dispersivity in horizontal direction.  This is the transverse dispersivity value for the second ellipsoid axis.  If flow is strictly horizontal and directed in the x direction (along a row for a regular grid), then this value controls spreading in the y direction.  If mechanical dispersion is represented (by specifying any dispersivity values) then this array is required.",
-      ".dsp": "transverse dispersivity in horizontal direction.  This is the transverse dispersivity value for the second ellipsoid axis.  If flow is strictly horizontal and directed in the x direction (along a row for a regular grid), then this value controls spreading in the y direction.  If mechanical dispersion is represented (by specifying any dispersivity values) then this array is required."
+      "gwe-cnd": "transverse dispersivity in horizontal direction.  This is the transverse dispersivity value for the second ellipsoid axis.  If flow is strictly horizontal and directed in the x direction (along a row for a regular grid), then this value controls spreading in the y direction.  If mechanical dispersion is represented (by specifying any dispersivity values) then this array is required.",
+      "gwt-dsp": "transverse dispersivity in horizontal direction.  This is the transverse dispersivity value for the second ellipsoid axis.  If flow is strictly horizontal and directed in the x direction (along a row for a regular grid), then this value controls spreading in the y direction.  If mechanical dispersion is represented (by specifying any dispersivity values) then this array is required."
     }
   },
   "ath2": {
     "griddata": {
-      ".cnd": "transverse dispersivity in horizontal direction.  This is the transverse dispersivity value for the third ellipsoid axis.  If flow is strictly horizontal and directed in the x direction (along a row for a regular grid), then this value controls spreading in the z direction.  If this value is not specified and mechanical dispersion is represented, then this array is set equal to ATH1.",
-      ".dsp": "transverse dispersivity in horizontal direction.  This is the transverse dispersivity value for the third ellipsoid axis.  If flow is strictly horizontal and directed in the x direction (along a row for a regular grid), then this value controls spreading in the z direction.  If this value is not specified and mechanical dispersion is represented, then this array is set equal to ATH1."
+      "gwe-cnd": "transverse dispersivity in horizontal direction.  This is the transverse dispersivity value for the third ellipsoid axis.  If flow is strictly horizontal and directed in the x direction (along a row for a regular grid), then this value controls spreading in the z direction.  If this value is not specified and mechanical dispersion is represented, then this array is set equal to ATH1.",
+      "gwt-dsp": "transverse dispersivity in horizontal direction.  This is the transverse dispersivity value for the third ellipsoid axis.  If flow is strictly horizontal and directed in the x direction (along a row for a regular grid), then this value controls spreading in the z direction.  If this value is not specified and mechanical dispersion is represented, then this array is set equal to ATH1."
     }
   },
   "ats6": {
     "options": {
-      ".tdis": "keyword to specify that record corresponds to an adaptive time step (ATS) input file.  The behavior of ATS and a description of the input file is provided separately."
+      "sim-tdis": "keyword to specify that record corresponds to an adaptive time step (ATS) input file.  The behavior of ATS and a description of the input file is provided separately."
     }
   },
   "ats_outer_maximum_fraction": {
     "options": {
-      ".ims": "real value defining the fraction of the maximum allowable outer iterations used with the Adaptive Time Step (ATS) capability if it is active.  If this value is set to zero by the user, then this solution will have no effect on ATS behavior.  This value must be greater than or equal to zero and less than or equal to 0.5 or the program will terminate with an error.  If it is not specified by the user, then it is assigned a default value of one third.  When the number of outer iterations for this solution is less than the product of this value and the maximum allowable outer iterations, then ATS will increase the time step length by a factor of DTADJ in the ATS input file.  When the number of outer iterations for this solution is greater than the maximum allowable outer iterations minus the product of this value and the maximum allowable outer iterations, then the ATS (if active) will decrease the time step length by a factor of 1 / DTADJ.",
-      ".pts": "real value defining the fraction of the maximum allowable outer iterations used with the Adaptive Time Step (ATS) capability if it is active.  If this value is set to zero by the user, then this solution will have no effect on ATS behavior.  This value must be greater than or equal to zero and less than or equal to 0.5 or the program will terminate with an error.  If it is not specified by the user, then it is assigned a default value of one third.  When the number of outer iterations for this solution is less than the product of this value and the maximum allowable outer iterations, then ATS will increase the time step length by a factor of DTADJ in the ATS input file.  When the number of outer iterations for this solution is greater than the maximum allowable outer iterations minus the product of this value and the maximum allowable outer iterations, then the ATS (if active) will decrease the time step length by a factor of 1 / DTADJ."
+      "sln-ims": "real value defining the fraction of the maximum allowable outer iterations used with the Adaptive Time Step (ATS) capability if it is active.  If this value is set to zero by the user, then this solution will have no effect on ATS behavior.  This value must be greater than or equal to zero and less than or equal to 0.5 or the program will terminate with an error.  If it is not specified by the user, then it is assigned a default value of one third.  When the number of outer iterations for this solution is less than the product of this value and the maximum allowable outer iterations, then ATS will increase the time step length by a factor of DTADJ in the ATS input file.  When the number of outer iterations for this solution is greater than the maximum allowable outer iterations minus the product of this value and the maximum allowable outer iterations, then the ATS (if active) will decrease the time step length by a factor of 1 / DTADJ.",
+      "sln-pts": "real value defining the fraction of the maximum allowable outer iterations used with the Adaptive Time Step (ATS) capability if it is active.  If this value is set to zero by the user, then this solution will have no effect on ATS behavior.  This value must be greater than or equal to zero and less than or equal to 0.5 or the program will terminate with an error.  If it is not specified by the user, then it is assigned a default value of one third.  When the number of outer iterations for this solution is less than the product of this value and the maximum allowable outer iterations, then ATS will increase the time step length by a factor of DTADJ in the ATS input file.  When the number of outer iterations for this solution is greater than the maximum allowable outer iterations minus the product of this value and the maximum allowable outer iterations, then the ATS (if active) will decrease the time step length by a factor of 1 / DTADJ."
     }
   },
   "ats_percel": {
     "options": {
-      ".adv": "fractional cell distance submitted by the ADV Package to the adaptive time stepping (ATS) package.  If ATS\\_PERCEL is specified and the ATS Package is active, a time step calculation will be made for each cell based on flow through the cell and cell properties.  The largest time step will be calculated such that the advective fractional cell distance (ATS\\_PERCEL) is not exceeded for any active cell in the grid.  This time-step constraint will be submitted to the ATS Package, perhaps with constraints submitted by other packages, in the calculation of the time step.  ATS\\_PERCEL must be greater than zero.  If a value of zero is specified for ATS\\_PERCEL the program will automatically reset it to an internal no data value to indicate that time steps should not be subject to this constraint."
+      "gwt-adv": "fractional cell distance submitted by the ADV Package to the adaptive time stepping (ATS) package.  If ATS\\_PERCEL is specified and the ATS Package is active, a time step calculation will be made for each cell based on flow through the cell and cell properties.  The largest time step will be calculated such that the advective fractional cell distance (ATS\\_PERCEL) is not exceeded for any active cell in the grid.  This time-step constraint will be submitted to the ATS Package, perhaps with constraints submitted by other packages, in the calculation of the time step.  ATS\\_PERCEL must be greater than zero.  If a value of zero is specified for ATS\\_PERCEL the program will automatically reset it to an internal no data value to indicate that time steps should not be subject to this constraint."
     }
   },
   "atv": {
     "griddata": {
-      ".cnd": "transverse dispersivity when flow is in vertical direction.  If flow is strictly vertical and directed in the z direction, then this value controls spreading in the x and y directions.  If this value is not specified and mechanical dispersion is represented, then this array is set equal to ATH2.",
-      ".dsp": "transverse dispersivity when flow is in vertical direction.  If flow is strictly vertical and directed in the z direction, then this value controls spreading in the x and y directions.  If this value is not specified and mechanical dispersion is represented, then this array is set equal to ATH2."
+      "gwe-cnd": "transverse dispersivity when flow is in vertical direction.  If flow is strictly vertical and directed in the z direction, then this value controls spreading in the x and y directions.  If this value is not specified and mechanical dispersion is represented, then this array is set equal to ATH2.",
+      "gwt-dsp": "transverse dispersivity when flow is in vertical direction.  If flow is strictly vertical and directed in the z direction, then this value controls spreading in the x and y directions.  If this value is not specified and mechanical dispersion is represented, then this array is set equal to ATH2."
     }
   },
   "auto_flow_reduce": {
     "options": {
-      ".wel": "keyword and real value that defines the fraction of the cell thickness used as an interval for smoothly adjusting negative pumping rates to 0 in cells with head values less than or equal to the bottom of the cell. Negative pumping rates are adjusted to 0 or a smaller negative value when the head in the cell is equal to or less than the calculated interval above the cell bottom. AUTO\\_FLOW\\_REDUCE is set to 0.1 if the specified value is less than or equal to zero. By default, negative pumping rates are not reduced during a simulation.  This AUTO\\_FLOW\\_REDUCE option only applies to wells in model cells that are marked as ``convertible'' (ICELLTYPE /= 0) in the Node Property Flow (NPF) input file. Reduction in flow will not occur for wells in cells marked as confined (ICELLTYPE = 0)."
+      "gwf-wel": "keyword and real value that defines the fraction of the cell thickness used as an interval for smoothly adjusting negative pumping rates to 0 in cells with head values less than or equal to the bottom of the cell. Negative pumping rates are adjusted to 0 or a smaller negative value when the head in the cell is equal to or less than the calculated interval above the cell bottom. AUTO\\_FLOW\\_REDUCE is set to 0.1 if the specified value is less than or equal to zero. By default, negative pumping rates are not reduced during a simulation.  This AUTO\\_FLOW\\_REDUCE option only applies to wells in model cells that are marked as ``convertible'' (ICELLTYPE /= 0) in the Node Property Flow (NPF) input file. Reduction in flow will not occur for wells in cells marked as confined (ICELLTYPE = 0)."
     }
   },
   "auto_flow_reduce_csv": {
     "options": {
-      ".wel": "keyword to specify that record corresponds to the AUTO\\_FLOW\\_REDUCE output option in which a new record is written for each well and for each time step in which the user-requested extraction rate is reduced by the program."
+      "gwf-wel": "keyword to specify that record corresponds to the AUTO\\_FLOW\\_REDUCE output option in which a new record is written for each well and for each time step in which the user-requested extraction rate is reduced by the program."
     }
   },
   "aux": {
     "period": {
-      ".evta": "is an array of values for auxiliary variable AUX(IAUX), where iaux is a value from 1 to NAUX, and AUX(IAUX) must be listed as part of the auxiliary variables.  A separate array can be specified for each auxiliary variable.  If an array is not specified for an auxiliary variable, then a value of zero is assigned.  If the value specified here for the auxiliary variable is the same as auxmultname, then the evapotranspiration rate will be multiplied by this array.",
-      ".rcha": "is an array of values for auxiliary variable aux(iaux), where iaux is a value from 1 to naux, and aux(iaux) must be listed as part of the auxiliary variables.  A separate array can be specified for each auxiliary variable.  If an array is not specified for an auxiliary variable, then a value of zero is assigned.  If the value specified here for the auxiliary variable is the same as auxmultname, then the recharge array will be multiplied by this array."
+      "gwf-evta": "is an array of values for auxiliary variable AUX(IAUX), where iaux is a value from 1 to NAUX, and AUX(IAUX) must be listed as part of the auxiliary variables.  A separate array can be specified for each auxiliary variable.  If an array is not specified for an auxiliary variable, then a value of zero is assigned.  If the value specified here for the auxiliary variable is the same as auxmultname, then the evapotranspiration rate will be multiplied by this array.",
+      "gwf-rcha": "is an array of values for auxiliary variable aux(iaux), where iaux is a value from 1 to naux, and aux(iaux) must be listed as part of the auxiliary variables.  A separate array can be specified for each auxiliary variable.  If an array is not specified for an auxiliary variable, then a value of zero is assigned.  If the value specified here for the auxiliary variable is the same as auxmultname, then the recharge array will be multiplied by this array."
     }
   },
   "auxdepthname": {
     "options": {
-      ".drn": "name of a variable listed in AUXILIARY that defines the depth at which drainage discharge will be scaled. If a positive value is specified for the AUXDEPTHNAME AUXILIARY variable, then ELEV is the elevation at which the drain starts to discharge and ELEV + DDRN (assuming DDRN is the AUXDEPTHNAME variable) is the elevation when the drain conductance (COND) scaling factor is 1. If a negative drainage depth value is specified for DDRN, then ELEV + DDRN is the elevation at which the drain starts to discharge and ELEV is the elevation when the conductance (COND) scaling factor is 1. A linear- or cubic-scaling is used to scale the drain conductance (COND) when the Standard or Newton-Raphson Formulation is used, respectively.  This discharge scaling option is described in more detail in Chapter 3 of the Supplemental Technical Information."
+      "gwf-drn": "name of a variable listed in AUXILIARY that defines the depth at which drainage discharge will be scaled. If a positive value is specified for the AUXDEPTHNAME AUXILIARY variable, then ELEV is the elevation at which the drain starts to discharge and ELEV + DDRN (assuming DDRN is the AUXDEPTHNAME variable) is the elevation when the drain conductance (COND) scaling factor is 1. If a negative drainage depth value is specified for DDRN, then ELEV + DDRN is the elevation at which the drain starts to discharge and ELEV is the elevation when the conductance (COND) scaling factor is 1. A linear- or cubic-scaling is used to scale the drain conductance (COND) when the Standard or Newton-Raphson Formulation is used, respectively.  This discharge scaling option is described in more detail in Chapter 3 of the Supplemental Technical Information."
     }
   },
   "auxiliary": {
     "options": {
-      ".cdb": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".chd": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".cnc": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".ctp": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".drn": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".esl": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".evp": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".evt": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".evta": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".flw": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".ghb": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".gwegwe": "an array of auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided. Most auxiliary variables will not be used by the GWE-GWE Exchange, but they will be available for use by other parts of the program.  If an auxiliary variable with the name ``ANGLDEGX'' is found, then this information will be used as the angle (provided in degrees) between the connection face normal and the x axis, where a value of zero indicates that a normal vector points directly along the positive x axis.  The connection face normal is a normal vector on the cell face shared between the cell in model 1 and the cell in model 2 pointing away from the model 1 cell.  Additional information on ``ANGLDEGX'' is provided in the description of the DISU Package.  If an auxiliary variable with the name ``CDIST'' is found, then this information will be used as the straight-line connection distance, including the vertical component, between the two cell centers.  Both ANGLDEGX and CDIST are required if specific discharge is calculated for either of the groundwater models.",
-      ".gwfgwf": "an array of auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided. Most auxiliary variables will not be used by the GWF-GWF Exchange, but they will be available for use by other parts of the program.  If an auxiliary variable with the name ``ANGLDEGX'' is found, then this information will be used as the angle (provided in degrees) between the connection face normal and the x axis, where a value of zero indicates that a normal vector points directly along the positive x axis.  The connection face normal is a normal vector on the cell face shared between the cell in model 1 and the cell in model 2 pointing away from the model 1 cell.  Additional information on ``ANGLDEGX'' and when it is required is provided in the description of the DISU Package.  If an auxiliary variable with the name ``CDIST'' is found, then this information will be used in the calculation of specific discharge within model cells connected by the exchange.  For a horizontal connection, CDIST should be specified as the horizontal distance between the cell centers, and should not include the vertical component.  For vertical connections, CDIST should be specified as the difference in elevation between the two cell centers.  Both ANGLDEGX and CDIST are required if specific discharge is calculated for either of the groundwater models.",
-      ".gwtgwt": "an array of auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided. Most auxiliary variables will not be used by the GWT-GWT Exchange, but they will be available for use by other parts of the program.  If an auxiliary variable with the name ``ANGLDEGX'' is found, then this information will be used as the angle (provided in degrees) between the connection face normal and the x axis, where a value of zero indicates that a normal vector points directly along the positive x axis.  The connection face normal is a normal vector on the cell face shared between the cell in model 1 and the cell in model 2 pointing away from the model 1 cell.  Additional information on ``ANGLDEGX'' is provided in the description of the DISU Package.  ANGLDEGX must be specified if dispersion is simulated in the connected GWT models.",
-      ".lak": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".lke": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".lkt": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".maw": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".mwe": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".mwt": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".pcp": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".rch": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".rcha": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".riv": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".sfe": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".sfr": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".sft": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".src": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".uze": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".uzf": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".uzt": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".wel": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
-      ".zdg": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block."
+      "chf-cdb": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      "chf-chd": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      "chf-evp": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      "chf-flw": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      "chf-pcp": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      "chf-zdg": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      "exg-gwegwe": "an array of auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided. Most auxiliary variables will not be used by the GWE-GWE Exchange, but they will be available for use by other parts of the program.  If an auxiliary variable with the name ``ANGLDEGX'' is found, then this information will be used as the angle (provided in degrees) between the connection face normal and the x axis, where a value of zero indicates that a normal vector points directly along the positive x axis.  The connection face normal is a normal vector on the cell face shared between the cell in model 1 and the cell in model 2 pointing away from the model 1 cell.  Additional information on ``ANGLDEGX'' is provided in the description of the DISU Package.  If an auxiliary variable with the name ``CDIST'' is found, then this information will be used as the straight-line connection distance, including the vertical component, between the two cell centers.  Both ANGLDEGX and CDIST are required if specific discharge is calculated for either of the groundwater models.",
+      "exg-gwfgwf": "an array of auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided. Most auxiliary variables will not be used by the GWF-GWF Exchange, but they will be available for use by other parts of the program.  If an auxiliary variable with the name ``ANGLDEGX'' is found, then this information will be used as the angle (provided in degrees) between the connection face normal and the x axis, where a value of zero indicates that a normal vector points directly along the positive x axis.  The connection face normal is a normal vector on the cell face shared between the cell in model 1 and the cell in model 2 pointing away from the model 1 cell.  Additional information on ``ANGLDEGX'' and when it is required is provided in the description of the DISU Package.  If an auxiliary variable with the name ``CDIST'' is found, then this information will be used in the calculation of specific discharge within model cells connected by the exchange.  For a horizontal connection, CDIST should be specified as the horizontal distance between the cell centers, and should not include the vertical component.  For vertical connections, CDIST should be specified as the difference in elevation between the two cell centers.  Both ANGLDEGX and CDIST are required if specific discharge is calculated for either of the groundwater models.",
+      "exg-gwtgwt": "an array of auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided. Most auxiliary variables will not be used by the GWT-GWT Exchange, but they will be available for use by other parts of the program.  If an auxiliary variable with the name ``ANGLDEGX'' is found, then this information will be used as the angle (provided in degrees) between the connection face normal and the x axis, where a value of zero indicates that a normal vector points directly along the positive x axis.  The connection face normal is a normal vector on the cell face shared between the cell in model 1 and the cell in model 2 pointing away from the model 1 cell.  Additional information on ``ANGLDEGX'' is provided in the description of the DISU Package.  ANGLDEGX must be specified if dispersion is simulated in the connected GWT models.",
+      "gwe-ctp": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      "gwe-esl": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      "gwe-lke": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      "gwe-mwe": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      "gwe-sfe": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      "gwe-uze": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      "gwf-chd": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      "gwf-drn": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      "gwf-evt": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      "gwf-evta": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      "gwf-ghb": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      "gwf-lak": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      "gwf-maw": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      "gwf-rch": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      "gwf-rcha": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      "gwf-riv": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      "gwf-sfr": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      "gwf-uzf": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      "gwf-wel": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      "gwt-cnc": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      "gwt-lkt": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      "gwt-mwt": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      "gwt-sft": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      "gwt-src": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      "gwt-uzt": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      "olf-cdb": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      "olf-chd": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      "olf-evp": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      "olf-flw": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      "olf-pcp": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      "olf-zdg": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      "swf-cdb": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      "swf-chd": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      "swf-evp": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      "swf-flw": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      "swf-pcp": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block.",
+      "swf-zdg": "defines an array of one or more auxiliary variable names.  There is no limit on the number of auxiliary variables that can be provided on this line; however, lists of information provided in subsequent blocks must have a column of data for each auxiliary variable name defined here.   The number of auxiliary variables detected on this line determines the value for naux.  Comments cannot be provided anywhere on this line as they will be interpreted as auxiliary variable names.  Auxiliary variables may not be used by the package, but they will be available for use by other parts of the program.  The program will terminate with an error if auxiliary variables are specified on more than one line in the options block."
     },
     "period": {
-      ".lak": "keyword for specifying auxiliary variable.",
-      ".lke": "keyword for specifying auxiliary variable.",
-      ".lkt": "keyword for specifying auxiliary variable.",
-      ".maw": "keyword for specifying auxiliary variable.",
-      ".mwe": "keyword for specifying auxiliary variable.",
-      ".mwt": "keyword for specifying auxiliary variable.",
-      ".sfe": "keyword for specifying auxiliary variable.",
-      ".sfr": "keyword for specifying auxiliary variable.",
-      ".sft": "keyword for specifying auxiliary variable.",
-      ".uze": "keyword for specifying auxiliary variable.",
-      ".uzt": "keyword for specifying auxiliary variable."
+      "gwe-lke": "keyword for specifying auxiliary variable.",
+      "gwe-mwe": "keyword for specifying auxiliary variable.",
+      "gwe-sfe": "keyword for specifying auxiliary variable.",
+      "gwe-uze": "keyword for specifying auxiliary variable.",
+      "gwf-lak": "keyword for specifying auxiliary variable.",
+      "gwf-maw": "keyword for specifying auxiliary variable.",
+      "gwf-sfr": "keyword for specifying auxiliary variable.",
+      "gwt-lkt": "keyword for specifying auxiliary variable.",
+      "gwt-mwt": "keyword for specifying auxiliary variable.",
+      "gwt-sft": "keyword for specifying auxiliary variable.",
+      "gwt-uzt": "keyword for specifying auxiliary variable."
     }
   },
   "auxmultname": {
     "options": {
-      ".chd": "name of auxiliary variable to be used as multiplier of CHD head value.",
-      ".cnc": "name of auxiliary variable to be used as multiplier of concentration value.",
-      ".ctp": "name of auxiliary variable to be used as multiplier of temperature value.",
-      ".drn": "name of auxiliary variable to be used as multiplier of drain conductance.",
-      ".esl": "name of auxiliary variable to be used as multiplier of energy loading rate.",
-      ".evp": "name of auxiliary variable to be used as multiplier of evaporation.",
-      ".evt": "name of auxiliary variable to be used as multiplier of evapotranspiration rate.",
-      ".evta": "name of auxiliary variable to be used as multiplier of evapotranspiration rate.",
-      ".flw": "name of auxiliary variable to be used as multiplier of flow rate.",
-      ".ghb": "name of auxiliary variable to be used as multiplier of general-head boundary conductance.",
-      ".pcp": "name of auxiliary variable to be used as multiplier of precipitation.",
-      ".rch": "name of auxiliary variable to be used as multiplier of recharge.",
-      ".rcha": "name of auxiliary variable to be used as multiplier of recharge.",
-      ".riv": "name of auxiliary variable to be used as multiplier of riverbed conductance.",
-      ".src": "name of auxiliary variable to be used as multiplier of mass loading rate.",
-      ".uzf": "name of auxiliary variable to be used as multiplier of GWF cell area used by UZF cell.",
-      ".wel": "name of auxiliary variable to be used as multiplier of well flow rate."
+      "chf-chd": "name of auxiliary variable to be used as multiplier of CHD head value.",
+      "chf-evp": "name of auxiliary variable to be used as multiplier of evaporation.",
+      "chf-flw": "name of auxiliary variable to be used as multiplier of flow rate.",
+      "chf-pcp": "name of auxiliary variable to be used as multiplier of precipitation.",
+      "gwe-ctp": "name of auxiliary variable to be used as multiplier of temperature value.",
+      "gwe-esl": "name of auxiliary variable to be used as multiplier of energy loading rate.",
+      "gwf-chd": "name of auxiliary variable to be used as multiplier of CHD head value.",
+      "gwf-drn": "name of auxiliary variable to be used as multiplier of drain conductance.",
+      "gwf-evt": "name of auxiliary variable to be used as multiplier of evapotranspiration rate.",
+      "gwf-evta": "name of auxiliary variable to be used as multiplier of evapotranspiration rate.",
+      "gwf-ghb": "name of auxiliary variable to be used as multiplier of general-head boundary conductance.",
+      "gwf-rch": "name of auxiliary variable to be used as multiplier of recharge.",
+      "gwf-rcha": "name of auxiliary variable to be used as multiplier of recharge.",
+      "gwf-riv": "name of auxiliary variable to be used as multiplier of riverbed conductance.",
+      "gwf-uzf": "name of auxiliary variable to be used as multiplier of GWF cell area used by UZF cell.",
+      "gwf-wel": "name of auxiliary variable to be used as multiplier of well flow rate.",
+      "gwt-cnc": "name of auxiliary variable to be used as multiplier of concentration value.",
+      "gwt-src": "name of auxiliary variable to be used as multiplier of mass loading rate.",
+      "olf-chd": "name of auxiliary variable to be used as multiplier of CHD head value.",
+      "olf-evp": "name of auxiliary variable to be used as multiplier of evaporation.",
+      "olf-flw": "name of auxiliary variable to be used as multiplier of flow rate.",
+      "olf-pcp": "name of auxiliary variable to be used as multiplier of precipitation.",
+      "swf-chd": "name of auxiliary variable to be used as multiplier of CHD head value.",
+      "swf-evp": "name of auxiliary variable to be used as multiplier of evaporation.",
+      "swf-flw": "name of auxiliary variable to be used as multiplier of flow rate.",
+      "swf-pcp": "name of auxiliary variable to be used as multiplier of precipitation."
     }
   },
   "backtracking_number": {
     "nonlinear": {
-      ".ims": "integer value defining the maximum number of backtracking iterations allowed for residual reduction computations. If BACKTRACKING\\_NUMBER = 0 then the backtracking iterations are omitted. The value usually ranges from 2 to 20; a value of 10 works well for most problems."
+      "sln-ims": "integer value defining the maximum number of backtracking iterations allowed for residual reduction computations. If BACKTRACKING\\_NUMBER = 0 then the backtracking iterations are omitted. The value usually ranges from 2 to 20; a value of 10 works well for most problems."
     }
   },
   "backtracking_reduction_factor": {
     "nonlinear": {
-      ".ims": "real value defining the reduction in step size used for residual reduction computations. The value of BACKTRACKING\\_REDUCTION\\_FACTOR is between zero and one. The value usually ranges from 0.1 to 0.3; a value of 0.2 works well for most problems. BACKTRACKING\\_REDUCTION\\_FACTOR only needs to be specified if BACKTRACKING\\_NUMBER is greater than zero."
+      "sln-ims": "real value defining the reduction in step size used for residual reduction computations. The value of BACKTRACKING\\_REDUCTION\\_FACTOR is between zero and one. The value usually ranges from 0.1 to 0.3; a value of 0.2 works well for most problems. BACKTRACKING\\_REDUCTION\\_FACTOR only needs to be specified if BACKTRACKING\\_NUMBER is greater than zero."
     }
   },
   "backtracking_residual_limit": {
     "nonlinear": {
-      ".ims": "real value defining the limit to which the residual is reduced with backtracking. If the residual is smaller than BACKTRACKING\\_RESIDUAL\\_LIMIT, then further backtracking is not performed. A value of 100 is suitable for large problems and residual reduction to smaller values may only slow down computations. BACKTRACKING\\_RESIDUAL\\_LIMIT only needs to be specified if BACKTRACKING\\_NUMBER is greater than zero."
+      "sln-ims": "real value defining the limit to which the residual is reduced with backtracking. If the residual is smaller than BACKTRACKING\\_RESIDUAL\\_LIMIT, then further backtracking is not performed. A value of 100 is suitable for large problems and residual reduction to smaller values may only slow down computations. BACKTRACKING\\_RESIDUAL\\_LIMIT only needs to be specified if BACKTRACKING\\_NUMBER is greater than zero."
     }
   },
   "backtracking_tolerance": {
     "nonlinear": {
-      ".ims": "real value defining the tolerance for residual change that is allowed for residual reduction computations. BACKTRACKING\\_TOLERANCE should not be less than one to avoid getting stuck in local minima. A large value serves to check for extreme residual increases, while a low value serves to control step size more severely. The value usually ranges from 1.0 to 10$^6$; a value of 10$^4$ works well for most problems but lower values like 1.1 may be required for harder problems. BACKTRACKING\\_TOLERANCE only needs to be specified if BACKTRACKING\\_NUMBER is greater than zero."
+      "sln-ims": "real value defining the tolerance for residual change that is allowed for residual reduction computations. BACKTRACKING\\_TOLERANCE should not be less than one to avoid getting stuck in local minima. A large value serves to check for extreme residual increases, while a low value serves to control step size more severely. The value usually ranges from 1.0 to 10$^6$; a value of 10$^4$ works well for most problems but lower values like 1.1 may be required for harder problems. BACKTRACKING\\_TOLERANCE only needs to be specified if BACKTRACKING\\_NUMBER is greater than zero."
     }
   },
   "bedk": {
     "period": {
-      ".sfr": "real or character value that defines the hydraulic conductivity of the reach streambed. BEDK can be any positive value if the reach is not connected to an underlying GWF cell. Otherwise, BEDK must be greater than zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+      "gwf-sfr": "real or character value that defines the hydraulic conductivity of the reach streambed. BEDK can be any positive value if the reach is not connected to an underlying GWF cell. Otherwise, BEDK must be greater than zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
     }
   },
   "beta": {
     "options": {
-      ".csub": "compressibility of water. Typical values of BETA are 4.6512e-10 1/Pa or 2.2270e-8 lb/square foot in SI and English units, respectively. By default, BETA is 4.6512e-10 1/Pa."
+      "gwf-csub": "compressibility of water. Typical values of BETA are 4.6512e-10 1/Pa or 2.2270e-8 lb/square foot in SI and English units, respectively. By default, BETA is 4.6512e-10 1/Pa."
     }
   },
   "binary": {
     "continuous": {
-      ".obs": "an optional keyword used to indicate that the output file should be written in binary (unformatted) form."
+      "utl-obs": "an optional keyword used to indicate that the output file should be written in binary (unformatted) form."
     }
   },
   "bot": {
     "griddata": {
-      ".disu": "is the bottom elevation for each cell."
+      "gwe-disu": "is the bottom elevation for each cell.",
+      "gwf-disu": "is the bottom elevation for each cell.",
+      "gwt-disu": "is the bottom elevation for each cell."
     }
   },
   "botm": {
     "griddata": {
-      ".dis": "is the bottom elevation for each cell.",
-      ".disv": "is the bottom elevation for each cell."
+      "gwe-dis": "is the bottom elevation for each cell.",
+      "gwe-disv": "is the bottom elevation for each cell.",
+      "gwf-dis": "is the bottom elevation for each cell.",
+      "gwf-disv": "is the bottom elevation for each cell.",
+      "gwt-dis": "is the bottom elevation for each cell.",
+      "gwt-disv": "is the bottom elevation for each cell.",
+      "prt-dis": "is the bottom elevation for each cell.",
+      "prt-disv": "is the bottom elevation for each cell."
     }
   },
   "bottom": {
     "griddata": {
-      ".dis2d": "is the bottom elevation for each cell.",
-      ".disv1d": "bottom elevation for the one-dimensional cell.",
-      ".disv2d": "is the bottom elevation for each cell."
+      "chf-disv1d": "bottom elevation for the one-dimensional cell.",
+      "olf-dis2d": "is the bottom elevation for each cell.",
+      "olf-disv1d": "bottom elevation for the one-dimensional cell.",
+      "olf-disv2d": "is the bottom elevation for each cell.",
+      "swf-dis2d": "is the bottom elevation for each cell.",
+      "swf-disv1d": "bottom elevation for the one-dimensional cell.",
+      "swf-disv2d": "is the bottom elevation for each cell."
     }
   },
   "boundnames": {
     "options": {
-      ".api": "keyword to indicate that boundary names may be provided with the list of api boundary cells.",
-      ".cdb": "keyword to indicate that boundary names may be provided with the list of critical depth boundary cells.",
-      ".chd": "keyword to indicate that boundary names may be provided with the list of constant-head cells.",
-      ".cnc": "keyword to indicate that boundary names may be provided with the list of constant concentration cells.",
-      ".csub": "keyword to indicate that boundary names may be provided with the list of CSUB cells.",
-      ".ctp": "keyword to indicate that boundary names may be provided with the list of constant temperature cells.",
-      ".drn": "keyword to indicate that boundary names may be provided with the list of drain cells.",
-      ".esl": "keyword to indicate that boundary names may be provided with the list of energy source loading cells.",
-      ".evp": "keyword to indicate that boundary names may be provided with the list of evaporation cells.",
-      ".evt": "keyword to indicate that boundary names may be provided with the list of evapotranspiration cells.",
-      ".flw": "keyword to indicate that boundary names may be provided with the list of inflow cells.",
-      ".ghb": "keyword to indicate that boundary names may be provided with the list of general-head boundary cells.",
-      ".gwegwe": "keyword to indicate that boundary names may be provided with the list of GWE Exchange cells.",
-      ".gwtgwt": "keyword to indicate that boundary names may be provided with the list of GWT Exchange cells.",
-      ".lak": "keyword to indicate that boundary names may be provided with the list of lake cells.",
-      ".lke": "keyword to indicate that boundary names may be provided with the list of lake cells.",
-      ".lkt": "keyword to indicate that boundary names may be provided with the list of lake cells.",
-      ".maw": "keyword to indicate that boundary names may be provided with the list of multi-aquifer well cells.",
-      ".mwe": "keyword to indicate that boundary names may be provided with the list of well cells.",
-      ".mwt": "keyword to indicate that boundary names may be provided with the list of well cells.",
-      ".pcp": "keyword to indicate that boundary names may be provided with the list of precipitation cells.",
-      ".prp": "keyword to indicate that boundary names may be provided with the list of particle release points.",
-      ".rch": "keyword to indicate that boundary names may be provided with the list of recharge cells.",
-      ".riv": "keyword to indicate that boundary names may be provided with the list of river cells.",
-      ".sfe": "keyword to indicate that boundary names may be provided with the list of reach cells.",
-      ".sfr": "keyword to indicate that boundary names may be provided with the list of stream reach cells.",
-      ".sft": "keyword to indicate that boundary names may be provided with the list of reach cells.",
-      ".src": "keyword to indicate that boundary names may be provided with the list of mass source cells.",
-      ".uze": "keyword to indicate that boundary names may be provided with the list of unsaturated zone flow cells.",
-      ".uzf": "keyword to indicate that boundary names may be provided with the list of UZF cells.",
-      ".uzt": "keyword to indicate that boundary names may be provided with the list of unsaturated zone flow cells.",
-      ".wel": "keyword to indicate that boundary names may be provided with the list of well cells.",
-      ".zdg": "keyword to indicate that boundary names may be provided with the list of zero-depth-gradient boundary cells."
+      "chf-cdb": "keyword to indicate that boundary names may be provided with the list of critical depth boundary cells.",
+      "chf-chd": "keyword to indicate that boundary names may be provided with the list of constant-head cells.",
+      "chf-evp": "keyword to indicate that boundary names may be provided with the list of evaporation cells.",
+      "chf-flw": "keyword to indicate that boundary names may be provided with the list of inflow cells.",
+      "chf-pcp": "keyword to indicate that boundary names may be provided with the list of precipitation cells.",
+      "chf-zdg": "keyword to indicate that boundary names may be provided with the list of zero-depth-gradient boundary cells.",
+      "exg-gwegwe": "keyword to indicate that boundary names may be provided with the list of GWE Exchange cells.",
+      "exg-gwtgwt": "keyword to indicate that boundary names may be provided with the list of GWT Exchange cells.",
+      "gwe-ctp": "keyword to indicate that boundary names may be provided with the list of constant temperature cells.",
+      "gwe-esl": "keyword to indicate that boundary names may be provided with the list of energy source loading cells.",
+      "gwe-lke": "keyword to indicate that boundary names may be provided with the list of lake cells.",
+      "gwe-mwe": "keyword to indicate that boundary names may be provided with the list of well cells.",
+      "gwe-sfe": "keyword to indicate that boundary names may be provided with the list of reach cells.",
+      "gwe-uze": "keyword to indicate that boundary names may be provided with the list of unsaturated zone flow cells.",
+      "gwf-api": "keyword to indicate that boundary names may be provided with the list of api boundary cells.",
+      "gwf-chd": "keyword to indicate that boundary names may be provided with the list of constant-head cells.",
+      "gwf-csub": "keyword to indicate that boundary names may be provided with the list of CSUB cells.",
+      "gwf-drn": "keyword to indicate that boundary names may be provided with the list of drain cells.",
+      "gwf-evt": "keyword to indicate that boundary names may be provided with the list of evapotranspiration cells.",
+      "gwf-ghb": "keyword to indicate that boundary names may be provided with the list of general-head boundary cells.",
+      "gwf-lak": "keyword to indicate that boundary names may be provided with the list of lake cells.",
+      "gwf-maw": "keyword to indicate that boundary names may be provided with the list of multi-aquifer well cells.",
+      "gwf-rch": "keyword to indicate that boundary names may be provided with the list of recharge cells.",
+      "gwf-riv": "keyword to indicate that boundary names may be provided with the list of river cells.",
+      "gwf-sfr": "keyword to indicate that boundary names may be provided with the list of stream reach cells.",
+      "gwf-uzf": "keyword to indicate that boundary names may be provided with the list of UZF cells.",
+      "gwf-wel": "keyword to indicate that boundary names may be provided with the list of well cells.",
+      "gwt-api": "keyword to indicate that boundary names may be provided with the list of api boundary cells.",
+      "gwt-cnc": "keyword to indicate that boundary names may be provided with the list of constant concentration cells.",
+      "gwt-lkt": "keyword to indicate that boundary names may be provided with the list of lake cells.",
+      "gwt-mwt": "keyword to indicate that boundary names may be provided with the list of well cells.",
+      "gwt-sft": "keyword to indicate that boundary names may be provided with the list of reach cells.",
+      "gwt-src": "keyword to indicate that boundary names may be provided with the list of mass source cells.",
+      "gwt-uzt": "keyword to indicate that boundary names may be provided with the list of unsaturated zone flow cells.",
+      "olf-cdb": "keyword to indicate that boundary names may be provided with the list of critical depth boundary cells.",
+      "olf-chd": "keyword to indicate that boundary names may be provided with the list of constant-head cells.",
+      "olf-evp": "keyword to indicate that boundary names may be provided with the list of evaporation cells.",
+      "olf-flw": "keyword to indicate that boundary names may be provided with the list of inflow cells.",
+      "olf-pcp": "keyword to indicate that boundary names may be provided with the list of precipitation cells.",
+      "olf-zdg": "keyword to indicate that boundary names may be provided with the list of zero-depth-gradient boundary cells.",
+      "prt-prp": "keyword to indicate that boundary names may be provided with the list of particle release points.",
+      "swf-cdb": "keyword to indicate that boundary names may be provided with the list of critical depth boundary cells.",
+      "swf-chd": "keyword to indicate that boundary names may be provided with the list of constant-head cells.",
+      "swf-evp": "keyword to indicate that boundary names may be provided with the list of evaporation cells.",
+      "swf-flw": "keyword to indicate that boundary names may be provided with the list of inflow cells.",
+      "swf-pcp": "keyword to indicate that boundary names may be provided with the list of precipitation cells.",
+      "swf-zdg": "keyword to indicate that boundary names may be provided with the list of zero-depth-gradient boundary cells."
     }
   },
   "budget": {
     "options": {
-      ".ist": "keyword to specify that record corresponds to the budget.",
-      ".lak": "keyword to specify that record corresponds to the budget.",
-      ".lke": "keyword to specify that record corresponds to the budget.",
-      ".lkt": "keyword to specify that record corresponds to the budget.",
-      ".maw": "keyword to specify that record corresponds to the budget.",
-      ".mve": "keyword to specify that record corresponds to the budget.",
-      ".mvr": "keyword to specify that record corresponds to the budget.",
-      ".mvt": "keyword to specify that record corresponds to the budget.",
-      ".mwe": "keyword to specify that record corresponds to the budget.",
-      ".mwt": "keyword to specify that record corresponds to the budget.",
-      ".oc": "keyword to specify that record corresponds to the budget.",
-      ".sfe": "keyword to specify that record corresponds to the budget.",
-      ".sfr": "keyword to specify that record corresponds to the budget.",
-      ".sft": "keyword to specify that record corresponds to the budget.",
-      ".uze": "keyword to specify that record corresponds to the budget.",
-      ".uzf": "keyword to specify that record corresponds to the budget.",
-      ".uzt": "keyword to specify that record corresponds to the budget."
+      "chf-oc": "keyword to specify that record corresponds to the budget.",
+      "gwe-lke": "keyword to specify that record corresponds to the budget.",
+      "gwe-mve": "keyword to specify that record corresponds to the budget.",
+      "gwe-mwe": "keyword to specify that record corresponds to the budget.",
+      "gwe-oc": "keyword to specify that record corresponds to the budget.",
+      "gwe-sfe": "keyword to specify that record corresponds to the budget.",
+      "gwe-uze": "keyword to specify that record corresponds to the budget.",
+      "gwf-lak": "keyword to specify that record corresponds to the budget.",
+      "gwf-maw": "keyword to specify that record corresponds to the budget.",
+      "gwf-mvr": "keyword to specify that record corresponds to the budget.",
+      "gwf-oc": "keyword to specify that record corresponds to the budget.",
+      "gwf-sfr": "keyword to specify that record corresponds to the budget.",
+      "gwf-uzf": "keyword to specify that record corresponds to the budget.",
+      "gwt-ist": "keyword to specify that record corresponds to the budget.",
+      "gwt-lkt": "keyword to specify that record corresponds to the budget.",
+      "gwt-mvt": "keyword to specify that record corresponds to the budget.",
+      "gwt-mwt": "keyword to specify that record corresponds to the budget.",
+      "gwt-oc": "keyword to specify that record corresponds to the budget.",
+      "gwt-sft": "keyword to specify that record corresponds to the budget.",
+      "gwt-uzt": "keyword to specify that record corresponds to the budget.",
+      "olf-oc": "keyword to specify that record corresponds to the budget.",
+      "prt-oc": "keyword to specify that record corresponds to the budget.",
+      "swf-oc": "keyword to specify that record corresponds to the budget."
     }
   },
   "budgetcsv": {
     "options": {
-      ".ist": "keyword to specify that record corresponds to the budget CSV.",
-      ".lak": "keyword to specify that record corresponds to the budget CSV.",
-      ".lke": "keyword to specify that record corresponds to the budget CSV.",
-      ".lkt": "keyword to specify that record corresponds to the budget CSV.",
-      ".maw": "keyword to specify that record corresponds to the budget CSV.",
-      ".mve": "keyword to specify that record corresponds to the budget CSV.",
-      ".mvr": "keyword to specify that record corresponds to the budget CSV.",
-      ".mvt": "keyword to specify that record corresponds to the budget CSV.",
-      ".mwe": "keyword to specify that record corresponds to the budget CSV.",
-      ".mwt": "keyword to specify that record corresponds to the budget CSV.",
-      ".oc": "keyword to specify that record corresponds to the budget CSV.",
-      ".sfe": "keyword to specify that record corresponds to the budget CSV.",
-      ".sfr": "keyword to specify that record corresponds to the budget CSV.",
-      ".sft": "keyword to specify that record corresponds to the budget CSV.",
-      ".uze": "keyword to specify that record corresponds to the budget CSV.",
-      ".uzf": "keyword to specify that record corresponds to the budget CSV.",
-      ".uzt": "keyword to specify that record corresponds to the budget CSV."
+      "chf-oc": "keyword to specify that record corresponds to the budget CSV.",
+      "gwe-lke": "keyword to specify that record corresponds to the budget CSV.",
+      "gwe-mve": "keyword to specify that record corresponds to the budget CSV.",
+      "gwe-mwe": "keyword to specify that record corresponds to the budget CSV.",
+      "gwe-oc": "keyword to specify that record corresponds to the budget CSV.",
+      "gwe-sfe": "keyword to specify that record corresponds to the budget CSV.",
+      "gwe-uze": "keyword to specify that record corresponds to the budget CSV.",
+      "gwf-lak": "keyword to specify that record corresponds to the budget CSV.",
+      "gwf-maw": "keyword to specify that record corresponds to the budget CSV.",
+      "gwf-mvr": "keyword to specify that record corresponds to the budget CSV.",
+      "gwf-oc": "keyword to specify that record corresponds to the budget CSV.",
+      "gwf-sfr": "keyword to specify that record corresponds to the budget CSV.",
+      "gwf-uzf": "keyword to specify that record corresponds to the budget CSV.",
+      "gwt-ist": "keyword to specify that record corresponds to the budget CSV.",
+      "gwt-lkt": "keyword to specify that record corresponds to the budget CSV.",
+      "gwt-mvt": "keyword to specify that record corresponds to the budget CSV.",
+      "gwt-mwt": "keyword to specify that record corresponds to the budget CSV.",
+      "gwt-oc": "keyword to specify that record corresponds to the budget CSV.",
+      "gwt-sft": "keyword to specify that record corresponds to the budget CSV.",
+      "gwt-uzt": "keyword to specify that record corresponds to the budget CSV.",
+      "olf-oc": "keyword to specify that record corresponds to the budget CSV.",
+      "prt-oc": "keyword to specify that record corresponds to the budget CSV.",
+      "swf-oc": "keyword to specify that record corresponds to the budget CSV."
     }
   },
   "bulk_density": {
     "griddata": {
-      ".ist": "is the bulk density of this immobile domain in mass per length cubed.  Bulk density is defined as the immobile domain solid mass per volume of the immobile domain.  bulk\\_density is not required unless the SORPTION keyword is specified in the options block.  If the SORPTION keyword is not specified in the options block, bulk\\_density will have no effect on simulation results.  ",
-      ".mst": "is the bulk density of the aquifer in mass per length cubed.  bulk\\_density is not required unless the SORPTION keyword is specified.  Bulk density is defined as the mobile domain solid mass per mobile domain volume.  Additional information on bulk density is included in the MODFLOW 6 Supplemental Technical Information document."
+      "gwt-ist": "is the bulk density of this immobile domain in mass per length cubed.  Bulk density is defined as the immobile domain solid mass per volume of the immobile domain.  bulk\\_density is not required unless the SORPTION keyword is specified in the options block.  If the SORPTION keyword is not specified in the options block, bulk\\_density will have no effect on simulation results.  ",
+      "gwt-mst": "is the bulk density of the aquifer in mass per length cubed.  bulk\\_density is not required unless the SORPTION keyword is specified.  Bulk density is defined as the mobile domain solid mass per mobile domain volume.  Additional information on bulk density is included in the MODFLOW 6 Supplemental Technical Information document."
     }
   },
   "cell_averaging": {
     "options": {
-      ".gwfgwf": "is a keyword and text keyword to indicate the method that will be used for calculating the conductance for horizontal cell connections.  The text value for CELL\\_AVERAGING can be ``HARMONIC'', ``LOGARITHMIC'', or ``AMT-LMK'', which means ``arithmetic-mean thickness and logarithmic-mean hydraulic conductivity''. If the user does not specify a value for CELL\\_AVERAGING, then the harmonic-mean method will be used."
+      "exg-gwfgwf": "is a keyword and text keyword to indicate the method that will be used for calculating the conductance for horizontal cell connections.  The text value for CELL\\_AVERAGING can be ``HARMONIC'', ``LOGARITHMIC'', or ``AMT-LMK'', which means ``arithmetic-mean thickness and logarithmic-mean hydraulic conductivity''. If the user does not specify a value for CELL\\_AVERAGING, then the harmonic-mean method will be used."
     }
   },
   "cell_fraction": {
     "options": {
-      ".csub": "keyword to indicate that the thickness of interbeds will be specified in terms of the fraction of cell thickness. If not specified, interbed thicknness must be specified."
+      "gwf-csub": "keyword to indicate that the thickness of interbeds will be specified in terms of the fraction of cell thickness. If not specified, interbed thicknness must be specified."
     }
   },
   "central_in_space": {
     "options": {
-      ".dfw": "keyword to indicate conductance should be calculated using central-in-space weighting instead of the default upstream weighting approach.  This option should be used with caution as it does not work well unless all of the stream reaches are saturated.  With this option, there is no way for water to flow into a dry reach from connected reaches."
+      "chf-dfw": "keyword to indicate conductance should be calculated using central-in-space weighting instead of the default upstream weighting approach.  This option should be used with caution as it does not work well unless all of the stream reaches are saturated.  With this option, there is no way for water to flow into a dry reach from connected reaches.",
+      "olf-dfw": "keyword to indicate conductance should be calculated using central-in-space weighting instead of the default upstream weighting approach.  This option should be used with caution as it does not work well unless all of the stream reaches are saturated.  With this option, there is no way for water to flow into a dry reach from connected reaches.",
+      "swf-dfw": "keyword to indicate conductance should be calculated using central-in-space weighting instead of the default upstream weighting approach.  This option should be used with caution as it does not work well unless all of the stream reaches are saturated.  With this option, there is no way for water to flow into a dry reach from connected reaches."
     }
   },
   "cg_ske_cr": {
     "griddata": {
-      ".csub": "is the initial elastic coarse-grained material specific storage or recompression index. The recompression index is specified if COMPRESSION\\_INDICES is specified in the OPTIONS block.  Specified or calculated elastic coarse-grained material specific storage values are not adjusted from initial values if HEAD\\_BASED is specified in the OPTIONS block."
+      "gwf-csub": "is the initial elastic coarse-grained material specific storage or recompression index. The recompression index is specified if COMPRESSION\\_INDICES is specified in the OPTIONS block.  Specified or calculated elastic coarse-grained material specific storage values are not adjusted from initial values if HEAD\\_BASED is specified in the OPTIONS block."
     }
   },
   "cg_theta": {
     "griddata": {
-      ".csub": "is the initial porosity of coarse-grained materials."
+      "gwf-csub": "is the initial porosity of coarse-grained materials."
     }
   },
   "chunk_face": {
     "options": {
-      ".ncf": "is the keyword used to provide a data chunk size for the face dimension in a NETCDF\\_MESH2D output file. Must be used in combination with the the chunk\\_time parameter to have an effect."
+      "utl-ncf": "is the keyword used to provide a data chunk size for the face dimension in a NETCDF\\_MESH2D output file. Must be used in combination with the the chunk\\_time parameter to have an effect."
     }
   },
   "chunk_time": {
     "options": {
-      ".ncf": "is the keyword used to provide a data chunk size for the time dimension in a NETCDF\\_MESH2D or NETCDF\\_STRUCTURED output file. Must be used in combination with the the chunk\\_face parameter (NETCDF\\_MESH2D) or the chunk\\_z, chunk\\_y, and chunk\\_x parameter set (NETCDF\\_STRUCTURED) to have an effect."
+      "utl-ncf": "is the keyword used to provide a data chunk size for the time dimension in a NETCDF\\_MESH2D or NETCDF\\_STRUCTURED output file. Must be used in combination with the the chunk\\_face parameter (NETCDF\\_MESH2D) or the chunk\\_z, chunk\\_y, and chunk\\_x parameter set (NETCDF\\_STRUCTURED) to have an effect."
     }
   },
   "chunk_x": {
     "options": {
-      ".ncf": "is the keyword used to provide a data chunk size for the x dimension in a NETCDF\\_STRUCTURED output file. Must be used in combination with the the chunk\\_time, chunk\\_y and chunk\\_z parameter set to have an effect."
+      "utl-ncf": "is the keyword used to provide a data chunk size for the x dimension in a NETCDF\\_STRUCTURED output file. Must be used in combination with the the chunk\\_time, chunk\\_y and chunk\\_z parameter set to have an effect."
     }
   },
   "chunk_y": {
     "options": {
-      ".ncf": "is the keyword used to provide a data chunk size for the y dimension in a NETCDF\\_STRUCTURED output file. Must be used in combination with the the chunk\\_time, chunk\\_x and chunk\\_z parameter set to have an effect."
+      "utl-ncf": "is the keyword used to provide a data chunk size for the y dimension in a NETCDF\\_STRUCTURED output file. Must be used in combination with the the chunk\\_time, chunk\\_x and chunk\\_z parameter set to have an effect."
     }
   },
   "chunk_z": {
     "options": {
-      ".ncf": "is the keyword used to provide a data chunk size for the z dimension in a NETCDF\\_STRUCTURED output file. Must be used in combination with the the chunk\\_time, chunk\\_x and chunk\\_y parameter set to have an effect."
+      "utl-ncf": "is the keyword used to provide a data chunk size for the z dimension in a NETCDF\\_STRUCTURED output file. Must be used in combination with the the chunk\\_time, chunk\\_x and chunk\\_y parameter set to have an effect."
     }
   },
   "cim": {
     "griddata": {
-      ".ist": "initial concentration of the immobile domain in mass per length cubed.  If CIM is not specified, then it is assumed to be zero."
+      "gwt-ist": "initial concentration of the immobile domain in mass per length cubed.  If CIM is not specified, then it is assumed to be zero."
     },
     "options": {
-      ".ist": "keyword to specify that record corresponds to immobile concentration."
+      "gwt-ist": "keyword to specify that record corresponds to immobile concentration."
     }
   },
   "cl12": {
     "connectiondata": {
-      ".disu": "is the array containing connection lengths between the center of cell n and the shared face with each adjacent m cell."
+      "gwe-disu": "is the array containing connection lengths between the center of cell n and the shared face with each adjacent m cell.",
+      "gwf-disu": "is the array containing connection lengths between the center of cell n and the shared face with each adjacent m cell.",
+      "gwt-disu": "is the array containing connection lengths between the center of cell n and the shared face with each adjacent m cell."
     }
   },
   "cnd_xt3d_off": {
     "options": {
-      ".gwegwe": "deactivate the xt3d method for the dispersive flux and use the faster and less accurate approximation for this exchange."
+      "exg-gwegwe": "deactivate the xt3d method for the dispersive flux and use the faster and less accurate approximation for this exchange."
     }
   },
   "cnd_xt3d_rhs": {
     "options": {
-      ".gwegwe": "add xt3d dispersion terms to right-hand side, when possible, for this exchange."
+      "exg-gwegwe": "add xt3d dispersion terms to right-hand side, when possible, for this exchange."
     }
   },
   "columns": {
     "options": {
-      ".ist": "number of columns for writing data.",
-      ".oc": "number of columns for writing data."
+      "chf-oc": "number of columns for writing data.",
+      "gwe-oc": "number of columns for writing data.",
+      "gwf-oc": "number of columns for writing data.",
+      "gwt-ist": "number of columns for writing data.",
+      "gwt-oc": "number of columns for writing data.",
+      "olf-oc": "number of columns for writing data.",
+      "swf-oc": "number of columns for writing data."
     }
   },
   "compaction": {
     "options": {
-      ".csub": "keyword to specify that record corresponds to the compaction."
+      "gwf-csub": "keyword to specify that record corresponds to the compaction."
     }
   },
   "compaction_coarse": {
     "options": {
-      ".csub": "keyword to specify that record corresponds to the elastic coarse-grained material compaction binary file."
+      "gwf-csub": "keyword to specify that record corresponds to the elastic coarse-grained material compaction binary file."
     }
   },
   "compaction_elastic": {
     "options": {
-      ".csub": "keyword to specify that record corresponds to the elastic interbed compaction binary file."
+      "gwf-csub": "keyword to specify that record corresponds to the elastic interbed compaction binary file."
     }
   },
   "compaction_inelastic": {
     "options": {
-      ".csub": "keyword to specify that record corresponds to the inelastic interbed compaction binary file."
+      "gwf-csub": "keyword to specify that record corresponds to the inelastic interbed compaction binary file."
     }
   },
   "compaction_interbed": {
     "options": {
-      ".csub": "keyword to specify that record corresponds to the interbed compaction binary file."
+      "gwf-csub": "keyword to specify that record corresponds to the interbed compaction binary file."
     }
   },
   "complexity": {
     "options": {
-      ".ims": "is an optional keyword that defines default non-linear and linear solver parameters.  SIMPLE - indicates that default solver input values will be defined that work well for nearly linear models. This would be used for models that do not include nonlinear stress packages and models that are either confined or consist of a single unconfined layer that is thick enough to contain the water table within a single layer. MODERATE - indicates that default solver input values will be defined that work well for moderately nonlinear models. This would be used for models that include nonlinear stress packages and models that consist of one or more unconfined layers. The MODERATE option should be used when the SIMPLE option does not result in successful convergence.  COMPLEX - indicates that default solver input values will be defined that work well for highly nonlinear models. This would be used for models that include nonlinear stress packages and models that consist of one or more unconfined layers representing complex geology and surface-water/groundwater interaction. The COMPLEX option should be used when the MODERATE option does not result in successful convergence.  Non-linear and linear solver parameters assigned using a specified complexity can be modified in the NONLINEAR and LINEAR blocks. If the COMPLEXITY option is not specified, NONLINEAR and LINEAR variables will be assigned the simple complexity values.",
-      ".pts": "is an optional keyword that defines default non-linear and linear solver parameters.  SIMPLE - indicates that default solver input values will be defined that work well for nearly linear models. This would be used for models that do not include nonlinear stress packages and models that are either confined or consist of a single unconfined layer that is thick enough to contain the water table within a single layer. MODERATE - indicates that default solver input values will be defined that work well for moderately nonlinear models. This would be used for models that include nonlinear stress packages and models that consist of one or more unconfined layers. The MODERATE option should be used when the SIMPLE option does not result in successful convergence.  COMPLEX - indicates that default solver input values will be defined that work well for highly nonlinear models. This would be used for models that include nonlinear stress packages and models that consist of one or more unconfined layers representing complex geology and surface-water/groundwater interaction. The COMPLEX option should be used when the MODERATE option does not result in successful convergence.  Non-linear and linear solver parameters assigned using a specified complexity can be modified in the NONLINEAR and LINEAR blocks. If the COMPLEXITY option is not specified, NONLINEAR and LINEAR variables will be assigned the simple complexity values."
+      "sln-ims": "is an optional keyword that defines default non-linear and linear solver parameters.  SIMPLE - indicates that default solver input values will be defined that work well for nearly linear models. This would be used for models that do not include nonlinear stress packages and models that are either confined or consist of a single unconfined layer that is thick enough to contain the water table within a single layer. MODERATE - indicates that default solver input values will be defined that work well for moderately nonlinear models. This would be used for models that include nonlinear stress packages and models that consist of one or more unconfined layers. The MODERATE option should be used when the SIMPLE option does not result in successful convergence.  COMPLEX - indicates that default solver input values will be defined that work well for highly nonlinear models. This would be used for models that include nonlinear stress packages and models that consist of one or more unconfined layers representing complex geology and surface-water/groundwater interaction. The COMPLEX option should be used when the MODERATE option does not result in successful convergence.  Non-linear and linear solver parameters assigned using a specified complexity can be modified in the NONLINEAR and LINEAR blocks. If the COMPLEXITY option is not specified, NONLINEAR and LINEAR variables will be assigned the simple complexity values.",
+      "sln-pts": "is an optional keyword that defines default non-linear and linear solver parameters.  SIMPLE - indicates that default solver input values will be defined that work well for nearly linear models. This would be used for models that do not include nonlinear stress packages and models that are either confined or consist of a single unconfined layer that is thick enough to contain the water table within a single layer. MODERATE - indicates that default solver input values will be defined that work well for moderately nonlinear models. This would be used for models that include nonlinear stress packages and models that consist of one or more unconfined layers. The MODERATE option should be used when the SIMPLE option does not result in successful convergence.  COMPLEX - indicates that default solver input values will be defined that work well for highly nonlinear models. This would be used for models that include nonlinear stress packages and models that consist of one or more unconfined layers representing complex geology and surface-water/groundwater interaction. The COMPLEX option should be used when the MODERATE option does not result in successful convergence.  Non-linear and linear solver parameters assigned using a specified complexity can be modified in the NONLINEAR and LINEAR blocks. If the COMPLEXITY option is not specified, NONLINEAR and LINEAR variables will be assigned the simple complexity values."
     }
   },
   "compression_indices": {
     "options": {
-      ".csub": "keyword to indicate that the recompression (CR) and compression (CC) indices are specified instead of the elastic specific storage (SSE) and inelastic specific storage (SSV) coefficients. If not specified, then elastic specific storage (SSE) and inelastic specific storage (SSV) coefficients must be specified."
+      "gwf-csub": "keyword to indicate that the recompression (CR) and compression (CC) indices are specified instead of the elastic specific storage (SSE) and inelastic specific storage (SSV) coefficients. If not specified, then elastic specific storage (SSE) and inelastic specific storage (SSV) coefficients must be specified."
     }
   },
   "concentration": {
     "options": {
-      ".lkt": "keyword to specify that record corresponds to concentration.",
-      ".mwt": "keyword to specify that record corresponds to concentration.",
-      ".oc": "keyword to specify that record corresponds to concentration.",
-      ".sft": "keyword to specify that record corresponds to concentration.",
-      ".uzt": "keyword to specify that record corresponds to concentration."
+      "gwt-lkt": "keyword to specify that record corresponds to concentration.",
+      "gwt-mwt": "keyword to specify that record corresponds to concentration.",
+      "gwt-oc": "keyword to specify that record corresponds to concentration.",
+      "gwt-sft": "keyword to specify that record corresponds to concentration.",
+      "gwt-uzt": "keyword to specify that record corresponds to concentration."
     },
     "period": {
-      ".lkt": "real or character value that defines the concentration for the lake. The specified CONCENTRATION is only applied if the lake is a constant concentration lake. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      ".mwt": "real or character value that defines the concentration for the well. The specified CONCENTRATION is only applied if the well is a constant concentration well. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      ".sft": "real or character value that defines the concentration for the reach. The specified CONCENTRATION is only applied if the reach is a constant concentration reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      ".spc": "is the boundary concentration. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, the CONCENTRATION for each boundary feature is zero.",
-      ".spca": "is the concentration of the associated Recharge or Evapotranspiration stress package.  The concentration array may be defined by a time-array series (see the \"Using Time-Array Series in a Package\" section).",
-      ".uzt": "real or character value that defines the concentration for the unsaturated zone flow cell. The specified CONCENTRATION is only applied if the unsaturated zone flow cell is a constant concentration cell. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+      "gwt-lkt": "real or character value that defines the concentration for the lake. The specified CONCENTRATION is only applied if the lake is a constant concentration lake. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      "gwt-mwt": "real or character value that defines the concentration for the well. The specified CONCENTRATION is only applied if the well is a constant concentration well. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      "gwt-sft": "real or character value that defines the concentration for the reach. The specified CONCENTRATION is only applied if the reach is a constant concentration reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      "gwt-uzt": "real or character value that defines the concentration for the unsaturated zone flow cell. The specified CONCENTRATION is only applied if the unsaturated zone flow cell is a constant concentration cell. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      "utl-spc": "is the boundary concentration. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, the CONCENTRATION for each boundary feature is zero.",
+      "utl-spca": "is the concentration of the associated Recharge or Evapotranspiration stress package.  The concentration array may be defined by a time-array series (see the \"Using Time-Array Series in a Package\" section)."
     }
   },
   "continue": {
     "options": {
-      ".nam": "keyword flag to indicate that the simulation should continue even if one or more solutions do not converge."
+      "sim-nam": "keyword flag to indicate that the simulation should continue even if one or more solutions do not converge."
     }
   },
   "cross_section": {
     "period": {
-      ".sfr": "keyword to specify that record corresponds to a reach cross-section."
+      "gwf-sfr": "keyword to specify that record corresponds to a reach cross-section."
     }
   },
   "csv_inner_output": {
     "options": {
-      ".ims": "keyword to specify that the record corresponds to the comma separated values solver convergence output.",
-      ".pts": "keyword to specify that the record corresponds to the comma separated values solver convergence output."
+      "sln-ims": "keyword to specify that the record corresponds to the comma separated values solver convergence output.",
+      "sln-pts": "keyword to specify that the record corresponds to the comma separated values solver convergence output."
     }
   },
   "csv_outer_output": {
     "options": {
-      ".ims": "keyword to specify that the record corresponds to the comma separated values outer iteration convergence output.",
-      ".pts": "keyword to specify that the record corresponds to the comma separated values outer iteration convergence output."
+      "sln-ims": "keyword to specify that the record corresponds to the comma separated values outer iteration convergence output.",
+      "sln-pts": "keyword to specify that the record corresponds to the comma separated values outer iteration convergence output."
     }
   },
   "csv_output": {
     "options": {
-      ".ims": "keyword to specify that the record corresponds to the comma separated values solver convergence output.  The CSV\\_OUTPUT option has been deprecated and split into the CSV_OUTER_OUTPUT and CSV_INNER_OUTPUT options.  Starting with MODFLOW 6 version 6.1.1 if the CSV_OUTPUT option is specified, then it is treated as the CSV_OUTER_OUTPUT option.",
-      ".pts": "keyword to specify that the record corresponds to the comma separated values solver convergence output.  The CSV\\_OUTPUT option has been deprecated and split into the CSV_OUTER_OUTPUT and CSV_INNER_OUTPUT options.  Starting with MODFLOW 6 version 6.1.1 if the CSV_OUTPUT option is specified, then it is treated as the CSV_OUTER_OUTPUT option."
+      "sln-ims": "keyword to specify that the record corresponds to the comma separated values solver convergence output.  The CSV\\_OUTPUT option has been deprecated and split into the CSV_OUTER_OUTPUT and CSV_INNER_OUTPUT options.  Starting with MODFLOW 6 version 6.1.1 if the CSV_OUTPUT option is specified, then it is treated as the CSV_OUTER_OUTPUT option.",
+      "sln-pts": "keyword to specify that the record corresponds to the comma separated values solver convergence output.  The CSV\\_OUTPUT option has been deprecated and split into the CSV_OUTER_OUTPUT and CSV_INNER_OUTPUT options.  Starting with MODFLOW 6 version 6.1.1 if the CSV_OUTPUT option is specified, then it is treated as the CSV_OUTER_OUTPUT option."
     }
   },
   "cvoptions": {
     "options": {
-      ".gwfgwf": "none",
-      ".npf": "none"
+      "exg-gwfgwf": "none",
+      "gwf-npf": "none"
     }
   },
   "decay": {
     "griddata": {
-      ".ist": "is the rate coefficient for first or zero-order decay for the aqueous phase of the immobile domain.  A negative value indicates solute production.  The dimensions of decay for first-order decay is one over time.  The dimensions of decay for zero-order decay is mass per length cubed per time.  Decay will have no effect on simulation results unless either first- or zero-order decay is specified in the options block.",
-      ".mst": "is the rate coefficient for first or zero-order decay for the aqueous phase of the mobile domain.  A negative value indicates solute production.  The dimensions of decay for first-order decay is one over time.  The dimensions of decay for zero-order decay is mass per length cubed per time.  decay will have no effect on simulation results unless either first- or zero-order decay is specified in the options block."
+      "gwt-ist": "is the rate coefficient for first or zero-order decay for the aqueous phase of the immobile domain.  A negative value indicates solute production.  The dimensions of decay for first-order decay is one over time.  The dimensions of decay for zero-order decay is mass per length cubed per time.  Decay will have no effect on simulation results unless either first- or zero-order decay is specified in the options block.",
+      "gwt-mst": "is the rate coefficient for first or zero-order decay for the aqueous phase of the mobile domain.  A negative value indicates solute production.  The dimensions of decay for first-order decay is one over time.  The dimensions of decay for zero-order decay is mass per length cubed per time.  decay will have no effect on simulation results unless either first- or zero-order decay is specified in the options block."
     }
   },
   "decay_solid": {
     "griddata": {
-      ".est": "is the rate coefficient for zero-order decay for the solid phase.  A negative value indicates heat (energy) production. The dimensions of zero-order decay in the solid phase are energy per mass of solid per time. Zero-order decay in the solid phase will have no effect on simulation results unless ZERO\\_ORDER\\_DECAY\\_SOLID is specified in the options block."
+      "gwe-est": "is the rate coefficient for zero-order decay for the solid phase.  A negative value indicates heat (energy) production. The dimensions of zero-order decay in the solid phase are energy per mass of solid per time. Zero-order decay in the solid phase will have no effect on simulation results unless ZERO\\_ORDER\\_DECAY\\_SOLID is specified in the options block."
     }
   },
   "decay_sorbed": {
     "griddata": {
-      ".ist": "is the rate coefficient for first or zero-order decay for the sorbed phase of the immobile domain.  A negative value indicates solute production.  The dimensions of decay\\_sorbed for first-order decay is one over time.  The dimensions of decay\\_sorbed for zero-order decay is mass of solute per mass of aquifer per time.  If decay\\_sorbed is not specified and both decay and sorption are active, then the program will terminate with an error.  decay\\_sorbed will have no effect on simulation results unless the SORPTION keyword and either first- or zero-order decay are specified in the options block.",
-      ".mst": "is the rate coefficient for first or zero-order decay for the sorbed phase of the mobile domain.  A negative value indicates solute production.  The dimensions of decay\\_sorbed for first-order decay is one over time.  The dimensions of decay\\_sorbed for zero-order decay is mass of solute per mass of aquifer per time.  If decay\\_sorbed is not specified and both decay and sorption are active, then the program will terminate with an error.  decay\\_sorbed will have no effect on simulation results unless the SORPTION keyword and either first- or zero-order decay are specified in the options block."
+      "gwt-ist": "is the rate coefficient for first or zero-order decay for the sorbed phase of the immobile domain.  A negative value indicates solute production.  The dimensions of decay\\_sorbed for first-order decay is one over time.  The dimensions of decay\\_sorbed for zero-order decay is mass of solute per mass of aquifer per time.  If decay\\_sorbed is not specified and both decay and sorption are active, then the program will terminate with an error.  decay\\_sorbed will have no effect on simulation results unless the SORPTION keyword and either first- or zero-order decay are specified in the options block.",
+      "gwt-mst": "is the rate coefficient for first or zero-order decay for the sorbed phase of the mobile domain.  A negative value indicates solute production.  The dimensions of decay\\_sorbed for first-order decay is one over time.  The dimensions of decay\\_sorbed for zero-order decay is mass of solute per mass of aquifer per time.  If decay\\_sorbed is not specified and both decay and sorption are active, then the program will terminate with an error.  decay\\_sorbed will have no effect on simulation results unless the SORPTION keyword and either first- or zero-order decay are specified in the options block."
     }
   },
   "decay_water": {
     "griddata": {
-      ".est": "is the rate coefficient for zero-order decay for the aqueous phase of the mobile domain.  A negative value indicates heat (energy) production.  The dimensions of zero-order decay in the aqueous phase are energy per length cubed (volume of water) per time.  Zero-order decay in the aqueous phase will have no effect on simulation results unless ZERO\\_ORDER\\_DECAY\\_WATER is specified in the options block."
+      "gwe-est": "is the rate coefficient for zero-order decay for the aqueous phase of the mobile domain.  A negative value indicates heat (energy) production.  The dimensions of zero-order decay in the aqueous phase are energy per length cubed (volume of water) per time.  Zero-order decay in the aqueous phase will have no effect on simulation results unless ZERO\\_ORDER\\_DECAY\\_WATER is specified in the options block."
     }
   },
   "deflate": {
     "options": {
-      ".ncf": "is the variable deflate level (0=min, 9=max) in the netcdf file. Defining this parameter activates per-variable compression at the level specified."
+      "utl-ncf": "is the variable deflate level (0=min, 9=max) in the netcdf file. Defining this parameter activates per-variable compression at the level specified."
     }
   },
   "delc": {
     "griddata": {
-      ".dis": "is the row spacing in the column direction.",
-      ".dis2d": "is the row spacing in the column direction."
+      "gwe-dis": "is the row spacing in the column direction.",
+      "gwf-dis": "is the row spacing in the column direction.",
+      "gwt-dis": "is the row spacing in the column direction.",
+      "olf-dis2d": "is the row spacing in the column direction.",
+      "prt-dis": "is the row spacing in the column direction.",
+      "swf-dis2d": "is the row spacing in the column direction."
     }
   },
   "delr": {
     "griddata": {
-      ".dis": "is the column spacing in the row direction.",
-      ".dis2d": "is the column spacing in the row direction."
+      "gwe-dis": "is the column spacing in the row direction.",
+      "gwf-dis": "is the column spacing in the row direction.",
+      "gwt-dis": "is the column spacing in the row direction.",
+      "olf-dis2d": "is the column spacing in the row direction.",
+      "prt-dis": "is the column spacing in the row direction.",
+      "swf-dis2d": "is the column spacing in the row direction."
     }
   },
   "denseref": {
     "options": {
-      ".buy": "fluid reference density used in the equation of state.  This value is set to 1000. if not specified as an option."
+      "gwf-buy": "fluid reference density used in the equation of state.  This value is set to 1000. if not specified as an option."
     }
   },
   "density": {
     "options": {
-      ".buy": "keyword to specify that record corresponds to density."
+      "gwf-buy": "keyword to specify that record corresponds to density."
     }
   },
   "density_solid": {
     "griddata": {
-      ".est": "is a user-specified value of the density of aquifer material not considering the voids. Value will remain fixed for the entire simulation.  For example, if working in SI units, values may be entered as kilograms per cubic meter. "
+      "gwe-est": "is a user-specified value of the density of aquifer material not considering the voids. Value will remain fixed for the entire simulation.  For example, if working in SI units, values may be entered as kilograms per cubic meter. "
     }
   },
   "density_water": {
     "options": {
-      ".est": "density of water used by calculations related to heat storage and conduction.  This value is set to 1,000 kg/m3 if no overriding value is specified.  A user-specified value should be provided for models that use units other than kilograms and meters or if it is necessary to use a value other than the default."
+      "gwe-est": "density of water used by calculations related to heat storage and conduction.  This value is set to 1,000 kg/m3 if no overriding value is specified.  A user-specified value should be provided for models that use units other than kilograms and meters or if it is necessary to use a value other than the default."
     }
   },
   "depth": {
     "period": {
-      ".evta": "is the ET extinction depth ($L$)."
+      "gwf-evta": "is the ET extinction depth ($L$)."
     }
   },
   "dev_efh_formulation": {
     "options": {
-      ".buy": "use the variable-density equivalent freshwater head formulation instead of the hydraulic head head formulation.  This dev option has only been implemented for confined aquifer conditions and should generally not be used."
+      "gwf-buy": "use the variable-density equivalent freshwater head formulation instead of the hydraulic head head formulation.  This dev option has only been implemented for confined aquifer conditions and should generally not be used."
     }
   },
   "dev_exit_solve_method": {
     "options": {
-      ".prp": "the method for iterative solution of particle exit location and time in the generalized Pollock's method.  0 default, 1 Brent, 2 Chandrupatla.  The default is Brent's method."
+      "prt-prp": "the method for iterative solution of particle exit location and time in the generalized Pollock's method.  0 default, 1 Brent, 2 Chandrupatla.  The default is Brent's method."
     }
   },
   "dev_forceternary": {
     "options": {
-      ".prp": "force use of the ternary tracking method regardless of cell type in DISV grids."
+      "prt-prp": "force use of the ternary tracking method regardless of cell type in DISV grids."
     }
   },
   "dev_interfacemodel_on": {
     "options": {
-      ".gwegwe": "activates the interface model mechanism for calculating the coefficients at (and possibly near) the exchange. This keyword should only be used for development purposes.",
-      ".gwfgwf": "activates the interface model mechanism for calculating the coefficients at (and possibly near) the exchange. This keyword should only be used for development purposes.",
-      ".gwtgwt": "activates the interface model mechanism for calculating the coefficients at (and possibly near) the exchange. This keyword should only be used for development purposes."
+      "exg-gwegwe": "activates the interface model mechanism for calculating the coefficients at (and possibly near) the exchange. This keyword should only be used for development purposes.",
+      "exg-gwfgwf": "activates the interface model mechanism for calculating the coefficients at (and possibly near) the exchange. This keyword should only be used for development purposes.",
+      "exg-gwtgwt": "activates the interface model mechanism for calculating the coefficients at (and possibly near) the exchange. This keyword should only be used for development purposes."
     }
   },
   "dev_log_mpi": {
     "options": {
-      ".hpc": "keyword to enable (extremely verbose) logging of mpi traffic to file."
+      "utl-hpc": "keyword to enable (extremely verbose) logging of mpi traffic to file."
     }
   },
   "dev_no_newton": {
     "options": {
-      ".npf": "turn off Newton for unconfined cells"
+      "gwf-npf": "turn off Newton for unconfined cells"
     }
   },
   "dev_oldstorageformulation": {
     "options": {
-      ".sto": "development option flag for old storage formulation"
+      "gwf-sto": "development option flag for old storage formulation"
     }
   },
   "dev_omega": {
     "options": {
-      ".npf": "set saturation omega value"
+      "gwf-npf": "set saturation omega value"
     }
   },
   "dev_storage_weight": {
     "options": {
-      ".sfr": "real number value that defines the time weighting factor used to calculate the change in channel storage. STORAGE\\_WEIGHT must have a value between 0.5 and 1. Default STORAGE\\_WEIGHT value is 1."
+      "gwf-sfr": "real number value that defines the time weighting factor used to calculate the change in channel storage. STORAGE\\_WEIGHT must have a value between 0.5 and 1. Default STORAGE\\_WEIGHT value is 1."
     }
   },
   "dev_swr_conductance": {
     "options": {
-      ".dfw": "use the conductance formulation in the Surface Water Routing (SWR) Process for MODFLOW-2005."
+      "chf-dfw": "use the conductance formulation in the Surface Water Routing (SWR) Process for MODFLOW-2005.",
+      "olf-dfw": "use the conductance formulation in the Surface Water Routing (SWR) Process for MODFLOW-2005.",
+      "swf-dfw": "use the conductance formulation in the Surface Water Routing (SWR) Process for MODFLOW-2005."
     }
   },
   "dewatered": {
     "options": {
-      ".gwfgwf": "If the DEWATERED keyword is specified, then the vertical conductance is calculated using only the saturated thickness and properties of the overlying cell if the head in the underlying cell is below its top.",
-      ".npf": "If the DEWATERED keyword is specified, then the vertical conductance is calculated using only the saturated thickness and properties of the overlying cell if the head in the underlying cell is below its top."
+      "exg-gwfgwf": "If the DEWATERED keyword is specified, then the vertical conductance is calculated using only the saturated thickness and properties of the overlying cell if the head in the underlying cell is below its top.",
+      "gwf-npf": "If the DEWATERED keyword is specified, then the vertical conductance is calculated using only the saturated thickness and properties of the overlying cell if the head in the underlying cell is below its top."
     }
   },
   "diffc": {
     "griddata": {
-      ".dsp": "effective molecular diffusion coefficient."
+      "gwt-dsp": "effective molecular diffusion coefficient."
     }
   },
   "digits": {
     "options": {
-      ".ist": "number of digits to use for writing a number.",
-      ".obs": "Keyword and an integer digits specifier used for conversion of simulated values to text on output. If not specified, the default is the maximum number of digits stored in the program (as written with the G0 Fortran specifier). When simulated values are written to a comma-separated value text file specified in a CONTINUOUS block below, the digits specifier controls the number of significant digits with which simulated values are written to the output file. The digits specifier has no effect on the number of significant digits with which the simulation time is written for continuous observations.  If DIGITS is specified as zero, then observations are written with the default setting, which is the maximum number of digits.",
-      ".oc": "number of digits to use for writing a number."
+      "chf-oc": "number of digits to use for writing a number.",
+      "gwe-oc": "number of digits to use for writing a number.",
+      "gwf-oc": "number of digits to use for writing a number.",
+      "gwt-ist": "number of digits to use for writing a number.",
+      "gwt-oc": "number of digits to use for writing a number.",
+      "olf-oc": "number of digits to use for writing a number.",
+      "swf-oc": "number of digits to use for writing a number.",
+      "utl-obs": "Keyword and an integer digits specifier used for conversion of simulated values to text on output. If not specified, the default is the maximum number of digits stored in the program (as written with the G0 Fortran specifier). When simulated values are written to a comma-separated value text file specified in a CONTINUOUS block below, the digits specifier controls the number of significant digits with which simulated values are written to the output file. The digits specifier has no effect on the number of significant digits with which the simulation time is written for continuous observations.  If DIGITS is specified as zero, then observations are written with the default setting, which is the maximum number of digits."
     }
   },
   "disable_storage_change_integration": {
     "options": {
-      ".tvs": "keyword that deactivates inclusion of storage derivative terms in the STO package matrix formulation.  In the absence of this keyword (the default), the groundwater storage formulation will be modified to correctly adjust heads based on transient variations in stored water volumes arising from changes to SS and SY properties."
+      "utl-tvs": "keyword that deactivates inclusion of storage derivative terms in the STO package matrix formulation.  In the absence of this keyword (the default), the groundwater storage formulation will be modified to correctly adjust heads based on transient variations in stored water volumes arising from changes to SS and SY properties."
     }
   },
   "distcoef": {
     "griddata": {
-      ".ist": "is the distribution coefficient for the equilibrium-controlled linear sorption isotherm in dimensions of length cubed per mass.  distcoef is not required unless the SORPTION keyword is specified in the options block.  If the SORPTION keyword is not specified in the options block, distcoef will have no effect on simulation results. ",
-      ".mst": "is the distribution coefficient for the equilibrium-controlled linear sorption isotherm in dimensions of length cubed per mass.  If the Freunchlich isotherm is specified, then discoef is the Freundlich constant.  If the Langmuir isotherm is specified, then distcoef is the Langmuir constant.  distcoef is not required unless the SORPTION keyword is specified."
+      "gwt-ist": "is the distribution coefficient for the equilibrium-controlled linear sorption isotherm in dimensions of length cubed per mass.  distcoef is not required unless the SORPTION keyword is specified in the options block.  If the SORPTION keyword is not specified in the options block, distcoef will have no effect on simulation results. ",
+      "gwt-mst": "is the distribution coefficient for the equilibrium-controlled linear sorption isotherm in dimensions of length cubed per mass.  If the Freunchlich isotherm is specified, then discoef is the Freundlich constant.  If the Langmuir isotherm is specified, then distcoef is the Langmuir constant.  distcoef is not required unless the SORPTION keyword is specified."
     }
   },
   "diversion": {
     "period": {
-      ".sfr": "keyword to indicate diversion record."
+      "gwf-sfr": "keyword to indicate diversion record."
     }
   },
   "drape": {
     "options": {
-      ".prp": "is a text keyword to indicate that if a particle's release point is in a cell that happens to be inactive at release time, the particle is to be moved to the topmost active cell below it, if any. By default, a particle is not released into the simulation if its release point's cell is inactive at release time."
+      "prt-prp": "is a text keyword to indicate that if a particle's release point is in a cell that happens to be inactive at release time, the particle is to be moved to the topmost active cell below it, if any. By default, a particle is not released into the simulation if its release point's cell is inactive at release time."
     }
   },
   "dry_tracking_method": {
     "options": {
-      ".prp": "is a string indicating how particles should behave in dry-but-active cells (as can occur with the Newton formulation).  The value can be ``DROP'', ``STOP'', or ``STAY''.  The default is ``DROP'', which passes particles vertically and instantaneously to the water table. ``STOP'' causes particles to terminate. ``STAY'' causes particles to remain stationary but active."
+      "prt-prp": "is a string indicating how particles should behave in dry-but-active cells (as can occur with the Newton formulation).  The value can be ``DROP'', ``STOP'', or ``STAY''.  The default is ``DROP'', which passes particles vertically and instantaneously to the water table. ``STOP'' causes particles to terminate. ``STAY'' causes particles to remain stationary but active."
     }
   },
   "dsp_xt3d_off": {
     "options": {
-      ".gwtgwt": "deactivate the xt3d method for the dispersive flux and use the faster and less accurate approximation for this exchange."
+      "exg-gwtgwt": "deactivate the xt3d method for the dispersive flux and use the faster and less accurate approximation for this exchange."
     }
   },
   "dsp_xt3d_rhs": {
     "options": {
-      ".gwtgwt": "add xt3d dispersion terms to right-hand side, when possible, for this exchange."
+      "exg-gwtgwt": "add xt3d dispersion terms to right-hand side, when possible, for this exchange."
     }
   },
   "effective_stress_lag": {
     "options": {
-      ".csub": "keyword to indicate the effective stress from the previous time step will be used to calculate specific storage values. This option can 1) help with convergence in models with thin cells and water table elevations close to land surface; 2) is identical to the approach used in the SUBWT package for MODFLOW-2005; and 3) is only used if the effective-stress formulation is being used. By default, current effective stress values are used to calculate specific storage values."
+      "gwf-csub": "keyword to indicate the effective stress from the previous time step will be used to calculate specific storage values. This option can 1) help with convergence in models with thin cells and water table elevations close to land surface; 2) is identical to the approach used in the SUBWT package for MODFLOW-2005; and 3) is only used if the effective-stress formulation is being used. By default, current effective stress values are used to calculate specific storage values."
     }
   },
   "evaporation": {
     "period": {
-      ".lak": "real or character value that defines the maximum evaporation rate $(LT^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      ".lke": "use of the EVAPORATION keyword is allowed in the LKE package; however, the specified value is not currently used in LKE calculations.  Instead, the latent heat of evaporation is multiplied by the simulated evaporation rate for determining the thermal energy lost from a stream reach.",
-      ".lkt": "real or character value that defines the concentration of evaporated water $(ML^{-3})$ for the lake. If this concentration value is larger than the simulated concentration in the lake, then the evaporated water will be removed at the same concentration as the lake.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      ".sfe": "use of the EVAPORATION keyword is allowed in the SFE package; however, the specified value is not currently used in SFE calculations.  Instead, the latent heat of evaporation is multiplied by the simulated evaporation rate for determining the thermal energy lost from a stream reach.",
-      ".sfr": "real or character value that defines the volumetric rate per unit area of water subtracted by evaporation from the streamflow routing reach. A positive evaporation rate should be provided. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. If the volumetric evaporation rate for a reach exceeds the sources of water to the reach (upstream and specified inflows, rainfall, and runoff but excluding groundwater leakage into the reach) the volumetric evaporation rate is limited to the sources of water to the reach. By default, evaporation rates are zero for each reach.",
-      ".sft": "real or character value that defines the concentration of evaporated water $(ML^{-3})$ for the reach. If this concentration value is larger than the simulated concentration in the reach, then the evaporated water will be removed at the same concentration as the reach.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+      "gwe-lke": "use of the EVAPORATION keyword is allowed in the LKE package; however, the specified value is not currently used in LKE calculations.  Instead, the latent heat of evaporation is multiplied by the simulated evaporation rate for determining the thermal energy lost from a stream reach.",
+      "gwe-sfe": "use of the EVAPORATION keyword is allowed in the SFE package; however, the specified value is not currently used in SFE calculations.  Instead, the latent heat of evaporation is multiplied by the simulated evaporation rate for determining the thermal energy lost from a stream reach.",
+      "gwf-lak": "real or character value that defines the maximum evaporation rate $(LT^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      "gwf-sfr": "real or character value that defines the volumetric rate per unit area of water subtracted by evaporation from the streamflow routing reach. A positive evaporation rate should be provided. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. If the volumetric evaporation rate for a reach exceeds the sources of water to the reach (upstream and specified inflows, rainfall, and runoff but excluding groundwater leakage into the reach) the volumetric evaporation rate is limited to the sources of water to the reach. By default, evaporation rates are zero for each reach.",
+      "gwt-lkt": "real or character value that defines the concentration of evaporated water $(ML^{-3})$ for the lake. If this concentration value is larger than the simulated concentration in the lake, then the evaporated water will be removed at the same concentration as the lake.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      "gwt-sft": "real or character value that defines the concentration of evaporated water $(ML^{-3})$ for the reach. If this concentration value is larger than the simulated concentration in the reach, then the evaporated water will be removed at the same concentration as the reach.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
     }
   },
   "exchanges": {
     "exchanges": {
-      ".nam": "is the list of exchange types, exchange files, and model names."
+      "sim-nam": "is the list of exchange types, exchange files, and model names."
     }
   },
   "exit_solve_tolerance": {
     "options": {
-      ".prp": "the convergence tolerance for iterative solution of particle exit location and time in the generalized Pollock's method.  A value of 0.00001 works well for many problems, but the value that strikes the best balance between accuracy and runtime is problem-dependent."
+      "prt-prp": "the convergence tolerance for iterative solution of particle exit location and time in the generalized Pollock's method.  A value of 0.00001 works well for many problems, but the value that strikes the best balance between accuracy and runtime is problem-dependent."
     }
   },
   "explicit": {
     "options": {
-      ".gnc": "keyword to indicate that the ghost node correction is applied in an explicit manner on the right-hand side of the matrix.  The explicit approach will likely require additional outer iterations.  If the keyword is not specified, then the correction will be applied in an implicit manner on the left-hand side.  The implicit approach will likely converge better, but may require additional memory.  If the EXPLICIT keyword is not specified, then the BICGSTAB linear acceleration option should be specified within the LINEAR block of the Sparse Matrix Solver."
+      "gwf-gnc": "keyword to indicate that the ghost node correction is applied in an explicit manner on the right-hand side of the matrix.  The explicit approach will likely require additional outer iterations.  If the keyword is not specified, then the correction will be applied in an implicit manner on the left-hand side.  The implicit approach will likely converge better, but may require additional memory.  If the EXPLICIT keyword is not specified, then the BICGSTAB linear acceleration option should be specified within the LINEAR block of the Sparse Matrix Solver."
     }
   },
   "export_array_ascii": {
     "options": {
-      ".cnd": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
-      ".dfw": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
-      ".dis": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
-      ".dis2d": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
-      ".disu": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
-      ".disv": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
-      ".disv1d": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
-      ".disv2d": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
-      ".dsp": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
-      ".ic": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
-      ".mip": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
-      ".npf": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
-      ".sto": "keyword that specifies input grid arrays, which already support the layered keyword, should be written to layered ascii output files."
+      "chf-dfw": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
+      "chf-disv1d": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
+      "chf-ic": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
+      "chf-sto": "keyword that specifies input grid arrays, which already support the layered keyword, should be written to layered ascii output files.",
+      "gwe-cnd": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
+      "gwe-dis": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
+      "gwe-disu": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
+      "gwe-disv": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
+      "gwe-ic": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
+      "gwf-dis": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
+      "gwf-disu": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
+      "gwf-disv": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
+      "gwf-ic": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
+      "gwf-npf": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
+      "gwf-sto": "keyword that specifies input grid arrays, which already support the layered keyword, should be written to layered ascii output files.",
+      "gwt-dis": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
+      "gwt-disu": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
+      "gwt-disv": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
+      "gwt-dsp": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
+      "gwt-ic": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
+      "olf-dfw": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
+      "olf-dis2d": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
+      "olf-disv1d": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
+      "olf-disv2d": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
+      "olf-ic": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
+      "olf-sto": "keyword that specifies input grid arrays, which already support the layered keyword, should be written to layered ascii output files.",
+      "prt-dis": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
+      "prt-disv": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
+      "prt-mip": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
+      "swf-dfw": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
+      "swf-dis2d": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
+      "swf-disv1d": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
+      "swf-disv2d": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
+      "swf-ic": "keyword that specifies input griddata arrays should be written to layered ascii output files.",
+      "swf-sto": "keyword that specifies input grid arrays, which already support the layered keyword, should be written to layered ascii output files."
     }
   },
   "export_array_netcdf": {
     "options": {
-      ".cnd": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
-      ".dis": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
-      ".disv": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
-      ".dsp": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
-      ".evta": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
-      ".ic": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
-      ".npf": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
-      ".rcha": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
-      ".sto": "keyword that specifies input griddata arrays should be written to the model output netcdf file."
+      "gwe-cnd": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
+      "gwe-dis": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
+      "gwe-disv": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
+      "gwe-ic": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
+      "gwf-dis": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
+      "gwf-disv": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
+      "gwf-evta": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
+      "gwf-ic": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
+      "gwf-npf": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
+      "gwf-rcha": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
+      "gwf-sto": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
+      "gwt-dis": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
+      "gwt-disv": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
+      "gwt-dsp": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
+      "gwt-ic": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
+      "prt-dis": "keyword that specifies input griddata arrays should be written to the model output netcdf file.",
+      "prt-disv": "keyword that specifies input griddata arrays should be written to the model output netcdf file."
     }
   },
   "ext-inflow": {
     "period": {
-      ".lke": "real or character value that defines the temperature of external inflow for the lake.  Users are free to use whatever temperature scale they want, which might include negative temperatures.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      ".lkt": "real or character value that defines the concentration of external inflow $(ML^{-3})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+      "gwe-lke": "real or character value that defines the temperature of external inflow for the lake.  Users are free to use whatever temperature scale they want, which might include negative temperatures.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      "gwt-lkt": "real or character value that defines the concentration of external inflow $(ML^{-3})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
     }
   },
   "extend_tracking": {
     "options": {
-      ".prp": "indicates that particles should be tracked beyond the end of the simulation's final time step (using that time step's flows) until particles terminate or reach a specified stop time.  By default, particles are terminated at the end of the simulation's final time step."
+      "prt-prp": "indicates that particles should be tracked beyond the end of the simulation's final time step (using that time step's flows) until particles terminate or reach a specified stop time.  By default, particles are terminated at the end of the simulation's final time step."
     }
   },
   "filein": {
     "crosssections": {
-      ".sfr": "keyword to specify that an input filename is expected next."
+      "gwf-sfr": "keyword to specify that an input filename is expected next."
     },
     "fileinput": {
-      ".ssm": "keyword to specify that an input filename is expected next."
+      "gwe-ssm": "keyword to specify that an input filename is expected next.",
+      "gwt-ssm": "keyword to specify that an input filename is expected next."
     },
     "options": {
-      ".api": "keyword to specify that an input filename is expected next.",
-      ".cdb": "keyword to specify that an input filename is expected next.",
-      ".chd": "keyword to specify that an input filename is expected next.",
-      ".chfgwf": "keyword to specify that an input filename is expected next.",
-      ".cnc": "keyword to specify that an input filename is expected next.",
-      ".csub": "keyword to specify that an input filename is expected next.",
-      ".ctp": "keyword to specify that an input filename is expected next.",
-      ".dfw": "keyword to specify that an input filename is expected next.",
-      ".dis": "keyword to specify that an input filename is expected next.",
-      ".disv": "keyword to specify that an input filename is expected next.",
-      ".drn": "keyword to specify that an input filename is expected next.",
-      ".esl": "keyword to specify that an input filename is expected next.",
-      ".evp": "keyword to specify that an input filename is expected next.",
-      ".evt": "keyword to specify that an input filename is expected next.",
-      ".evta": "keyword to specify that an input filename is expected next.",
-      ".flw": "keyword to specify that an input filename is expected next.",
-      ".ghb": "keyword to specify that an input filename is expected next.",
-      ".gwegwe": "keyword to specify that an input filename is expected next.",
-      ".gwfgwf": "keyword to specify that an input filename is expected next.",
-      ".gwtgwt": "keyword to specify that an input filename is expected next.",
-      ".lak": "keyword to specify that an input filename is expected next.",
-      ".lke": "keyword to specify that an input filename is expected next.",
-      ".lkt": "keyword to specify that an input filename is expected next.",
-      ".maw": "keyword to specify that an input filename is expected next.",
-      ".mwe": "keyword to specify that an input filename is expected next.",
-      ".mwt": "keyword to specify that an input filename is expected next.",
-      ".nam": "keyword to specify that an input filename is expected next.",
-      ".npf": "keyword to specify that an input filename is expected next.",
-      ".olfgwf": "keyword to specify that an input filename is expected next.",
-      ".pcp": "keyword to specify that an input filename is expected next.",
-      ".rch": "keyword to specify that an input filename is expected next.",
-      ".rcha": "keyword to specify that an input filename is expected next.",
-      ".riv": "keyword to specify that an input filename is expected next.",
-      ".sfe": "keyword to specify that an input filename is expected next.",
-      ".sfr": "keyword to specify that an input filename is expected next.",
-      ".sft": "keyword to specify that an input filename is expected next.",
-      ".spc": "keyword to specify that an input filename is expected next.",
-      ".spca": "keyword to specify that an input filename is expected next.",
-      ".src": "keyword to specify that an input filename is expected next.",
-      ".sto": "keyword to specify that an input filename is expected next.",
-      ".tdis": "keyword to specify that an input filename is expected next.",
-      ".tvk": "keyword to specify that an input filename is expected next.",
-      ".tvs": "keyword to specify that an input filename is expected next.",
-      ".uze": "keyword to specify that an input filename is expected next.",
-      ".uzf": "keyword to specify that an input filename is expected next.",
-      ".uzt": "keyword to specify that an input filename is expected next.",
-      ".wel": "keyword to specify that an input filename is expected next.",
-      ".zdg": "keyword to specify that an input filename is expected next."
+      "chf-cdb": "keyword to specify that an input filename is expected next.",
+      "chf-chd": "keyword to specify that an input filename is expected next.",
+      "chf-dfw": "keyword to specify that an input filename is expected next.",
+      "chf-evp": "keyword to specify that an input filename is expected next.",
+      "chf-flw": "keyword to specify that an input filename is expected next.",
+      "chf-pcp": "keyword to specify that an input filename is expected next.",
+      "chf-zdg": "keyword to specify that an input filename is expected next.",
+      "exg-chfgwf": "keyword to specify that an input filename is expected next.",
+      "exg-gwegwe": "keyword to specify that an input filename is expected next.",
+      "exg-gwfgwf": "keyword to specify that an input filename is expected next.",
+      "exg-gwtgwt": "keyword to specify that an input filename is expected next.",
+      "exg-olfgwf": "keyword to specify that an input filename is expected next.",
+      "gwe-ctp": "keyword to specify that an input filename is expected next.",
+      "gwe-dis": "keyword to specify that an input filename is expected next.",
+      "gwe-disv": "keyword to specify that an input filename is expected next.",
+      "gwe-esl": "keyword to specify that an input filename is expected next.",
+      "gwe-lke": "keyword to specify that an input filename is expected next.",
+      "gwe-mwe": "keyword to specify that an input filename is expected next.",
+      "gwe-nam": "keyword to specify that an input filename is expected next.",
+      "gwe-sfe": "keyword to specify that an input filename is expected next.",
+      "gwe-uze": "keyword to specify that an input filename is expected next.",
+      "gwf-api": "keyword to specify that an input filename is expected next.",
+      "gwf-chd": "keyword to specify that an input filename is expected next.",
+      "gwf-csub": "keyword to specify that an input filename is expected next.",
+      "gwf-dis": "keyword to specify that an input filename is expected next.",
+      "gwf-disv": "keyword to specify that an input filename is expected next.",
+      "gwf-drn": "keyword to specify that an input filename is expected next.",
+      "gwf-evt": "keyword to specify that an input filename is expected next.",
+      "gwf-evta": "keyword to specify that an input filename is expected next.",
+      "gwf-ghb": "keyword to specify that an input filename is expected next.",
+      "gwf-lak": "keyword to specify that an input filename is expected next.",
+      "gwf-maw": "keyword to specify that an input filename is expected next.",
+      "gwf-nam": "keyword to specify that an input filename is expected next.",
+      "gwf-npf": "keyword to specify that an input filename is expected next.",
+      "gwf-rch": "keyword to specify that an input filename is expected next.",
+      "gwf-rcha": "keyword to specify that an input filename is expected next.",
+      "gwf-riv": "keyword to specify that an input filename is expected next.",
+      "gwf-sfr": "keyword to specify that an input filename is expected next.",
+      "gwf-sto": "keyword to specify that an input filename is expected next.",
+      "gwf-uzf": "keyword to specify that an input filename is expected next.",
+      "gwf-wel": "keyword to specify that an input filename is expected next.",
+      "gwt-api": "keyword to specify that an input filename is expected next.",
+      "gwt-cnc": "keyword to specify that an input filename is expected next.",
+      "gwt-dis": "keyword to specify that an input filename is expected next.",
+      "gwt-disv": "keyword to specify that an input filename is expected next.",
+      "gwt-lkt": "keyword to specify that an input filename is expected next.",
+      "gwt-mwt": "keyword to specify that an input filename is expected next.",
+      "gwt-nam": "keyword to specify that an input filename is expected next.",
+      "gwt-sft": "keyword to specify that an input filename is expected next.",
+      "gwt-src": "keyword to specify that an input filename is expected next.",
+      "gwt-uzt": "keyword to specify that an input filename is expected next.",
+      "olf-cdb": "keyword to specify that an input filename is expected next.",
+      "olf-chd": "keyword to specify that an input filename is expected next.",
+      "olf-dfw": "keyword to specify that an input filename is expected next.",
+      "olf-evp": "keyword to specify that an input filename is expected next.",
+      "olf-flw": "keyword to specify that an input filename is expected next.",
+      "olf-pcp": "keyword to specify that an input filename is expected next.",
+      "olf-zdg": "keyword to specify that an input filename is expected next.",
+      "prt-dis": "keyword to specify that an input filename is expected next.",
+      "prt-disv": "keyword to specify that an input filename is expected next.",
+      "sim-nam": "keyword to specify that an input filename is expected next.",
+      "sim-tdis": "keyword to specify that an input filename is expected next.",
+      "swf-cdb": "keyword to specify that an input filename is expected next.",
+      "swf-chd": "keyword to specify that an input filename is expected next.",
+      "swf-dfw": "keyword to specify that an input filename is expected next.",
+      "swf-evp": "keyword to specify that an input filename is expected next.",
+      "swf-flw": "keyword to specify that an input filename is expected next.",
+      "swf-pcp": "keyword to specify that an input filename is expected next.",
+      "swf-zdg": "keyword to specify that an input filename is expected next.",
+      "utl-spc": "keyword to specify that an input filename is expected next.",
+      "utl-spca": "keyword to specify that an input filename is expected next.",
+      "utl-tvk": "keyword to specify that an input filename is expected next.",
+      "utl-tvs": "keyword to specify that an input filename is expected next."
     },
     "packagedata": {
-      ".fmi": "keyword to specify that an input filename is expected next."
+      "gwe-fmi": "keyword to specify that an input filename is expected next.",
+      "gwt-fmi": "keyword to specify that an input filename is expected next.",
+      "prt-fmi": "keyword to specify that an input filename is expected next."
     },
     "period": {
-      ".sfr": "keyword to specify that an input filename is expected next."
+      "gwf-sfr": "keyword to specify that an input filename is expected next."
     },
     "tables": {
-      ".lak": "keyword to specify that an input filename is expected next."
+      "gwf-lak": "keyword to specify that an input filename is expected next."
     }
   },
   "fileout": {
     "continuous": {
-      ".obs": "keyword to specify that an output filename is expected next."
+      "utl-obs": "keyword to specify that an output filename is expected next."
     },
     "options": {
-      ".buy": "keyword to specify that an output filename is expected next.",
-      ".csub": "keyword to specify that an output filename is expected next.",
-      ".ims": "keyword to specify that an output filename is expected next.",
-      ".ist": "keyword to specify that an output filename is expected next.",
-      ".lak": "keyword to specify that an output filename is expected next.",
-      ".lke": "keyword to specify that an output filename is expected next.",
-      ".lkt": "keyword to specify that an output filename is expected next.",
-      ".maw": "keyword to specify that an output filename is expected next.",
-      ".mst": "keyword to specify that an output filename is expected next.",
-      ".mve": "keyword to specify that an output filename is expected next.",
-      ".mvr": "keyword to specify that an output filename is expected next.",
-      ".mvt": "keyword to specify that an output filename is expected next.",
-      ".mwe": "keyword to specify that an output filename is expected next.",
-      ".mwt": "keyword to specify that an output filename is expected next.",
-      ".nam": "keyword to specify that an output filename is expected next.",
-      ".oc": "keyword to specify that an output filename is expected next.",
-      ".prp": "keyword to specify that an output filename is expected next.",
-      ".pts": "keyword to specify that an output filename is expected next.",
-      ".sfe": "keyword to specify that an output filename is expected next.",
-      ".sfr": "keyword to specify that an output filename is expected next.",
-      ".sft": "keyword to specify that an output filename is expected next.",
-      ".uze": "keyword to specify that an output filename is expected next.",
-      ".uzf": "keyword to specify that an output filename is expected next.",
-      ".uzt": "keyword to specify that an output filename is expected next.",
-      ".vsc": "keyword to specify that an output filename is expected next.",
-      ".wel": "keyword to specify that an output filename is expected next."
+      "chf-oc": "keyword to specify that an output filename is expected next.",
+      "gwe-lke": "keyword to specify that an output filename is expected next.",
+      "gwe-mve": "keyword to specify that an output filename is expected next.",
+      "gwe-mwe": "keyword to specify that an output filename is expected next.",
+      "gwe-nam": "keyword to specify that an output filename is expected next.",
+      "gwe-oc": "keyword to specify that an output filename is expected next.",
+      "gwe-sfe": "keyword to specify that an output filename is expected next.",
+      "gwe-uze": "keyword to specify that an output filename is expected next.",
+      "gwf-buy": "keyword to specify that an output filename is expected next.",
+      "gwf-csub": "keyword to specify that an output filename is expected next.",
+      "gwf-lak": "keyword to specify that an output filename is expected next.",
+      "gwf-maw": "keyword to specify that an output filename is expected next.",
+      "gwf-mvr": "keyword to specify that an output filename is expected next.",
+      "gwf-nam": "keyword to specify that an output filename is expected next.",
+      "gwf-oc": "keyword to specify that an output filename is expected next.",
+      "gwf-sfr": "keyword to specify that an output filename is expected next.",
+      "gwf-uzf": "keyword to specify that an output filename is expected next.",
+      "gwf-vsc": "keyword to specify that an output filename is expected next.",
+      "gwf-wel": "keyword to specify that an output filename is expected next.",
+      "gwt-ist": "keyword to specify that an output filename is expected next.",
+      "gwt-lkt": "keyword to specify that an output filename is expected next.",
+      "gwt-mst": "keyword to specify that an output filename is expected next.",
+      "gwt-mvt": "keyword to specify that an output filename is expected next.",
+      "gwt-mwt": "keyword to specify that an output filename is expected next.",
+      "gwt-nam": "keyword to specify that an output filename is expected next.",
+      "gwt-oc": "keyword to specify that an output filename is expected next.",
+      "gwt-sft": "keyword to specify that an output filename is expected next.",
+      "gwt-uzt": "keyword to specify that an output filename is expected next.",
+      "olf-oc": "keyword to specify that an output filename is expected next.",
+      "prt-oc": "keyword to specify that an output filename is expected next.",
+      "prt-prp": "keyword to specify that an output filename is expected next.",
+      "sln-ims": "keyword to specify that an output filename is expected next.",
+      "sln-pts": "keyword to specify that an output filename is expected next.",
+      "swf-oc": "keyword to specify that an output filename is expected next."
     }
   },
   "first": {
     "period": {
-      ".oc": "keyword to indicate save for first step in period. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
-      ".prp": "keyword to indicate release at the start of the first time step in the period. This keyword may be used in conjunction with other RELEASESETTING options."
+      "chf-oc": "keyword to indicate save for first step in period. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
+      "gwe-oc": "keyword to indicate save for first step in period. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
+      "gwf-oc": "keyword to indicate save for first step in period. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
+      "gwt-oc": "keyword to indicate save for first step in period. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
+      "olf-oc": "keyword to indicate save for first step in period. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
+      "prt-oc": "keyword to indicate save for first step in period. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
+      "prt-prp": "keyword to indicate release at the start of the first time step in the period. This keyword may be used in conjunction with other RELEASESETTING options.",
+      "swf-oc": "keyword to indicate save for first step in period. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps."
     }
   },
   "first_order_decay": {
     "options": {
-      ".ist": "is a text keyword to indicate that first-order decay will occur.  Use of this keyword requires that DECAY and DECAY\\_SORBED (if sorption is active) are specified in the GRIDDATA block.",
-      ".mst": "is a text keyword to indicate that first-order decay will occur.  Use of this keyword requires that DECAY and DECAY\\_SORBED (if sorption is active) are specified in the GRIDDATA block."
+      "gwt-ist": "is a text keyword to indicate that first-order decay will occur.  Use of this keyword requires that DECAY and DECAY\\_SORBED (if sorption is active) are specified in the GRIDDATA block.",
+      "gwt-mst": "is a text keyword to indicate that first-order decay will occur.  Use of this keyword requires that DECAY and DECAY\\_SORBED (if sorption is active) are specified in the GRIDDATA block."
     }
   },
   "fixed_cell": {
     "options": {
-      ".evt": "indicates that evapotranspiration will not be reassigned to a cell underlying the cell specified in the list if the specified cell is inactive.",
-      ".evta": "indicates that evapotranspiration will not be reassigned to a cell underlying the cell specified in the list if the specified cell is inactive.",
-      ".rch": "indicates that recharge will not be reassigned to a cell underlying the cell specified in the list if the specified cell is inactive.",
-      ".rcha": "indicates that recharge will not be reassigned to a cell underlying the cell specified in the list if the specified cell is inactive."
+      "gwf-evt": "indicates that evapotranspiration will not be reassigned to a cell underlying the cell specified in the list if the specified cell is inactive.",
+      "gwf-evta": "indicates that evapotranspiration will not be reassigned to a cell underlying the cell specified in the list if the specified cell is inactive.",
+      "gwf-rch": "indicates that recharge will not be reassigned to a cell underlying the cell specified in the list if the specified cell is inactive.",
+      "gwf-rcha": "indicates that recharge will not be reassigned to a cell underlying the cell specified in the list if the specified cell is inactive."
     }
   },
   "fixed_conductance": {
     "options": {
-      ".chfgwf": "keyword to indicate that the product of the bedleak and cfact input variables in the exchangedata block represents conductance.  This conductance is fixed and does not change as a function of head in the surface water and groundwater models.",
-      ".olfgwf": "keyword to indicate that the product of the bedleak and cfact input variables in the exchangedata block represents conductance.  This conductance is fixed and does not change as a function of head in the surface water and groundwater models."
+      "exg-chfgwf": "keyword to indicate that the product of the bedleak and cfact input variables in the exchangedata block represents conductance.  This conductance is fixed and does not change as a function of head in the surface water and groundwater models.",
+      "exg-olfgwf": "keyword to indicate that the product of the bedleak and cfact input variables in the exchangedata block represents conductance.  This conductance is fixed and does not change as a function of head in the surface water and groundwater models."
     }
   },
   "flow_correction": {
     "options": {
-      ".maw": "keyword that activates flow corrections in cases where the head in a multi-aquifer well is below the bottom of the screen for a connection or the head in a convertible cell connected to a multi-aquifer well is below the cell bottom. When flow corrections are activated, unit head gradients are used to calculate the flow between a multi-aquifer well and a connected GWF cell. By default, flow corrections are not made."
+      "gwf-maw": "keyword that activates flow corrections in cases where the head in a multi-aquifer well is below the bottom of the screen for a connection or the head in a convertible cell connected to a multi-aquifer well is below the cell bottom. When flow corrections are activated, unit head gradients are used to calculate the flow between a multi-aquifer well and a connected GWF cell. By default, flow corrections are not made."
     }
   },
   "flow_imbalance_correction": {
     "options": {
-      ".fmi": "correct for an imbalance in flows by assuming that any residual flow error comes in or leaves at the concentration of the cell.  When this option is activated, the GWT Model budget written to the listing file will contain two additional entries: FLOW-ERROR and FLOW-CORRECTION.  These two entries will be equal but opposite in sign.  The FLOW-CORRECTION term is a mass flow that is added to offset the error caused by an imprecise flow balance.  If these terms are not relatively small, the flow model should be rerun with stricter convergence tolerances."
+      "gwe-fmi": "correct for an imbalance in flows by assuming that any residual flow error comes in or leaves at the temperature of the cell.  When this option is activated, the GWE Model budget written to the listing file will contain two additional entries: FLOW-ERROR and FLOW-CORRECTION.  These two entries will be equal but opposite in sign.  The FLOW-CORRECTION term is a mass flow that is added to offset the error caused by an imprecise flow balance.  If these terms are not relatively small, the flow model should be rerun with stricter convergence tolerances.",
+      "gwt-fmi": "correct for an imbalance in flows by assuming that any residual flow error comes in or leaves at the concentration of the cell.  When this option is activated, the GWT Model budget written to the listing file will contain two additional entries: FLOW-ERROR and FLOW-CORRECTION.  These two entries will be equal but opposite in sign.  The FLOW-CORRECTION term is a mass flow that is added to offset the error caused by an imprecise flow balance.  If these terms are not relatively small, the flow model should be rerun with stricter convergence tolerances."
     }
   },
   "flow_package_auxiliary_name": {
     "options": {
-      ".lke": "keyword to specify the name of an auxiliary variable in the corresponding flow package.  If specified, then the simulated temperatures from this advanced transport package will be copied into the auxiliary variable specified with this name.  Note that the flow package must have an auxiliary variable with this name or the program will terminate with an error.  If the flows for this advanced transport package are read from a file, then this option will have no effect.",
-      ".lkt": "keyword to specify the name of an auxiliary variable in the corresponding flow package.  If specified, then the simulated concentrations from this advanced transport package will be copied into the auxiliary variable specified with this name.  Note that the flow package must have an auxiliary variable with this name or the program will terminate with an error.  If the flows for this advanced transport package are read from a file, then this option will have no effect.",
-      ".mwe": "keyword to specify the name of an auxiliary variable in the corresponding flow package.  If specified, then the simulated temperatures from this advanced transport package will be copied into the auxiliary variable specified with this name.  Note that the flow package must have an auxiliary variable with this name or the program will terminate with an error.  If the flows for this advanced transport package are read from a file, then this option will have no effect.",
-      ".mwt": "keyword to specify the name of an auxiliary variable in the corresponding flow package.  If specified, then the simulated concentrations from this advanced transport package will be copied into the auxiliary variable specified with this name.  Note that the flow package must have an auxiliary variable with this name or the program will terminate with an error.  If the flows for this advanced transport package are read from a file, then this option will have no effect.",
-      ".sfe": "keyword to specify the name of an auxiliary variable provided in the corresponding flow package (i.e., FLOW\\_PACKAGE\\_NAME).  If specified, then the simulated temperatures from this advanced energy transport package will be copied into the auxiliary variable specified with this name.  Note that the flow package must have an auxiliary variable with this name or the program will terminate with an error.  If the flows for this advanced energy transport package are read from a file, then this option will have no effect.",
-      ".sft": "keyword to specify the name of an auxiliary variable in the corresponding flow package.  If specified, then the simulated concentrations from this advanced transport package will be copied into the auxiliary variable specified with this name.  Note that the flow package must have an auxiliary variable with this name or the program will terminate with an error.  If the flows for this advanced transport package are read from a file, then this option will have no effect.",
-      ".uze": "keyword to specify the name of an auxiliary variable in the corresponding flow package.  If specified, then the simulated temperatures from this advanced transport package will be copied into the auxiliary variable specified with this name.  Note that the flow package must have an auxiliary variable with this name or the program will terminate with an error.  If the flows for this advanced transport package are read from a file, then this option will have no effect.",
-      ".uzt": "keyword to specify the name of an auxiliary variable in the corresponding flow package.  If specified, then the simulated concentrations from this advanced transport package will be copied into the auxiliary variable specified with this name.  Note that the flow package must have an auxiliary variable with this name or the program will terminate with an error.  If the flows for this advanced transport package are read from a file, then this option will have no effect."
+      "gwe-lke": "keyword to specify the name of an auxiliary variable in the corresponding flow package.  If specified, then the simulated temperatures from this advanced transport package will be copied into the auxiliary variable specified with this name.  Note that the flow package must have an auxiliary variable with this name or the program will terminate with an error.  If the flows for this advanced transport package are read from a file, then this option will have no effect.",
+      "gwe-mwe": "keyword to specify the name of an auxiliary variable in the corresponding flow package.  If specified, then the simulated temperatures from this advanced transport package will be copied into the auxiliary variable specified with this name.  Note that the flow package must have an auxiliary variable with this name or the program will terminate with an error.  If the flows for this advanced transport package are read from a file, then this option will have no effect.",
+      "gwe-sfe": "keyword to specify the name of an auxiliary variable provided in the corresponding flow package (i.e., FLOW\\_PACKAGE\\_NAME).  If specified, then the simulated temperatures from this advanced energy transport package will be copied into the auxiliary variable specified with this name.  Note that the flow package must have an auxiliary variable with this name or the program will terminate with an error.  If the flows for this advanced energy transport package are read from a file, then this option will have no effect.",
+      "gwe-uze": "keyword to specify the name of an auxiliary variable in the corresponding flow package.  If specified, then the simulated temperatures from this advanced transport package will be copied into the auxiliary variable specified with this name.  Note that the flow package must have an auxiliary variable with this name or the program will terminate with an error.  If the flows for this advanced transport package are read from a file, then this option will have no effect.",
+      "gwt-lkt": "keyword to specify the name of an auxiliary variable in the corresponding flow package.  If specified, then the simulated concentrations from this advanced transport package will be copied into the auxiliary variable specified with this name.  Note that the flow package must have an auxiliary variable with this name or the program will terminate with an error.  If the flows for this advanced transport package are read from a file, then this option will have no effect.",
+      "gwt-mwt": "keyword to specify the name of an auxiliary variable in the corresponding flow package.  If specified, then the simulated concentrations from this advanced transport package will be copied into the auxiliary variable specified with this name.  Note that the flow package must have an auxiliary variable with this name or the program will terminate with an error.  If the flows for this advanced transport package are read from a file, then this option will have no effect.",
+      "gwt-sft": "keyword to specify the name of an auxiliary variable in the corresponding flow package.  If specified, then the simulated concentrations from this advanced transport package will be copied into the auxiliary variable specified with this name.  Note that the flow package must have an auxiliary variable with this name or the program will terminate with an error.  If the flows for this advanced transport package are read from a file, then this option will have no effect.",
+      "gwt-uzt": "keyword to specify the name of an auxiliary variable in the corresponding flow package.  If specified, then the simulated concentrations from this advanced transport package will be copied into the auxiliary variable specified with this name.  Note that the flow package must have an auxiliary variable with this name or the program will terminate with an error.  If the flows for this advanced transport package are read from a file, then this option will have no effect."
     }
   },
   "flow_package_name": {
     "options": {
-      ".lke": "keyword to specify the name of the corresponding flow package.  If not specified, then the corresponding flow package must have the same name as this advanced transport package (the name associated with this package in the GWE name file).",
-      ".lkt": "keyword to specify the name of the corresponding flow package.  If not specified, then the corresponding flow package must have the same name as this advanced transport package (the name associated with this package in the GWT name file).",
-      ".mwe": "keyword to specify the name of the corresponding flow package.  If not specified, then the corresponding flow package must have the same name as this advanced transport package (the name associated with this package in the GWE name file).",
-      ".mwt": "keyword to specify the name of the corresponding flow package.  If not specified, then the corresponding flow package must have the same name as this advanced transport package (the name associated with this package in the GWT name file).",
-      ".sfe": "keyword to specify the name of the corresponding flow package.  If not specified, then the corresponding flow package must have the same name as this advanced transport package (the name associated with this package in the GWE name file).",
-      ".sft": "keyword to specify the name of the corresponding flow package.  If not specified, then the corresponding flow package must have the same name as this advanced transport package (the name associated with this package in the GWT name file).",
-      ".uze": "keyword to specify the name of the corresponding flow package.  If not specified, then the corresponding flow package must have the same name as this advanced transport package (the name associated with this package in the GWE name file).",
-      ".uzt": "keyword to specify the name of the corresponding flow package.  If not specified, then the corresponding flow package must have the same name as this advanced transport package (the name associated with this package in the GWT name file)."
+      "gwe-lke": "keyword to specify the name of the corresponding flow package.  If not specified, then the corresponding flow package must have the same name as this advanced transport package (the name associated with this package in the GWE name file).",
+      "gwe-mwe": "keyword to specify the name of the corresponding flow package.  If not specified, then the corresponding flow package must have the same name as this advanced transport package (the name associated with this package in the GWE name file).",
+      "gwe-sfe": "keyword to specify the name of the corresponding flow package.  If not specified, then the corresponding flow package must have the same name as this advanced transport package (the name associated with this package in the GWE name file).",
+      "gwe-uze": "keyword to specify the name of the corresponding flow package.  If not specified, then the corresponding flow package must have the same name as this advanced transport package (the name associated with this package in the GWE name file).",
+      "gwt-lkt": "keyword to specify the name of the corresponding flow package.  If not specified, then the corresponding flow package must have the same name as this advanced transport package (the name associated with this package in the GWT name file).",
+      "gwt-mwt": "keyword to specify the name of the corresponding flow package.  If not specified, then the corresponding flow package must have the same name as this advanced transport package (the name associated with this package in the GWT name file).",
+      "gwt-sft": "keyword to specify the name of the corresponding flow package.  If not specified, then the corresponding flow package must have the same name as this advanced transport package (the name associated with this package in the GWT name file).",
+      "gwt-uzt": "keyword to specify the name of the corresponding flow package.  If not specified, then the corresponding flow package must have the same name as this advanced transport package (the name associated with this package in the GWT name file)."
     }
   },
   "flowing_well": {
     "period": {
-      ".maw": "keyword to indicate the well is a flowing well.  The FLOWING\\_WELL option can be used to simulate flowing wells when the simulated well head exceeds the specified drainage elevation."
+      "gwf-maw": "keyword to indicate the well is a flowing well.  The FLOWING\\_WELL option can be used to simulate flowing wells when the simulated well head exceeds the specified drainage elevation."
     }
   },
   "flowing_wells": {
     "options": {
-      ".maw": "keyword that activates the flowing wells option for the multi-aquifer well package."
+      "gwf-maw": "keyword that activates the flowing wells option for the multi-aquifer well package."
     }
   },
   "fraction": {
     "period": {
-      ".prp": "release particles after the specified fraction of the time step has elapsed. If FRACTION is not set, particles are released at the start of the specified time step(s). FRACTION must be a single value when used with ALL, FIRST, or FREQUENCY. When used with STEPS, FRACTION may be a single value or an array of the same length as STEPS. If a single FRACTION value is provided with STEPS, the fraction applies to all steps. NOTE: The FRACTION option has been removed. For fine control over release timing, specify times explicitly using the RELEASETIMES block."
+      "prt-prp": "release particles after the specified fraction of the time step has elapsed. If FRACTION is not set, particles are released at the start of the specified time step(s). FRACTION must be a single value when used with ALL, FIRST, or FREQUENCY. When used with STEPS, FRACTION may be a single value or an array of the same length as STEPS. If a single FRACTION value is provided with STEPS, the fraction applies to all steps. NOTE: The FRACTION option has been removed. For fine control over release timing, specify times explicitly using the RELEASETIMES block."
     }
   },
   "frequency": {
     "period": {
-      ".oc": "save at the specified time step frequency. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
-      ".prp": "release at the specified time step frequency. This keyword may be used in conjunction with other RELEASESETTING options."
+      "chf-oc": "save at the specified time step frequency. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
+      "gwe-oc": "save at the specified time step frequency. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
+      "gwf-oc": "save at the specified time step frequency. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
+      "gwt-oc": "save at the specified time step frequency. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
+      "olf-oc": "save at the specified time step frequency. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
+      "prt-oc": "save at the specified time step frequency. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
+      "prt-prp": "release at the specified time step frequency. This keyword may be used in conjunction with other RELEASESETTING options.",
+      "swf-oc": "save at the specified time step frequency. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps."
     }
   },
   "gnc6": {
     "options": {
-      ".gwfgwf": "keyword to specify that record corresponds to a ghost-node correction file."
+      "exg-gwfgwf": "keyword to specify that record corresponds to a ghost-node correction file."
     }
   },
   "gwfmodelname1": {
     "options": {
-      ".gwegwe": "keyword to specify name of first corresponding GWF Model.  In the simulation name file, the GWE6-GWE6 entry contains names for GWE Models (exgmnamea and exgmnameb).  The GWE Model with the name exgmnamea must correspond to the GWF Model with the name gwfmodelname1.",
-      ".gwtgwt": "keyword to specify name of first corresponding GWF Model.  In the simulation name file, the GWT6-GWT6 entry contains names for GWT Models (exgmnamea and exgmnameb).  The GWT Model with the name exgmnamea must correspond to the GWF Model with the name gwfmodelname1."
+      "exg-gwegwe": "keyword to specify name of first corresponding GWF Model.  In the simulation name file, the GWE6-GWE6 entry contains names for GWE Models (exgmnamea and exgmnameb).  The GWE Model with the name exgmnamea must correspond to the GWF Model with the name gwfmodelname1.",
+      "exg-gwtgwt": "keyword to specify name of first corresponding GWF Model.  In the simulation name file, the GWT6-GWT6 entry contains names for GWT Models (exgmnamea and exgmnameb).  The GWT Model with the name exgmnamea must correspond to the GWF Model with the name gwfmodelname1."
     }
   },
   "gwfmodelname2": {
     "options": {
-      ".gwegwe": "keyword to specify name of second corresponding GWF Model.  In the simulation name file, the GWE6-GWE6 entry contains names for GWE Models (exgmnamea and exgmnameb).  The GWE Model with the name exgmnameb must correspond to the GWF Model with the name gwfmodelname2.",
-      ".gwtgwt": "keyword to specify name of second corresponding GWF Model.  In the simulation name file, the GWT6-GWT6 entry contains names for GWT Models (exgmnamea and exgmnameb).  The GWT Model with the name exgmnameb must correspond to the GWF Model with the name gwfmodelname2."
+      "exg-gwegwe": "keyword to specify name of second corresponding GWF Model.  In the simulation name file, the GWE6-GWE6 entry contains names for GWE Models (exgmnamea and exgmnameb).  The GWE Model with the name exgmnameb must correspond to the GWF Model with the name gwfmodelname2.",
+      "exg-gwtgwt": "keyword to specify name of second corresponding GWF Model.  In the simulation name file, the GWT6-GWT6 entry contains names for GWT Models (exgmnamea and exgmnameb).  The GWT Model with the name exgmnameb must correspond to the GWF Model with the name gwfmodelname2."
     }
   },
   "head": {
     "options": {
-      ".maw": "keyword to specify that record corresponds to head.",
-      ".oc": "keyword to specify that record corresponds to head."
+      "gwf-maw": "keyword to specify that record corresponds to head.",
+      "gwf-oc": "keyword to specify that record corresponds to head."
     }
   },
   "head_based": {
     "options": {
-      ".csub": "keyword to indicate the head-based formulation will be used to simulate coarse-grained aquifer materials and no-delay and delay interbeds. Specifying HEAD\\_BASED also specifies the INITIAL\\_PRECONSOLIDATION\\_HEAD option."
+      "gwf-csub": "keyword to indicate the head-based formulation will be used to simulate coarse-grained aquifer materials and no-delay and delay interbeds. Specifying HEAD\\_BASED also specifies the INITIAL\\_PRECONSOLIDATION\\_HEAD option."
     }
   },
   "head_limit": {
     "period": {
-      ".maw": "is the limiting water level (head) in the well, which is the minimum of the well RATE or the well inflow rate from the aquifer. HEAD\\_LIMIT can be applied to extraction wells (RATE $<$ 0) or injection wells (RATE $>$ 0). HEAD\\_LIMIT can be deactivated by specifying the text string `OFF'. The HEAD\\_LIMIT option is based on the HEAD\\_LIMIT functionality available in the MNW2~\\citep{konikow2009} package for MODFLOW-2005. The HEAD\\_LIMIT option has been included to facilitate backward compatibility with previous versions of MODFLOW but use of the RATE\\_SCALING option instead of the HEAD\\_LIMIT option is recommended. By default, HEAD\\_LIMIT is `OFF'."
+      "gwf-maw": "is the limiting water level (head) in the well, which is the minimum of the well RATE or the well inflow rate from the aquifer. HEAD\\_LIMIT can be applied to extraction wells (RATE $<$ 0) or injection wells (RATE $>$ 0). HEAD\\_LIMIT can be deactivated by specifying the text string `OFF'. The HEAD\\_LIMIT option is based on the HEAD\\_LIMIT functionality available in the MNW2~\\citep{konikow2009} package for MODFLOW-2005. The HEAD\\_LIMIT option has been included to facilitate backward compatibility with previous versions of MODFLOW but use of the RATE\\_SCALING option instead of the HEAD\\_LIMIT option is recommended. By default, HEAD\\_LIMIT is `OFF'."
     }
   },
   "heat_capacity_solid": {
     "griddata": {
-      ".est": "is the mass-based heat capacity of dry solids (aquifer material). For example, units of J/kg/C may be used (or equivalent)."
+      "gwe-est": "is the mass-based heat capacity of dry solids (aquifer material). For example, units of J/kg/C may be used (or equivalent)."
     }
   },
   "heat_capacity_water": {
     "options": {
-      ".est": "heat capacity of water used by calculations related to heat storage and conduction.  This value is set to 4,184 J/kg/C if no overriding value is specified.  A user-specified value should be provided for models that use units other than kilograms, joules, and degrees Celsius or it is necessary to use a value other than the default."
+      "gwe-est": "heat capacity of water used by calculations related to heat storage and conduction.  This value is set to 4,184 J/kg/C if no overriding value is specified.  A user-specified value should be provided for models that use units other than kilograms, joules, and degrees Celsius or it is necessary to use a value other than the default."
     }
   },
   "hhformulation_rhs": {
     "options": {
-      ".buy": "use the variable-density hydraulic head formulation and add off-diagonal terms to the right-hand.  This option will prevent the BUY Package from adding asymmetric terms to the flow matrix."
+      "gwf-buy": "use the variable-density hydraulic head formulation and add off-diagonal terms to the right-hand.  This option will prevent the BUY Package from adding asymmetric terms to the flow matrix."
     }
   },
   "hpc6": {
     "options": {
-      ".nam": "keyword to specify that record corresponds to a hpc file."
+      "sim-nam": "keyword to specify that record corresponds to a hpc file."
     }
   },
   "hwva": {
     "connectiondata": {
-      ".disu": "is a symmetric array of size NJA.  For horizontal connections, entries in HWVA are the horizontal width perpendicular to flow.  For vertical connections, entries in HWVA are the vertical area for flow.  Thus, values in the HWVA array contain dimensions of both length and area.  Entries in the HWVA array have a one-to-one correspondence with the connections specified in the JA array.  Likewise, there is a one-to-one correspondence between entries in the HWVA array and entries in the IHC array, which specifies the connection type (horizontal or vertical).  Entries in the HWVA array must be symmetric; the program will terminate with an error if the value for HWVA for an n to m connection does not equal the value for HWVA for the corresponding n to m connection."
+      "gwe-disu": "is a symmetric array of size NJA.  For horizontal connections, entries in HWVA are the horizontal width perpendicular to flow.  For vertical connections, entries in HWVA are the vertical area for flow.  Thus, values in the HWVA array contain dimensions of both length and area.  Entries in the HWVA array have a one-to-one correspondence with the connections specified in the JA array.  Likewise, there is a one-to-one correspondence between entries in the HWVA array and entries in the IHC array, which specifies the connection type (horizontal or vertical).  Entries in the HWVA array must be symmetric; the program will terminate with an error if the value for HWVA for an n to m connection does not equal the value for HWVA for the corresponding n to m connection.",
+      "gwf-disu": "is a symmetric array of size NJA.  For horizontal connections, entries in HWVA are the horizontal width perpendicular to flow.  For vertical connections, entries in HWVA are the vertical area for flow.  Thus, values in the HWVA array contain dimensions of both length and area.  Entries in the HWVA array have a one-to-one correspondence with the connections specified in the JA array.  Likewise, there is a one-to-one correspondence between entries in the HWVA array and entries in the IHC array, which specifies the connection type (horizontal or vertical).  Entries in the HWVA array must be symmetric; the program will terminate with an error if the value for HWVA for an n to m connection does not equal the value for HWVA for the corresponding n to m connection.",
+      "gwt-disu": "is a symmetric array of size NJA.  For horizontal connections, entries in HWVA are the horizontal width perpendicular to flow.  For vertical connections, entries in HWVA are the vertical area for flow.  Thus, values in the HWVA array contain dimensions of both length and area.  Entries in the HWVA array have a one-to-one correspondence with the connections specified in the JA array.  Likewise, there is a one-to-one correspondence between entries in the HWVA array and entries in the IHC array, which specifies the connection type (horizontal or vertical).  Entries in the HWVA array must be symmetric; the program will terminate with an error if the value for HWVA for an n to m connection does not equal the value for HWVA for the corresponding n to m connection."
     }
   },
   "iac": {
     "connectiondata": {
-      ".disu": "is the number of connections (plus 1) for each cell.  The sum of all the entries in IAC must be equal to NJA."
+      "gwe-disu": "is the number of connections (plus 1) for each cell.  The sum of all the entries in IAC must be equal to NJA.",
+      "gwf-disu": "is the number of connections (plus 1) for each cell.  The sum of all the entries in IAC must be equal to NJA.",
+      "gwt-disu": "is the number of connections (plus 1) for each cell.  The sum of all the entries in IAC must be equal to NJA."
     }
   },
   "icelltype": {
     "griddata": {
-      ".npf": "flag for each cell that specifies how saturated thickness is treated.  0 means saturated thickness is held constant;  $>$0 means saturated thickness varies with computed head when head is below the cell top; $<$0 means saturated thickness varies with computed head unless the THICKSTRT option is in effect.  When THICKSTRT is in effect, a negative value for ICELLTYPE indicates that the saturated thickness value used in conductance calculations in the NPF Package will be computed as STRT-BOT and held constant.  If the THICKSTRT option is not in effect, then negative values provided by the user for ICELLTYPE are automatically reassigned by the program to a value of one."
+      "gwf-npf": "flag for each cell that specifies how saturated thickness is treated.  0 means saturated thickness is held constant;  $>$0 means saturated thickness varies with computed head when head is below the cell top; $<$0 means saturated thickness varies with computed head unless the THICKSTRT option is in effect.  When THICKSTRT is in effect, a negative value for ICELLTYPE indicates that the saturated thickness value used in conductance calculations in the NPF Package will be computed as STRT-BOT and held constant.  If the THICKSTRT option is not in effect, then negative values provided by the user for ICELLTYPE are automatically reassigned by the program to a value of one."
     }
   },
   "iconvert": {
     "griddata": {
-      ".sto": "is a flag for each cell that specifies whether or not a cell is convertible for the storage calculation. 0 indicates confined storage is used. $>$0 indicates confined storage is used when head is above cell top and a mixed formulation of unconfined and confined storage is used when head is below cell top."
+      "gwf-sto": "is a flag for each cell that specifies whether or not a cell is convertible for the storage calculation. 0 indicates confined storage is used. $>$0 indicates confined storage is used when head is above cell top and a mixed formulation of unconfined and confined storage is used when head is below cell top."
     }
   },
   "idcxs": {
     "griddata": {
-      ".dfw": "integer value indication the cross section identifier in the Cross Section Package that applies to the reach.  If not provided then reach will be treated as hydraulically wide."
+      "chf-dfw": "integer value indication the cross section identifier in the Cross Section Package that applies to the reach.  If not provided then reach will be treated as hydraulically wide.",
+      "olf-dfw": "integer value indication the cross section identifier in the Cross Section Package that applies to the reach.  If not provided then reach will be treated as hydraulically wide.",
+      "swf-dfw": "integer value indication the cross section identifier in the Cross Section Package that applies to the reach.  If not provided then reach will be treated as hydraulically wide."
     }
   },
   "idomain": {
     "griddata": {
-      ".dis": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1, the cell exists in the simulation.  If the IDOMAIN value for a cell is -1, the cell does not exist in the simulation.  Furthermore, the first existing cell above will be connected to the first existing cell below.  This type of cell is referred to as a ``vertical pass through'' cell.",
-      ".dis2d": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1, the cell exists in the simulation.  If the IDOMAIN value for a cell is -1, the cell does not exist in the simulation.  Furthermore, the first existing cell above will be connected to the first existing cell below.  This type of cell is referred to as a ``vertical pass through'' cell.",
-      ".disu": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1 or greater, the cell exists in the simulation.  IDOMAIN values of -1 cannot be specified for the DISU Package.",
-      ".disv": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1 or greater, the cell exists in the simulation.  If the IDOMAIN value for a cell is -1, the cell does not exist in the simulation.  Furthermore, the first existing cell above will be connected to the first existing cell below.  This type of cell is referred to as a ``vertical pass through'' cell.",
-      ".disv1d": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1, the cell exists in the simulation.",
-      ".disv2d": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1 or greater, the cell exists in the simulation.  If the IDOMAIN value for a cell is -1, the cell does not exist in the simulation.  Furthermore, the first existing cell above will be connected to the first existing cell below.  This type of cell is referred to as a ``vertical pass through'' cell."
+      "chf-disv1d": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1, the cell exists in the simulation.",
+      "gwe-dis": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1, the cell exists in the simulation.  If the IDOMAIN value for a cell is -1, the cell does not exist in the simulation.  Furthermore, the first existing cell above will be connected to the first existing cell below.  This type of cell is referred to as a ``vertical pass through'' cell.",
+      "gwe-disu": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1 or greater, the cell exists in the simulation.  IDOMAIN values of -1 cannot be specified for the DISU Package.",
+      "gwe-disv": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1, the cell exists in the simulation.  If the IDOMAIN value for a cell is -1, the cell does not exist in the simulation.  Furthermore, the first existing cell above will be connected to the first existing cell below.  This type of cell is referred to as a ``vertical pass through'' cell.",
+      "gwf-dis": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1 or greater, the cell exists in the simulation.  If the IDOMAIN value for a cell is -1, the cell does not exist in the simulation.  Furthermore, the first existing cell above will be connected to the first existing cell below.  This type of cell is referred to as a ``vertical pass through'' cell.",
+      "gwf-disu": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1 or greater, the cell exists in the simulation.  IDOMAIN values of -1 cannot be specified for the DISU Package.",
+      "gwf-disv": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1 or greater, the cell exists in the simulation.  If the IDOMAIN value for a cell is -1, the cell does not exist in the simulation.  Furthermore, the first existing cell above will be connected to the first existing cell below.  This type of cell is referred to as a ``vertical pass through'' cell.",
+      "gwt-dis": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1, the cell exists in the simulation.  If the IDOMAIN value for a cell is -1, the cell does not exist in the simulation.  Furthermore, the first existing cell above will be connected to the first existing cell below.  This type of cell is referred to as a ``vertical pass through'' cell.",
+      "gwt-disu": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1 or greater, the cell exists in the simulation.  IDOMAIN values of -1 cannot be specified for the DISU Package.",
+      "gwt-disv": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1, the cell exists in the simulation.  If the IDOMAIN value for a cell is -1, the cell does not exist in the simulation.  Furthermore, the first existing cell above will be connected to the first existing cell below.  This type of cell is referred to as a ``vertical pass through'' cell.",
+      "olf-dis2d": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1, the cell exists in the simulation.  If the IDOMAIN value for a cell is -1, the cell does not exist in the simulation.  Furthermore, the first existing cell above will be connected to the first existing cell below.  This type of cell is referred to as a ``vertical pass through'' cell.",
+      "olf-disv1d": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1, the cell exists in the simulation.",
+      "olf-disv2d": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1 or greater, the cell exists in the simulation.  If the IDOMAIN value for a cell is -1, the cell does not exist in the simulation.  Furthermore, the first existing cell above will be connected to the first existing cell below.  This type of cell is referred to as a ``vertical pass through'' cell.",
+      "prt-dis": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1, the cell exists in the simulation.  If the IDOMAIN value for a cell is -1, the cell does not exist in the simulation.  Furthermore, the first existing cell above will be connected to the first existing cell below.  This type of cell is referred to as a ``vertical pass through'' cell.",
+      "prt-disv": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1, the cell exists in the simulation.  If the IDOMAIN value for a cell is -1, the cell does not exist in the simulation.  Furthermore, the first existing cell above will be connected to the first existing cell below.  This type of cell is referred to as a ``vertical pass through'' cell.",
+      "swf-dis2d": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1, the cell exists in the simulation.  If the IDOMAIN value for a cell is -1, the cell does not exist in the simulation.  Furthermore, the first existing cell above will be connected to the first existing cell below.  This type of cell is referred to as a ``vertical pass through'' cell.",
+      "swf-disv1d": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1, the cell exists in the simulation.",
+      "swf-disv2d": "is an optional array that characterizes the existence status of a cell.  If the IDOMAIN array is not specified, then all model cells exist within the solution.  If the IDOMAIN value for a cell is 0, the cell does not exist in the simulation.  Input and output values will be read and written for the cell, but internal to the program, the cell is excluded from the solution.  If the IDOMAIN value for a cell is 1 or greater, the cell exists in the simulation.  If the IDOMAIN value for a cell is -1, the cell does not exist in the simulation.  Furthermore, the first existing cell above will be connected to the first existing cell below.  This type of cell is referred to as a ``vertical pass through'' cell."
     }
   },
   "ievt": {
     "period": {
-      ".evta": "IEVT is the layer number that defines the layer in each vertical column where evapotranspiration is applied. If IEVT is omitted, evapotranspiration by default is applied to cells in layer 1.  If IEVT is specified, it must be specified as the first variable in the PERIOD block or MODFLOW will terminate with an error."
+      "gwf-evta": "IEVT is the layer number that defines the layer in each vertical column where evapotranspiration is applied. If IEVT is omitted, evapotranspiration by default is applied to cells in layer 1.  If IEVT is specified, it must be specified as the first variable in the PERIOD block or MODFLOW will terminate with an error."
     }
   },
   "ihc": {
     "connectiondata": {
-      ".disu": "is an index array indicating the direction between node n and all of its m connections.  If IHC = 0 then cell n and cell m are connected in the vertical direction.  Cell n overlies cell m if the cell number for n is less than m; cell m overlies cell n if the cell number for m is less than n.  If IHC = 1 then cell n and cell m are connected in the horizontal direction.  If IHC = 2 then cell n and cell m are connected in the horizontal direction, and the connection is vertically staggered.  A vertically staggered connection is one in which a cell is horizontally connected to more than one cell in a horizontal connection."
+      "gwe-disu": "is an index array indicating the direction between node n and all of its m connections.  If IHC = 0 then cell n and cell m are connected in the vertical direction.  Cell n overlies cell m if the cell number for n is less than m; cell m overlies cell n if the cell number for m is less than n.  If IHC = 1 then cell n and cell m are connected in the horizontal direction.  If IHC = 2 then cell n and cell m are connected in the horizontal direction, and the connection is vertically staggered.  A vertically staggered connection is one in which a cell is horizontally connected to more than one cell in a horizontal connection.",
+      "gwf-disu": "is an index array indicating the direction between node n and all of its m connections.  If IHC = 0 then cell n and cell m are connected in the vertical direction.  Cell n overlies cell m if the cell number for n is less than m; cell m overlies cell n if the cell number for m is less than n.  If IHC = 1 then cell n and cell m are connected in the horizontal direction.  If IHC = 2 then cell n and cell m are connected in the horizontal direction, and the connection is vertically staggered.  A vertically staggered connection is one in which a cell is horizontally connected to more than one cell in a horizontal connection.",
+      "gwt-disu": "is an index array indicating the direction between node n and all of its m connections.  If IHC = 0 then cell n and cell m are connected in the vertical direction.  Cell n overlies cell m if the cell number for n is less than m; cell m overlies cell n if the cell number for m is less than n.  If IHC = 1 then cell n and cell m are connected in the horizontal direction.  If IHC = 2 then cell n and cell m are connected in the horizontal direction, and the connection is vertically staggered.  A vertically staggered connection is one in which a cell is horizontally connected to more than one cell in a horizontal connection."
     }
   },
   "ihdwet": {
     "options": {
-      ".npf": "is a keyword and integer flag that determines which equation is used to define the initial head at cells that become wet.  If IHDWET is 0, h = BOT + WETFCT (hm - BOT). If IHDWET is not 0, h = BOT + WETFCT (THRESH)."
+      "gwf-npf": "is a keyword and integer flag that determines which equation is used to define the initial head at cells that become wet.  If IHDWET is 0, h = BOT + WETFCT (hm - BOT). If IHDWET is not 0, h = BOT + WETFCT (THRESH)."
     }
   },
   "infiltration": {
     "period": {
-      ".uze": "real or character value that defines the temperature of the infiltration $(e.g.,\\:^{\\circ}C\\:or\\:^{\\circ}F)$ for the UZF cell. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      ".uzt": "real or character value that defines the infiltration solute concentration $(ML^{-3})$ for the UZF cell. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+      "gwe-uze": "real or character value that defines the temperature of the infiltration $(e.g.,\\:^{\\circ}C\\:or\\:^{\\circ}F)$ for the UZF cell. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      "gwt-uzt": "real or character value that defines the infiltration solute concentration $(ML^{-3})$ for the UZF cell. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
     }
   },
   "inflow": {
     "period": {
-      ".lak": "real or character value that defines the volumetric inflow rate $(L^3 T^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, inflow rates are zero for each lake.",
-      ".sfe": "real or character value that defines the temperature of inflow $(e.g.,\\:^{\\circ}C\\:or\\:^{\\circ}F)$ for the reach. Users are free to use whatever temperature scale they want, which might include negative temperatures.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      ".sfr": "real or character value that defines the volumetric inflow rate for the streamflow routing reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, inflow rates are zero for each reach.",
-      ".sft": "real or character value that defines the concentration of inflow $(ML^{-3})$ for the reach. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+      "gwe-sfe": "real or character value that defines the temperature of inflow $(e.g.,\\:^{\\circ}C\\:or\\:^{\\circ}F)$ for the reach. Users are free to use whatever temperature scale they want, which might include negative temperatures.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      "gwf-lak": "real or character value that defines the volumetric inflow rate $(L^3 T^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, inflow rates are zero for each lake.",
+      "gwf-sfr": "real or character value that defines the volumetric inflow rate for the streamflow routing reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, inflow rates are zero for each reach.",
+      "gwt-sft": "real or character value that defines the concentration of inflow $(ML^{-3})$ for the reach. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
     }
   },
   "initial_preconsolidation_head": {
     "options": {
-      ".csub": "keyword to indicate that preconsolidation heads will be specified for no-delay and delay interbeds in the PACKAGEDATA block. If the SPECIFIED\\_INITIAL\\_INTERBED\\_STATE option is specified in the OPTIONS block, user-specified preconsolidation heads in the PACKAGEDATA block are absolute values. Otherwise, user-specified preconsolidation heads in the PACKAGEDATA block are relative to steady-state or initial heads."
+      "gwf-csub": "keyword to indicate that preconsolidation heads will be specified for no-delay and delay interbeds in the PACKAGEDATA block. If the SPECIFIED\\_INITIAL\\_INTERBED\\_STATE option is specified in the OPTIONS block, user-specified preconsolidation heads in the PACKAGEDATA block are absolute values. Otherwise, user-specified preconsolidation heads in the PACKAGEDATA block are relative to steady-state or initial heads."
     }
   },
   "inner_dvclose": {
     "linear": {
-      ".ims": "real value defining the dependent-variable (for example, head) change criterion for convergence of the inner (linear) iterations, in units of the dependent-variable (for example, length for head). When the maximum absolute value of the dependent-variable change at all nodes during an iteration is less than or equal to INNER\\_DVCLOSE, the matrix solver assumes convergence. Commonly, INNER\\_DVCLOSE is set equal to or an order of magnitude less than the OUTER\\_DVCLOSE value specified for the NONLINEAR block. The keyword, INNER\\_HCLOSE can be still be specified instead of INNER\\_DVCLOSE for backward compatibility with previous versions of MODFLOW 6 but eventually INNER\\_HCLOSE will be deprecated and specification of INNER\\_HCLOSE will cause MODFLOW 6 to terminate with an error."
+      "sln-ims": "real value defining the dependent-variable (for example, head) change criterion for convergence of the inner (linear) iterations, in units of the dependent-variable (for example, length for head). When the maximum absolute value of the dependent-variable change at all nodes during an iteration is less than or equal to INNER\\_DVCLOSE, the matrix solver assumes convergence. Commonly, INNER\\_DVCLOSE is set equal to or an order of magnitude less than the OUTER\\_DVCLOSE value specified for the NONLINEAR block. The keyword, INNER\\_HCLOSE can be still be specified instead of INNER\\_DVCLOSE for backward compatibility with previous versions of MODFLOW 6 but eventually INNER\\_HCLOSE will be deprecated and specification of INNER\\_HCLOSE will cause MODFLOW 6 to terminate with an error."
     }
   },
   "inner_hclose": {
     "linear": {
-      ".ims": "real value defining the head change criterion for convergence of the inner (linear) iterations, in units of length. When the maximum absolute value of the head change at all nodes during an iteration is less than or equal to INNER\\_HCLOSE, the matrix solver assumes convergence. Commonly, INNER\\_HCLOSE is set equal to or an order of magnitude less than the OUTER\\_HCLOSE value specified for the NONLINEAR block.  The INNER\\_HCLOSE keyword has been deprecated in favor of the more general INNER\\_DVCLOSE (for dependent variable), however either one can be specified in order to maintain backward compatibility."
+      "sln-ims": "real value defining the head change criterion for convergence of the inner (linear) iterations, in units of length. When the maximum absolute value of the head change at all nodes during an iteration is less than or equal to INNER\\_HCLOSE, the matrix solver assumes convergence. Commonly, INNER\\_HCLOSE is set equal to or an order of magnitude less than the OUTER\\_HCLOSE value specified for the NONLINEAR block.  The INNER\\_HCLOSE keyword has been deprecated in favor of the more general INNER\\_DVCLOSE (for dependent variable), however either one can be specified in order to maintain backward compatibility."
     }
   },
   "inner_maximum": {
     "linear": {
-      ".ims": "integer value defining the maximum number of inner (linear) iterations. The number typically depends on the characteristics of the matrix solution scheme being used. For nonlinear problems, INNER\\_MAXIMUM usually ranges from 60 to 600; a value of 100 will be sufficient for most linear problems."
+      "sln-ims": "integer value defining the maximum number of inner (linear) iterations. The number typically depends on the characteristics of the matrix solution scheme being used. For nonlinear problems, INNER\\_MAXIMUM usually ranges from 60 to 600; a value of 100 will be sufficient for most linear problems."
     }
   },
   "inner_rclose": {
     "linear": {
-      ".ims": "real value that defines the flow residual tolerance for convergence of the IMS linear solver and specific flow residual criteria used. This value represents the maximum allowable residual at any single node.  Value is in units of length cubed per time, and must be consistent with \\mf length and time units. Usually a value of $1.0 \\times 10^{-1}$ is sufficient for the flow-residual criteria when meters and seconds are the defined \\mf length and time."
+      "sln-ims": "real value that defines the flow residual tolerance for convergence of the IMS linear solver and specific flow residual criteria used. This value represents the maximum allowable residual at any single node.  Value is in units of length cubed per time, and must be consistent with \\mf length and time units. Usually a value of $1.0 \\times 10^{-1}$ is sufficient for the flow-residual criteria when meters and seconds are the defined \\mf length and time."
     }
   },
   "invert": {
     "period": {
-      ".lak": "real or character value that defines the invert elevation for the lake outlet. A specified INVERT value is only used for active lakes if COUTTYPE for lake outlet OUTLETNO is not SPECIFIED. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+      "gwf-lak": "real or character value that defines the invert elevation for the lake outlet. A specified INVERT value is only used for active lakes if COUTTYPE for lake outlet OUTLETNO is not SPECIFIED. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
     }
   },
   "irch": {
     "period": {
-      ".rcha": "IRCH is the layer number that defines the layer in each vertical column where recharge is applied. If IRCH is omitted, recharge by default is applied to cells in layer 1.  IRCH can only be used if READASARRAYS is specified in the OPTIONS block.  If IRCH is specified, it must be specified as the first variable in the PERIOD block or MODFLOW will terminate with an error."
+      "gwf-rcha": "IRCH is the layer number that defines the layer in each vertical column where recharge is applied. If IRCH is omitted, recharge by default is applied to cells in layer 1.  IRCH can only be used if READASARRAYS is specified in the OPTIONS block.  If IRCH is specified, it must be specified as the first variable in the PERIOD block or MODFLOW will terminate with an error."
     }
   },
   "istopzone": {
     "options": {
-      ".prp": "integer value defining the stop zone number.  If cells have been assigned IZONE values in the GRIDDATA block, a particle terminates if it enters a cell whose IZONE value matches ISTOPZONE.  An ISTOPZONE value of zero indicates that there is no stop zone.  The default value is zero."
+      "prt-prp": "integer value defining the stop zone number.  If cells have been assigned IZONE values in the GRIDDATA block, a particle terminates if it enters a cell whose IZONE value matches ISTOPZONE.  An ISTOPZONE value of zero indicates that there is no stop zone.  The default value is zero."
     }
   },
   "iwetit": {
     "options": {
-      ".npf": "is a keyword and iteration interval for attempting to wet cells. Wetting is attempted every IWETIT iteration. This applies to outer iterations and not inner iterations. If IWETIT is specified as zero or less, then the value is changed to 1."
+      "gwf-npf": "is a keyword and iteration interval for attempting to wet cells. Wetting is attempted every IWETIT iteration. This applies to outer iterations and not inner iterations. If IWETIT is specified as zero or less, then the value is changed to 1."
     }
   },
   "izone": {
     "griddata": {
-      ".mip": "is an integer zone number assigned to each cell.  IZONE may be positive, negative, or zero.  The current cell's zone number is recorded with each particle track datum.  If a PRP package's ISTOPZONE option is set to any value other than zero, particles released by that PRP Package terminate if they enter a cell whose IZONE value matches ISTOPZONE.  If ISTOPZONE is not specified or is set to zero in a PRP Package, IZONE has no effect on the termination of particles released by that PRP Package.  Each PRP Package may configure a single ISTOPZONE value."
+      "prt-mip": "is an integer zone number assigned to each cell.  IZONE may be positive, negative, or zero.  The current cell's zone number is recorded with each particle track datum.  If a PRP package's ISTOPZONE option is set to any value other than zero, particles released by that PRP Package terminate if they enter a cell whose IZONE value matches ISTOPZONE.  If ISTOPZONE is not specified or is set to zero in a PRP Package, IZONE has no effect on the termination of particles released by that PRP Package.  Each PRP Package may configure a single ISTOPZONE value."
     }
   },
   "ja": {
     "connectiondata": {
-      ".disu": "is a list of cell number (n) followed by its connecting cell numbers (m) for each of the m cells connected to cell n. The number of values to provide for cell n is IAC(n).  This list is sequentially provided for the first to the last cell. The first value in the list must be cell n itself, and the remaining cells must be listed in an increasing order (sorted from lowest number to highest).  Note that the cell and its connections are only supplied for the GWE cells and their connections to the other GWE cells.  Also note that the JA list input may be divided such that every node and its connectivity list can be on a separate line for ease in readability of the file. To further ease readability of the file, the node number of the cell whose connectivity is subsequently listed, may be expressed as a negative number, the sign of which is subsequently converted to positive by the code."
+      "gwe-disu": "is a list of cell number (n) followed by its connecting cell numbers (m) for each of the m cells connected to cell n. The number of values to provide for cell n is IAC(n).  This list is sequentially provided for the first to the last cell. The first value in the list must be cell n itself, and the remaining cells must be listed in an increasing order (sorted from lowest number to highest).  Note that the cell and its connections are only supplied for the GWE cells and their connections to the other GWE cells.  Also note that the JA list input may be divided such that every node and its connectivity list can be on a separate line for ease in readability of the file. To further ease readability of the file, the node number of the cell whose connectivity is subsequently listed, may be expressed as a negative number, the sign of which is subsequently converted to positive by the code.",
+      "gwf-disu": "is a list of cell number (n) followed by its connecting cell numbers (m) for each of the m cells connected to cell n. The number of values to provide for cell n is IAC(n).  This list is sequentially provided for the first to the last cell. The first value in the list must be cell n itself, and the remaining cells must be listed in an increasing order (sorted from lowest number to highest).  Note that the cell and its connections are only supplied for the GWF cells and their connections to the other GWF cells.  Also note that the JA list input may be divided such that every node and its connectivity list can be on a separate line for ease in readability of the file. To further ease readability of the file, the node number of the cell whose connectivity is subsequently listed, may be expressed as a negative number, the sign of which is subsequently converted to positive by the code.",
+      "gwt-disu": "is a list of cell number (n) followed by its connecting cell numbers (m) for each of the m cells connected to cell n. The number of values to provide for cell n is IAC(n).  This list is sequentially provided for the first to the last cell. The first value in the list must be cell n itself, and the remaining cells must be listed in an increasing order (sorted from lowest number to highest).  Note that the cell and its connections are only supplied for the GWT cells and their connections to the other GWT cells.  Also note that the JA list input may be divided such that every node and its connectivity list can be on a separate line for ease in readability of the file. To further ease readability of the file, the node number of the cell whose connectivity is subsequently listed, may be expressed as a negative number, the sign of which is subsequently converted to positive by the code."
     }
   },
   "k": {
     "griddata": {
-      ".npf": "is the hydraulic conductivity.  For the common case in which the user would like to specify the horizontal hydraulic conductivity and the vertical hydraulic conductivity, then K should be assigned as the horizontal hydraulic conductivity, K33 should be assigned as the vertical hydraulic conductivity, and K22 and the three rotation angles should not be specified.  When more sophisticated anisotropy is required, then K corresponds to the K11 hydraulic conductivity axis.  All included cells (IDOMAIN $>$ 0) must have a K value greater than zero."
+      "gwf-npf": "is the hydraulic conductivity.  For the common case in which the user would like to specify the horizontal hydraulic conductivity and the vertical hydraulic conductivity, then K should be assigned as the horizontal hydraulic conductivity, K33 should be assigned as the vertical hydraulic conductivity, and K22 and the three rotation angles should not be specified.  When more sophisticated anisotropy is required, then K corresponds to the K11 hydraulic conductivity axis.  All included cells (IDOMAIN $>$ 0) must have a K value greater than zero."
     },
     "period": {
-      ".tvk": "is the new value to be assigned as the cell's hydraulic conductivity from the start of the specified stress period, as per K in the NPF package.  If the OPTIONS block includes a TS6 entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+      "utl-tvk": "is the new value to be assigned as the cell's hydraulic conductivity from the start of the specified stress period, as per K in the NPF package.  If the OPTIONS block includes a TS6 entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
     }
   },
   "k22": {
     "griddata": {
-      ".npf": "is the hydraulic conductivity of the second ellipsoid axis (or the ratio of K22/K if the K22OVERK option is specified); for an unrotated case this is the hydraulic conductivity in the y direction.  If K22 is not included in the GRIDDATA block, then K22 is set equal to K.  For a regular MODFLOW grid (DIS Package is used) in which no rotation angles are specified, K22 is the hydraulic conductivity along columns in the y direction. For an unstructured DISU grid, the user must assign principal x and y axes and provide the angle for each cell face relative to the assigned x direction.  All included cells (IDOMAIN $>$ 0) must have a K22 value greater than zero."
+      "gwf-npf": "is the hydraulic conductivity of the second ellipsoid axis (or the ratio of K22/K if the K22OVERK option is specified); for an unrotated case this is the hydraulic conductivity in the y direction.  If K22 is not included in the GRIDDATA block, then K22 is set equal to K.  For a regular MODFLOW grid (DIS Package is used) in which no rotation angles are specified, K22 is the hydraulic conductivity along columns in the y direction. For an unstructured DISU grid, the user must assign principal x and y axes and provide the angle for each cell face relative to the assigned x direction.  All included cells (IDOMAIN $>$ 0) must have a K22 value greater than zero."
     },
     "period": {
-      ".tvk": "is the new value to be assigned as the cell's hydraulic conductivity of the second ellipsoid axis (or the ratio of K22/K if the K22OVERK NPF package option is specified) from the start of the specified stress period, as per K22 in the NPF package.  For an unrotated case this is the hydraulic conductivity in the y direction.  If the OPTIONS block includes a TS6 entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+      "utl-tvk": "is the new value to be assigned as the cell's hydraulic conductivity of the second ellipsoid axis (or the ratio of K22/K if the K22OVERK NPF package option is specified) from the start of the specified stress period, as per K22 in the NPF package.  For an unrotated case this is the hydraulic conductivity in the y direction.  If the OPTIONS block includes a TS6 entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
     }
   },
   "k22overk": {
     "options": {
-      ".npf": "keyword to indicate that specified K22 is a ratio of K22 divided by K.  If this option is specified, then the K22 array entered in the NPF Package will be multiplied by K after being read."
+      "gwf-npf": "keyword to indicate that specified K22 is a ratio of K22 divided by K.  If this option is specified, then the K22 array entered in the NPF Package will be multiplied by K after being read."
     }
   },
   "k33": {
     "griddata": {
-      ".npf": "is the hydraulic conductivity of the third ellipsoid axis (or the ratio of K33/K if the K33OVERK option is specified); for an unrotated case, this is the vertical hydraulic conductivity.  When anisotropy is applied, K33 corresponds to the K33 tensor component.  All included cells (IDOMAIN $>$ 0) must have a K33 value greater than zero."
+      "gwf-npf": "is the hydraulic conductivity of the third ellipsoid axis (or the ratio of K33/K if the K33OVERK option is specified); for an unrotated case, this is the vertical hydraulic conductivity.  When anisotropy is applied, K33 corresponds to the K33 tensor component.  All included cells (IDOMAIN $>$ 0) must have a K33 value greater than zero."
     },
     "period": {
-      ".tvk": "is the new value to be assigned as the cell's hydraulic conductivity of the third ellipsoid axis (or the ratio of K33/K if the K33OVERK NPF package option is specified) from the start of the specified stress period, as per K33 in the NPF package.  For an unrotated case, this is the vertical hydraulic conductivity.  If the OPTIONS block includes a TS6 entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+      "utl-tvk": "is the new value to be assigned as the cell's hydraulic conductivity of the third ellipsoid axis (or the ratio of K33/K if the K33OVERK NPF package option is specified) from the start of the specified stress period, as per K33 in the NPF package.  For an unrotated case, this is the vertical hydraulic conductivity.  If the OPTIONS block includes a TS6 entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
     }
   },
   "k33overk": {
     "options": {
-      ".npf": "keyword to indicate that specified K33 is a ratio of K33 divided by K.  If this option is specified, then the K33 array entered in the NPF Package will be multiplied by K after being read."
+      "gwf-npf": "keyword to indicate that specified K33 is a ratio of K33 divided by K.  If this option is specified, then the K33 array entered in the NPF Package will be multiplied by K after being read."
     }
   },
   "kts": {
     "griddata": {
-      ".cnd": "thermal conductivity of the solid aquifer material"
+      "gwe-cnd": "thermal conductivity of the solid aquifer material"
     }
   },
   "ktw": {
     "griddata": {
-      ".cnd": "thermal conductivity of the simulated fluid.   Note that the CND Package does not account for the tortuosity of the flow paths when solving for the conductive spread of heat.  If tortuosity plays an important role in the thermal conductivity calculation, its effect should be reflected in the value specified for KTW."
+      "gwe-cnd": "thermal conductivity of the simulated fluid.   Note that the CND Package does not account for the tortuosity of the flow paths when solving for the conductive spread of heat.  If tortuosity plays an important role in the thermal conductivity calculation, its effect should be reflected in the value specified for KTW."
     }
   },
   "last": {
     "period": {
-      ".oc": "keyword to indicate save for last step in period. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
-      ".prp": "keyword to indicate release at the start of the last time step in the period. This keyword may be used in conjunction with other RELEASESETTING options."
+      "chf-oc": "keyword to indicate save for last step in period. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
+      "gwe-oc": "keyword to indicate save for last step in period. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
+      "gwf-oc": "keyword to indicate save for last step in period. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
+      "gwt-oc": "keyword to indicate save for last step in period. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
+      "olf-oc": "keyword to indicate save for last step in period. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
+      "prt-oc": "keyword to indicate save for last step in period. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
+      "prt-prp": "keyword to indicate release at the start of the last time step in the period. This keyword may be used in conjunction with other RELEASESETTING options.",
+      "swf-oc": "keyword to indicate save for last step in period. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps."
     }
   },
   "latent_heat_vaporization": {
     "options": {
-      ".est": "latent heat of vaporization is the amount of energy that is required to convert a given quantity of liquid into a gas and is associated with evaporative cooling.  While the EST package does not simulate evaporation, multiple other packages in a GWE simulation may.  To avoid having to specify the latent heat of vaporization in multiple packages, it is specified in a single location and accessed wherever it is needed.  For example, evaporation may occur from the surface of streams or lakes and the energy consumed by the change in phase would be needed in both the SFE and LKE packages.  This value is set to 2,453,500 J/kg if no overriding value is specified.  A user-specified value should be provided for models that use units other than joules and kilograms or if it is necessary to use a value other than the default."
+      "gwe-est": "latent heat of vaporization is the amount of energy that is required to convert a given quantity of liquid into a gas and is associated with evaporative cooling.  While the EST package does not simulate evaporation, multiple other packages in a GWE simulation may.  To avoid having to specify the latent heat of vaporization in multiple packages, it is specified in a single location and accessed wherever it is needed.  For example, evaporation may occur from the surface of streams or lakes and the energy consumed by the change in phase would be needed in both the SFE and LKE packages.  This value is set to 2,453,500 J/kg if no overriding value is specified.  A user-specified value should be provided for models that use units other than joules and kilograms or if it is necessary to use a value other than the default."
     }
   },
   "latitude": {
     "griddata": {
-      ".ncf": "cell center latitude."
+      "utl-ncf": "cell center latitude."
     }
   },
   "length": {
     "griddata": {
-      ".disv1d": "length for each one-dimensional cell"
+      "olf-disv1d": "length for each one-dimensional cell"
     }
   },
   "length_conversion": {
     "options": {
-      ".dfw": "real value that is used to convert user-specified Manning's roughness coefficients from meters to model length units. LENGTH\\_CONVERSION should be set to 3.28081, 1.0, and 100.0 when using length units (LENGTH\\_UNITS) of feet, meters, or centimeters in the simulation, respectively. LENGTH\\_CONVERSION does not need to be specified if LENGTH\\_UNITS are meters.",
-      ".lak": "real value that is used to convert outlet user-specified Manning's roughness coefficients or gravitational acceleration used to calculate outlet flows from meters to model length units. LENGTH\\_CONVERSION should be set to 3.28081, 1.0, and 100.0 when using length units (LENGTH\\_UNITS) of feet, meters, or centimeters in the simulation, respectively. LENGTH\\_CONVERSION does not need to be specified if no lake outlets are specified or LENGTH\\_UNITS are meters.",
-      ".sfr": "real value that is used to convert user-specified Manning's roughness coefficients from meters to model length units. LENGTH\\_CONVERSION should be set to 3.28081, 1.0, and 100.0 when using length units (LENGTH\\_UNITS) of feet, meters, or centimeters in the simulation, respectively. LENGTH\\_CONVERSION does not need to be specified if LENGTH\\_UNITS are meters."
+      "chf-dfw": "real value that is used to convert user-specified Manning's roughness coefficients from meters to model length units. LENGTH\\_CONVERSION should be set to 3.28081, 1.0, and 100.0 when using length units (LENGTH\\_UNITS) of feet, meters, or centimeters in the simulation, respectively. LENGTH\\_CONVERSION does not need to be specified if LENGTH\\_UNITS are meters.",
+      "gwf-lak": "real value that is used to convert outlet user-specified Manning's roughness coefficients or gravitational acceleration used to calculate outlet flows from meters to model length units. LENGTH\\_CONVERSION should be set to 3.28081, 1.0, and 100.0 when using length units (LENGTH\\_UNITS) of feet, meters, or centimeters in the simulation, respectively. LENGTH\\_CONVERSION does not need to be specified if no lake outlets are specified or LENGTH\\_UNITS are meters.",
+      "gwf-sfr": "real value that is used to convert user-specified Manning's roughness coefficients from meters to model length units. LENGTH\\_CONVERSION should be set to 3.28081, 1.0, and 100.0 when using length units (LENGTH\\_UNITS) of feet, meters, or centimeters in the simulation, respectively. LENGTH\\_CONVERSION does not need to be specified if LENGTH\\_UNITS are meters.",
+      "olf-dfw": "real value that is used to convert user-specified Manning's roughness coefficients from meters to model length units. LENGTH\\_CONVERSION should be set to 3.28081, 1.0, and 100.0 when using length units (LENGTH\\_UNITS) of feet, meters, or centimeters in the simulation, respectively. LENGTH\\_CONVERSION does not need to be specified if LENGTH\\_UNITS are meters.",
+      "swf-dfw": "real value that is used to convert user-specified Manning's roughness coefficients from meters to model length units. LENGTH\\_CONVERSION should be set to 3.28081, 1.0, and 100.0 when using length units (LENGTH\\_UNITS) of feet, meters, or centimeters in the simulation, respectively. LENGTH\\_CONVERSION does not need to be specified if LENGTH\\_UNITS are meters."
     }
   },
   "length_units": {
     "options": {
-      ".dis": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.",
-      ".dis2d": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.",
-      ".disu": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.",
-      ".disv": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.",
-      ".disv1d": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.",
-      ".disv2d": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''."
+      "chf-disv1d": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.",
+      "gwe-dis": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.",
+      "gwe-disu": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.",
+      "gwe-disv": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.",
+      "gwf-dis": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.",
+      "gwf-disu": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.",
+      "gwf-disv": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.",
+      "gwt-dis": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.",
+      "gwt-disu": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.",
+      "gwt-disv": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.",
+      "olf-dis2d": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.",
+      "olf-disv1d": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.",
+      "olf-disv2d": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.",
+      "prt-dis": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.",
+      "prt-disv": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.",
+      "swf-dis2d": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.",
+      "swf-disv1d": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''.",
+      "swf-disv2d": "is the length units used for this model.  Values can be ``FEET'', ``METERS'', or ``CENTIMETERS''.  If not specified, the default is ``UNKNOWN''."
     }
   },
   "linear_acceleration": {
     "linear": {
-      ".ims": "a keyword that defines the linear acceleration method used by the default IMS linear solvers.  CG - preconditioned conjugate gradient method.  BICGSTAB - preconditioned bi-conjugate gradient stabilized method."
+      "sln-ims": "a keyword that defines the linear acceleration method used by the default IMS linear solvers.  CG - preconditioned conjugate gradient method.  BICGSTAB - preconditioned bi-conjugate gradient stabilized method."
     }
   },
   "linear_gwet": {
     "options": {
-      ".uzf": "keyword specifying that groundwater ET will be simulated using the original ET formulation of MODFLOW-2005."
+      "gwf-uzf": "keyword specifying that groundwater ET will be simulated using the original ET formulation of MODFLOW-2005."
     }
   },
   "list": {
     "options": {
-      ".nam": "is name of the listing file to create for this GWE model.  If not specified, then the name of the list file will be the basename of the GWE model name file and the ``.lst'' extension.  For example, if the GWE name file is called ``my.model.nam'' then the list file will be called ``my.model.lst''."
+      "chf-nam": "is name of the listing file to create for this CHF model.  If not specified, then the name of the list file will be the basename of the CHF model name file and the '.lst' extension.  For example, if the CHF name file is called ``my.model.nam'' then the list file will be called ``my.model.lst''.",
+      "gwe-nam": "is name of the listing file to create for this GWE model.  If not specified, then the name of the list file will be the basename of the GWE model name file and the ``.lst'' extension.  For example, if the GWE name file is called ``my.model.nam'' then the list file will be called ``my.model.lst''.",
+      "gwf-nam": "is name of the listing file to create for this GWF model.  If not specified, then the name of the list file will be the basename of the GWF model name file and the '.lst' extension.  For example, if the GWF name file is called ``my.model.nam'' then the list file will be called ``my.model.lst''.",
+      "gwt-nam": "is name of the listing file to create for this GWT model.  If not specified, then the name of the list file will be the basename of the GWT model name file and the '.lst' extension.  For example, if the GWT name file is called ``my.model.nam'' then the list file will be called ``my.model.lst''.",
+      "olf-nam": "is name of the listing file to create for this OLF model.  If not specified, then the name of the list file will be the basename of the OLF model name file and the '.lst' extension.  For example, if the OLF name file is called ``my.model.nam'' then the list file will be called ``my.model.lst''.",
+      "prt-nam": "is name of the listing file to create for this PRT model.  If not specified, then the name of the list file will be the basename of the PRT model name file and the '.lst' extension.  For example, if the PRT name file is called ``my.model.nam'' then the list file will be called ``my.model.lst''.",
+      "swf-nam": "is name of the listing file to create for this SWF model.  If not specified, then the name of the list file will be the basename of the SWF model name file and the '.lst' extension.  For example, if the SWF name file is called ``my.model.nam'' then the list file will be called ``my.model.lst''."
     }
   },
   "local_z": {
     "options": {
-      ".prp": "indicates that ``zrpt'' defines the local z coordinate of the release point within the cell, with value of 0 at the bottom and 1 at the top of the cell.  If the cell is partially saturated at release time, the top of the cell is considered to be the water table elevation (the head in the cell) rather than the top defined by the user."
+      "prt-prp": "indicates that ``zrpt'' defines the local z coordinate of the release point within the cell, with value of 0 at the bottom and 1 at the top of the cell.  If the cell is partially saturated at release time, the top of the cell is considered to be the water table elevation (the head in the cell) rather than the top defined by the user."
     }
   },
   "longitude": {
     "griddata": {
-      ".ncf": "cell center longitude."
+      "utl-ncf": "cell center longitude."
     }
   },
   "manning": {
     "period": {
-      ".sfr": "real or character value that defines the Manning's roughness coefficient for the reach. MANNING must be greater than zero.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+      "gwf-sfr": "real or character value that defines the Manning's roughness coefficient for the reach. MANNING must be greater than zero.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
     }
   },
   "manningsn": {
     "griddata": {
-      ".dfw": "mannings roughness coefficient"
+      "chf-dfw": "mannings roughness coefficient",
+      "olf-dfw": "mannings roughness coefficient",
+      "swf-dfw": "mannings roughness coefficient"
     }
   },
   "maw_flow_reduce_csv": {
     "options": {
-      ".maw": "keyword to specify that record corresponds to the output option in which a new record is written for each multi-aquifer well and for each time step in which the user-requested extraction or injection rate is reduced by the program."
+      "gwf-maw": "keyword to specify that record corresponds to the output option in which a new record is written for each multi-aquifer well and for each time step in which the user-requested extraction or injection rate is reduced by the program."
     }
   },
   "maxats": {
     "dimensions": {
-      ".ats": "is the number of records in the subsequent perioddata block that will be used for adaptive time stepping."
+      "utl-ats": "is the number of records in the subsequent perioddata block that will be used for adaptive time stepping."
     }
   },
   "maxbound": {
     "dimensions": {
-      ".api": "integer value specifying the maximum number of api boundary cells that will be specified for use during any stress period.",
-      ".cdb": "integer value specifying the maximum number of critical depth boundary cells that will be specified for use during any stress period.",
-      ".chd": "integer value specifying the maximum number of constant-head cells that will be specified for use during any stress period.",
-      ".cnc": "integer value specifying the maximum number of constant concentrations cells that will be specified for use during any stress period.",
-      ".ctp": "integer value specifying the maximum number of constant temperature cells that will be specified for use during any stress period.",
-      ".drn": "integer value specifying the maximum number of drains cells that will be specified for use during any stress period.",
-      ".esl": "integer value specifying the maximum number of source cells that will be specified for use during any stress period.",
-      ".evp": "integer value specifying the maximum number of evaporation cells cells that will be specified for use during any stress period.",
-      ".evt": "integer value specifying the maximum number of evapotranspiration cells cells that will be specified for use during any stress period.",
-      ".flw": "integer value specifying the maximum number of inflow cells that will be specified for use during any stress period.",
-      ".ghb": "integer value specifying the maximum number of general-head boundary cells that will be specified for use during any stress period.",
-      ".pcp": "integer value specifying the maximum number of precipitation cells cells that will be specified for use during any stress period.",
-      ".rch": "integer value specifying the maximum number of recharge cells cells that will be specified for use during any stress period.",
-      ".riv": "integer value specifying the maximum number of rivers cells that will be specified for use during any stress period.",
-      ".spc": "integer value specifying the maximum number of spc cells that will be specified for use during any stress period.",
-      ".src": "integer value specifying the maximum number of sources cells that will be specified for use during any stress period.",
-      ".wel": "integer value specifying the maximum number of wells cells that will be specified for use during any stress period.",
-      ".zdg": "integer value specifying the maximum number of zero-depth-gradient boundary cells that will be specified for use during any stress period."
+      "chf-cdb": "integer value specifying the maximum number of critical depth boundary cells that will be specified for use during any stress period.",
+      "chf-chd": "integer value specifying the maximum number of constant-head cells that will be specified for use during any stress period.",
+      "chf-evp": "integer value specifying the maximum number of evaporation cells cells that will be specified for use during any stress period.",
+      "chf-flw": "integer value specifying the maximum number of inflow cells that will be specified for use during any stress period.",
+      "chf-pcp": "integer value specifying the maximum number of precipitation cells cells that will be specified for use during any stress period.",
+      "chf-zdg": "integer value specifying the maximum number of zero-depth-gradient boundary cells that will be specified for use during any stress period.",
+      "gwe-ctp": "integer value specifying the maximum number of constant temperature cells that will be specified for use during any stress period.",
+      "gwe-esl": "integer value specifying the maximum number of source cells that will be specified for use during any stress period.",
+      "gwf-api": "integer value specifying the maximum number of api boundary cells that will be specified for use during any stress period.",
+      "gwf-chd": "integer value specifying the maximum number of constant-head cells that will be specified for use during any stress period.",
+      "gwf-drn": "integer value specifying the maximum number of drains cells that will be specified for use during any stress period.",
+      "gwf-evt": "integer value specifying the maximum number of evapotranspiration cells cells that will be specified for use during any stress period.",
+      "gwf-ghb": "integer value specifying the maximum number of general-head boundary cells that will be specified for use during any stress period.",
+      "gwf-rch": "integer value specifying the maximum number of recharge cells cells that will be specified for use during any stress period.",
+      "gwf-riv": "integer value specifying the maximum number of rivers cells that will be specified for use during any stress period.",
+      "gwf-wel": "integer value specifying the maximum number of wells cells that will be specified for use during any stress period.",
+      "gwt-api": "integer value specifying the maximum number of api boundary cells that will be specified for use during any stress period.",
+      "gwt-cnc": "integer value specifying the maximum number of constant concentrations cells that will be specified for use during any stress period.",
+      "gwt-src": "integer value specifying the maximum number of sources cells that will be specified for use during any stress period.",
+      "olf-cdb": "integer value specifying the maximum number of critical depth boundary cells that will be specified for use during any stress period.",
+      "olf-chd": "integer value specifying the maximum number of constant-head cells that will be specified for use during any stress period.",
+      "olf-evp": "integer value specifying the maximum number of evaporation cells cells that will be specified for use during any stress period.",
+      "olf-flw": "integer value specifying the maximum number of inflow cells that will be specified for use during any stress period.",
+      "olf-pcp": "integer value specifying the maximum number of precipitation cells cells that will be specified for use during any stress period.",
+      "olf-zdg": "integer value specifying the maximum number of zero-depth-gradient boundary cells that will be specified for use during any stress period.",
+      "swf-cdb": "integer value specifying the maximum number of critical depth boundary cells that will be specified for use during any stress period.",
+      "swf-chd": "integer value specifying the maximum number of constant-head cells that will be specified for use during any stress period.",
+      "swf-evp": "integer value specifying the maximum number of evaporation cells cells that will be specified for use during any stress period.",
+      "swf-flw": "integer value specifying the maximum number of inflow cells that will be specified for use during any stress period.",
+      "swf-pcp": "integer value specifying the maximum number of precipitation cells cells that will be specified for use during any stress period.",
+      "swf-zdg": "integer value specifying the maximum number of zero-depth-gradient boundary cells that will be specified for use during any stress period.",
+      "utl-spc": "integer value specifying the maximum number of spc cells that will be specified for use during any stress period."
     }
   },
   "maxerrors": {
     "options": {
-      ".nam": "maximum number of errors that will be stored and printed."
+      "sim-nam": "maximum number of errors that will be stored and printed."
     }
   },
   "maxhfb": {
     "dimensions": {
-      ".hfb": "integer value specifying the maximum number of horizontal flow barriers that will be entered in this input file.  The value of MAXHFB is used to allocate memory for the horizontal flow barriers."
+      "gwf-hfb": "integer value specifying the maximum number of horizontal flow barriers that will be entered in this input file.  The value of MAXHFB is used to allocate memory for the horizontal flow barriers."
     }
   },
   "maximum_depth_change": {
     "options": {
-      ".sfr": "real value that defines the depth closure tolerance. By default, MAXIMUM\\_DEPTH\\_CHANGE is equal to $1 \\times 10^{-5}$. The MAXIMUM\\_STAGE\\_CHANGE would only need to be increased or decreased from the default value if the water budget error for one or more reach is too small or too large, respectively."
+      "gwf-sfr": "real value that defines the depth closure tolerance. By default, MAXIMUM\\_DEPTH\\_CHANGE is equal to $1 \\times 10^{-5}$. The MAXIMUM\\_STAGE\\_CHANGE would only need to be increased or decreased from the default value if the water budget error for one or more reach is too small or too large, respectively."
     }
   },
   "maximum_iterations": {
     "options": {
-      ".lak": "integer value that defines the maximum number of Newton-Raphson iterations allowed for a lake. By default, MAXIMUM\\_ITERATIONS is equal to 100. MAXIMUM\\_ITERATIONS would only need to be increased from the default value if one or more lakes in a simulation has a large water budget error.",
-      ".sfr": "integer value that defines the maximum number of Streamflow Routing Newton-Raphson iterations allowed for a reach. By default, MAXIMUM\\_ITERATIONS is equal to 100. MAXIMUM\\_ITERATIONS would only need to be increased from the default value if one or more reach in a simulation has a large water budget error."
+      "gwf-lak": "integer value that defines the maximum number of Newton-Raphson iterations allowed for a lake. By default, MAXIMUM\\_ITERATIONS is equal to 100. MAXIMUM\\_ITERATIONS would only need to be increased from the default value if one or more lakes in a simulation has a large water budget error.",
+      "gwf-sfr": "integer value that defines the maximum number of Streamflow Routing Newton-Raphson iterations allowed for a reach. By default, MAXIMUM\\_ITERATIONS is equal to 100. MAXIMUM\\_ITERATIONS would only need to be increased from the default value if one or more reach in a simulation has a large water budget error."
     }
   },
   "maximum_picard_iterations": {
     "options": {
-      ".sfr": "integer value that defines the maximum number of Streamflow Routing picard iterations allowed when solving for reach stages and flows as part of the GWF formulate step. Picard iterations are used to minimize differences in SFR package results between subsequent GWF picard (non-linear) iterations as a result of non-optimal reach numbering. If reaches are numbered in order, from upstream to downstream, MAXIMUM\\_PICARD\\_ITERATIONS can be set to 1 to reduce model run time. By default, MAXIMUM\\_PICARD\\_ITERATIONS is equal to 100."
+      "gwf-sfr": "integer value that defines the maximum number of Streamflow Routing picard iterations allowed when solving for reach stages and flows as part of the GWF formulate step. Picard iterations are used to minimize differences in SFR package results between subsequent GWF picard (non-linear) iterations as a result of non-optimal reach numbering. If reaches are numbered in order, from upstream to downstream, MAXIMUM\\_PICARD\\_ITERATIONS can be set to 1 to reduce model run time. By default, MAXIMUM\\_PICARD\\_ITERATIONS is equal to 100."
     }
   },
   "maximum_stage_change": {
     "options": {
-      ".lak": "real value that defines the lake stage closure tolerance. By default, MAXIMUM\\_STAGE\\_CHANGE is equal to $1 \\times 10^{-5}$. The MAXIMUM\\_STAGE\\_CHANGE would only need to be increased or decreased from the default value if the water budget error for one or more lakes is too small or too large, respectively."
+      "gwf-lak": "real value that defines the lake stage closure tolerance. By default, MAXIMUM\\_STAGE\\_CHANGE is equal to $1 \\times 10^{-5}$. The MAXIMUM\\_STAGE\\_CHANGE would only need to be increased or decreased from the default value if the water budget error for one or more lakes is too small or too large, respectively."
     }
   },
   "maxmvr": {
     "dimensions": {
-      ".mvr": "integer value specifying the maximum number of water mover entries that will specified for any stress period."
+      "gwf-mvr": "integer value specifying the maximum number of water mover entries that will specified for any stress period."
     }
   },
   "maxpackages": {
     "dimensions": {
-      ".mvr": "integer value specifying the number of unique packages that are included in this water mover input file."
+      "gwf-mvr": "integer value specifying the number of unique packages that are included in this water mover input file."
     }
   },
   "maxsig0": {
     "dimensions": {
-      ".csub": "is the maximum number of cells that can have a specified stress offset.  More than 1 stress offset can be assigned to a GWF cell. By default, MAXSIG0 is 0."
+      "gwf-csub": "is the maximum number of cells that can have a specified stress offset.  More than 1 stress offset can be assigned to a GWF cell. By default, MAXSIG0 is 0."
     }
   },
   "memory_print_option": {
     "options": {
-      ".nam": "is a flag that controls printing of detailed memory manager usage to the end of the simulation list file.  NONE means do not print detailed information. SUMMARY means print only the total memory for each simulation component. ALL means print information for each variable stored in the memory manager. NONE is default if MEMORY\\_PRINT\\_OPTION is not specified."
+      "sim-nam": "is a flag that controls printing of detailed memory manager usage to the end of the simulation list file.  NONE means do not print detailed information. SUMMARY means print only the total memory for each simulation component. ALL means print information for each variable stored in the memory manager. NONE is default if MEMORY\\_PRINT\\_OPTION is not specified."
     }
   },
   "method": {
     "attributes": {
-      ".tas": "xxx",
-      ".ts": "xxx"
+      "utl-tas": "xxx",
+      "utl-ts": "xxx"
     }
   },
   "methods": {
     "attributes": {
-      ".ts": "xxx"
+      "utl-ts": "xxx"
     }
   },
   "mixed": {
     "fileinput": {
-      ".ssm": "keyword to specify that these stress package boundaries will have the mixed condition.  The MIXED condition is described in the SOURCES block for AUXMIXED.  The MIXED condition allows for water to be withdrawn at a concentration that is less than the cell concentration.  It is intended primarily for representing evapotranspiration."
+      "gwe-ssm": "keyword to specify that these stress package boundaries will have the mixed condition.  The MIXED condition is described in the SOURCES block for AUXMIXED.  The MIXED condition allows for water to be withdrawn at a temperature that is less than the cell temperature.  It is intended primarily for representing evapotranspiration.",
+      "gwt-ssm": "keyword to specify that these stress package boundaries will have the mixed condition.  The MIXED condition is described in the SOURCES block for AUXMIXED.  The MIXED condition allows for water to be withdrawn at a concentration that is less than the cell concentration.  It is intended primarily for representing evapotranspiration."
     }
   },
   "modelnames": {
     "options": {
-      ".mvr": "keyword to indicate that all package names will be preceded by the model name for the package.  Model names are required when the Mover Package is used with a GWF-GWF Exchange.  The MODELNAME keyword should not be used for a Mover Package that is for a single GWF Model."
+      "gwf-mvr": "keyword to indicate that all package names will be preceded by the model name for the package.  Model names are required when the Mover Package is used with a GWF-GWF Exchange.  The MODELNAME keyword should not be used for a Mover Package that is for a single GWF Model."
     }
   },
   "models": {
     "models": {
-      ".nam": "is the list of model types, model name files, and model names."
+      "sim-nam": "is the list of model types, model name files, and model names."
     }
   },
   "modflow6_attr_off": {
     "options": {
-      ".ncf": "is the keyword used to turn off internal input tagging in the model netcdf file. Tagging adds internal modflow 6 attribute(s) to variables which facilitate identification. Currently this applies to gridded arrays."
+      "utl-ncf": "is the keyword used to turn off internal input tagging in the model netcdf file. Tagging adds internal modflow 6 attribute(s) to variables which facilitate identification. Currently this applies to gridded arrays."
     }
   },
   "mover": {
     "options": {
-      ".api": "keyword to indicate that this instance of the api boundary Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.",
-      ".drn": "keyword to indicate that this instance of the Drain Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.",
-      ".ghb": "keyword to indicate that this instance of the General-Head Boundary Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.",
-      ".lak": "keyword to indicate that this instance of the LAK Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.",
-      ".maw": "keyword to indicate that this instance of the MAW Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.",
-      ".riv": "keyword to indicate that this instance of the River Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.",
-      ".sfr": "keyword to indicate that this instance of the SFR Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.",
-      ".uzf": "keyword to indicate that this instance of the UZF Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.",
-      ".wel": "keyword to indicate that this instance of the Well Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water."
+      "gwf-api": "keyword to indicate that this instance of the api boundary Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.",
+      "gwf-drn": "keyword to indicate that this instance of the Drain Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.",
+      "gwf-ghb": "keyword to indicate that this instance of the General-Head Boundary Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.",
+      "gwf-lak": "keyword to indicate that this instance of the LAK Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.",
+      "gwf-maw": "keyword to indicate that this instance of the MAW Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.",
+      "gwf-riv": "keyword to indicate that this instance of the River Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.",
+      "gwf-sfr": "keyword to indicate that this instance of the SFR Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.",
+      "gwf-uzf": "keyword to indicate that this instance of the UZF Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.",
+      "gwf-wel": "keyword to indicate that this instance of the Well Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water.",
+      "gwt-api": "keyword to indicate that this instance of the api boundary Package can be used with the Water Mover (MVR) Package.  When the MOVER option is specified, additional memory is allocated within the package to store the available, provided, and received water."
     }
   },
   "mve6": {
     "options": {
-      ".gwegwe": "keyword to specify that record corresponds to an energy transport mover file."
+      "exg-gwegwe": "keyword to specify that record corresponds to an energy transport mover file."
     }
   },
   "mvr6": {
     "options": {
-      ".gwfgwf": "keyword to specify that record corresponds to a mover file."
+      "exg-gwfgwf": "keyword to specify that record corresponds to a mover file."
     }
   },
   "mvt6": {
     "options": {
-      ".gwtgwt": "keyword to specify that record corresponds to a transport mover file."
+      "exg-gwtgwt": "keyword to specify that record corresponds to a transport mover file."
     }
   },
   "mxiter": {
     "solutiongroup": {
-      ".nam": "is the maximum number of outer iterations for this solution group.  The default value is 1.  If there is only one solution in the solution group, then MXITER must be 1."
+      "sim-nam": "is the maximum number of outer iterations for this solution group.  The default value is 1.  If there is only one solution in the solution group, then MXITER must be 1."
     }
   },
   "name": {
     "attributes": {
-      ".tas": "xxx"
+      "utl-tas": "xxx"
     }
   },
   "names": {
     "attributes": {
-      ".ts": "xxx"
+      "utl-ts": "xxx"
     }
   },
   "ncf6": {
     "options": {
-      ".dis": "keyword to specify that record corresponds to a netcdf configuration (NCF) file.",
-      ".disv": "keyword to specify that record corresponds to a netcdf configuration (NCF) file."
+      "gwe-dis": "keyword to specify that record corresponds to a netcdf configuration (NCF) file.",
+      "gwe-disv": "keyword to specify that record corresponds to a netcdf configuration (NCF) file.",
+      "gwf-dis": "keyword to specify that record corresponds to a netcdf configuration (NCF) file.",
+      "gwf-disv": "keyword to specify that record corresponds to a netcdf configuration (NCF) file.",
+      "gwt-dis": "keyword to specify that record corresponds to a netcdf configuration (NCF) file.",
+      "gwt-disv": "keyword to specify that record corresponds to a netcdf configuration (NCF) file.",
+      "prt-dis": "keyword to specify that record corresponds to a netcdf configuration (NCF) file.",
+      "prt-disv": "keyword to specify that record corresponds to a netcdf configuration (NCF) file."
     }
   },
   "ncol": {
     "dimensions": {
-      ".dis": "is the number of columns in the model grid.",
-      ".dis2d": "is the number of columns in the model grid.",
-      ".laktab": "integer value specifying the number of columns in the lake table. There must be NCOL columns of data in the TABLE block. For lakes with HORIZONTAL and/or VERTICAL CTYPE connections, NCOL must be equal to 3. For lakes with EMBEDDEDH or EMBEDDEDV CTYPE connections, NCOL must be equal to 4.",
-      ".sfrtab": "integer value specifying the number of columns in the reach cross-section table. There must be NCOL columns of data in the TABLE block. NCOL must be equal to 2 if MANFRACTION is not specified or 3 otherwise."
+      "gwe-dis": "is the number of columns in the model grid.",
+      "gwf-dis": "is the number of columns in the model grid.",
+      "gwt-dis": "is the number of columns in the model grid.",
+      "olf-dis2d": "is the number of columns in the model grid.",
+      "prt-dis": "is the number of columns in the model grid.",
+      "swf-dis2d": "is the number of columns in the model grid.",
+      "utl-laktab": "integer value specifying the number of columns in the lake table. There must be NCOL columns of data in the TABLE block. For lakes with HORIZONTAL and/or VERTICAL CTYPE connections, NCOL must be equal to 3. For lakes with EMBEDDEDH or EMBEDDEDV CTYPE connections, NCOL must be equal to 4.",
+      "utl-sfrtab": "integer value specifying the number of columns in the reach cross-section table. There must be NCOL columns of data in the TABLE block. NCOL must be equal to 2 if MANFRACTION is not specified or 3 otherwise."
     }
   },
   "ncpl": {
     "dimensions": {
-      ".disv": "is the number of cells per layer.  This is a constant value for the grid and it applies to all layers.",
-      ".ncf": "is the number of cells in a projected plane layer."
+      "gwe-disv": "is the number of cells per layer.  This is a constant value for the grid and it applies to all layers.",
+      "gwf-disv": "is the number of cells per layer.  This is a constant value for the grid and it applies to all layers.",
+      "gwt-disv": "is the number of cells per layer.  This is a constant value for the grid and it applies to all layers.",
+      "prt-disv": "is the number of cells per layer.  This is a constant value for the grid and it applies to all layers.",
+      "utl-ncf": "is the number of cells in a projected plane layer."
     }
   },
   "ndelaycells": {
     "options": {
-      ".csub": "number of nodes used to discretize delay interbeds. If not specified, then a default value of 19 is assigned."
+      "gwf-csub": "number of nodes used to discretize delay interbeds. If not specified, then a default value of 19 is assigned."
     }
   },
   "netcdf": {
     "options": {
-      ".nam": "keyword to specify that record corresponds to a netcdf input file."
+      "gwe-nam": "keyword to specify that record corresponds to a netcdf input file.",
+      "gwf-nam": "keyword to specify that record corresponds to a netcdf input file.",
+      "gwt-nam": "keyword to specify that record corresponds to a netcdf input file."
     }
   },
   "netcdf_mesh2d": {
     "options": {
-      ".nam": "keyword to specify that record corresponds to a layered mesh netcdf file."
+      "gwe-nam": "keyword to specify that record corresponds to a layered mesh netcdf file.",
+      "gwf-nam": "keyword to specify that record corresponds to a layered mesh netcdf file. ",
+      "gwt-nam": "keyword to specify that record corresponds to a layered mesh netcdf file."
     }
   },
   "netcdf_structured": {
     "options": {
-      ".nam": "keyword to specify that record corresponds to a structured netcdf file."
+      "gwe-nam": "keyword to specify that record corresponds to a structured netcdf file.",
+      "gwf-nam": "keyword to specify that record corresponds to a structured netcdf file.",
+      "gwt-nam": "keyword to specify that record corresponds to a structured netcdf file."
     }
   },
   "newton": {
     "options": {
-      ".gwfgwf": "keyword that activates the Newton-Raphson formulation for groundwater flow between connected, convertible groundwater cells. Cells will not dry when this option is used.",
-      ".nam": "keyword that activates the Newton-Raphson formulation for surface water flow between connected reaches and stress packages that support calculation of Newton-Raphson terms. "
+      "chf-nam": "keyword that activates the Newton-Raphson formulation for surface water flow between connected reaches and stress packages that support calculation of Newton-Raphson terms. ",
+      "exg-gwfgwf": "keyword that activates the Newton-Raphson formulation for groundwater flow between connected, convertible groundwater cells. Cells will not dry when this option is used.",
+      "gwf-nam": "keyword that activates the Newton-Raphson formulation for groundwater flow between connected, convertible groundwater cells and stress packages that support calculation of Newton-Raphson terms for groundwater exchanges. Cells will not dry when this option is used. By default, the Newton-Raphson formulation is not applied.",
+      "olf-nam": "keyword that activates the Newton-Raphson formulation for surface water flow between connected reaches and stress packages that support calculation of Newton-Raphson terms. ",
+      "swf-nam": "keyword that activates the Newton-Raphson formulation for surface water flow between connected reaches and stress packages that support calculation of Newton-Raphson terms. "
     }
   },
   "newtonoptions": {
     "options": {
-      ".nam": "none"
+      "chf-nam": "none",
+      "gwf-nam": "none",
+      "olf-nam": "none",
+      "swf-nam": "none"
     }
   },
   "nexg": {
     "dimensions": {
-      ".chfgwf": "keyword and integer value specifying the number of SWF-GWF exchanges.",
-      ".gwegwe": "keyword and integer value specifying the number of GWE-GWE exchanges.",
-      ".gwfgwf": "keyword and integer value specifying the number of GWF-GWF exchanges.",
-      ".gwtgwt": "keyword and integer value specifying the number of GWT-GWT exchanges.",
-      ".olfgwf": "keyword and integer value specifying the number of SWF-GWF exchanges."
+      "exg-chfgwf": "keyword and integer value specifying the number of SWF-GWF exchanges.",
+      "exg-gwegwe": "keyword and integer value specifying the number of GWE-GWE exchanges.",
+      "exg-gwfgwf": "keyword and integer value specifying the number of GWF-GWF exchanges.",
+      "exg-gwtgwt": "keyword and integer value specifying the number of GWT-GWT exchanges.",
+      "exg-olfgwf": "keyword and integer value specifying the number of SWF-GWF exchanges."
     }
   },
   "ninterbeds": {
     "dimensions": {
-      ".csub": "is the number of CSUB interbed systems.  More than 1 CSUB interbed systems can be assigned to a GWF cell; however, only 1 GWF cell can be assigned to a single CSUB interbed system."
+      "gwf-csub": "is the number of CSUB interbed systems.  More than 1 CSUB interbed systems can be assigned to a GWF cell; however, only 1 GWF cell can be assigned to a single CSUB interbed system."
     }
   },
   "nja": {
     "dimensions": {
-      ".disu": "is the sum of the number of connections and NODES.  When calculating the total number of connections, the connection between cell n and cell m is considered to be different from the connection between cell m and cell n.  Thus, NJA is equal to the total number of connections, including n to m and m to n, and the total number of cells."
+      "gwe-disu": "is the sum of the number of connections and NODES.  When calculating the total number of connections, the connection between cell n and cell m is considered to be different from the connection between cell m and cell n.  Thus, NJA is equal to the total number of connections, including n to m and m to n, and the total number of cells.",
+      "gwf-disu": "is the sum of the number of connections and NODES.  When calculating the total number of connections, the connection between cell n and cell m is considered to be different from the connection between cell m and cell n.  Thus, NJA is equal to the total number of connections, including n to m and m to n, and the total number of cells.",
+      "gwt-disu": "is the sum of the number of connections and NODES.  When calculating the total number of connections, the connection between cell n and cell m is considered to be different from the connection between cell m and cell n.  Thus, NJA is equal to the total number of connections, including n to m and m to n, and the total number of cells."
     }
   },
   "nlakes": {
     "dimensions": {
-      ".lak": "value specifying the number of lakes that will be simulated for all stress periods."
+      "gwf-lak": "value specifying the number of lakes that will be simulated for all stress periods."
     }
   },
   "nlay": {
     "dimensions": {
-      ".dis": "is the number of layers in the model grid.",
-      ".disv": "is the number of layers in the model grid."
+      "gwe-dis": "is the number of layers in the model grid.",
+      "gwe-disv": "is the number of layers in the model grid.",
+      "gwf-dis": "is the number of layers in the model grid.",
+      "gwf-disv": "is the number of layers in the model grid.",
+      "gwt-dis": "is the number of layers in the model grid.",
+      "gwt-disv": "is the number of layers in the model grid.",
+      "prt-dis": "is the number of layers in the model grid.",
+      "prt-disv": "is the number of layers in the model grid."
     }
   },
   "nmawwells": {
     "dimensions": {
-      ".maw": "integer value specifying the number of multi-aquifer wells that will be simulated for all stress periods."
+      "gwf-maw": "integer value specifying the number of multi-aquifer wells that will be simulated for all stress periods."
     }
   },
   "no_ptc": {
     "options": {
-      ".ims": "is a flag that is used to disable pseudo-transient continuation (PTC). Option only applies to steady-state stress periods for models using the Newton-Raphson formulation. For many problems, PTC can significantly improve convergence behavior for steady-state simulations, and for this reason it is active by default.  In some cases, however, PTC can worsen the convergence behavior, especially when the initial conditions are similar to the solution.  When the initial conditions are similar to, or exactly the same as, the solution and convergence is slow, then the NO\\_PTC FIRST option should be used to deactivate PTC for the first stress period.  The NO\\_PTC ALL option should also be used in order to compare convergence behavior with other MODFLOW versions, as PTC is only available in MODFLOW 6.",
-      ".pts": "is a flag that is used to disable pseudo-transient continuation (PTC). Option only applies to steady-state stress periods for models using the Newton-Raphson formulation. For many problems, PTC can significantly improve convergence behavior for steady-state simulations, and for this reason it is active by default.  In some cases, however, PTC can worsen the convergence behavior, especially when the initial conditions are similar to the solution.  When the initial conditions are similar to, or exactly the same as, the solution and convergence is slow, then the NO\\_PTC FIRST option should be used to deactivate PTC for the first stress period.  The NO\\_PTC ALL option should also be used in order to compare convergence behavior with other MODFLOW versions, as PTC is only available in MODFLOW 6."
+      "sln-ims": "is a flag that is used to disable pseudo-transient continuation (PTC). Option only applies to steady-state stress periods for models using the Newton-Raphson formulation. For many problems, PTC can significantly improve convergence behavior for steady-state simulations, and for this reason it is active by default.  In some cases, however, PTC can worsen the convergence behavior, especially when the initial conditions are similar to the solution.  When the initial conditions are similar to, or exactly the same as, the solution and convergence is slow, then the NO\\_PTC FIRST option should be used to deactivate PTC for the first stress period.  The NO\\_PTC ALL option should also be used in order to compare convergence behavior with other MODFLOW versions, as PTC is only available in MODFLOW 6.",
+      "sln-pts": "is a flag that is used to disable pseudo-transient continuation (PTC). Option only applies to steady-state stress periods for models using the Newton-Raphson formulation. For many problems, PTC can significantly improve convergence behavior for steady-state simulations, and for this reason it is active by default.  In some cases, however, PTC can worsen the convergence behavior, especially when the initial conditions are similar to the solution.  When the initial conditions are similar to, or exactly the same as, the solution and convergence is slow, then the NO\\_PTC FIRST option should be used to deactivate PTC for the first stress period.  The NO\\_PTC ALL option should also be used in order to compare convergence behavior with other MODFLOW versions, as PTC is only available in MODFLOW 6."
     }
   },
   "no_well_storage": {
     "options": {
-      ".maw": "keyword that deactivates inclusion of well storage contributions to the multi-aquifer well package continuity equation."
+      "gwf-maw": "keyword that deactivates inclusion of well storage contributions to the multi-aquifer well package continuity equation."
     }
   },
   "nocheck": {
     "options": {
-      ".nam": "keyword flag to indicate that the model input check routines should not be called prior to each time step. Checks are performed by default."
+      "sim-nam": "keyword flag to indicate that the model input check routines should not be called prior to each time step. Checks are performed by default."
     }
   },
   "nodes": {
     "dimensions": {
-      ".disu": "is the number of cells in the model grid.",
-      ".disv1d": "is the number of linear cells.",
-      ".disv2d": "is the number of cells per layer.  This is a constant value for the grid and it applies to all layers."
+      "chf-disv1d": "is the number of linear cells.",
+      "gwe-disu": "is the number of cells in the model grid.",
+      "gwf-disu": "is the number of cells in the model grid.",
+      "gwt-disu": "is the number of cells in the model grid.",
+      "olf-disv1d": "is the number of linear cells.",
+      "olf-disv2d": "is the number of cells per layer.  This is a constant value for the grid and it applies to all layers.",
+      "swf-disv1d": "is the number of linear cells.",
+      "swf-disv2d": "is the number of cells per layer.  This is a constant value for the grid and it applies to all layers."
     }
   },
   "nogrb": {
     "options": {
-      ".dis": "keyword to deactivate writing of the binary grid file.",
-      ".dis2d": "keyword to deactivate writing of the binary grid file.",
-      ".disu": "keyword to deactivate writing of the binary grid file.",
-      ".disv": "keyword to deactivate writing of the binary grid file.",
-      ".disv1d": "keyword to deactivate writing of the binary grid file.",
-      ".disv2d": "keyword to deactivate writing of the binary grid file."
+      "chf-disv1d": "keyword to deactivate writing of the binary grid file.",
+      "gwe-dis": "keyword to deactivate writing of the binary grid file.",
+      "gwe-disu": "keyword to deactivate writing of the binary grid file.",
+      "gwe-disv": "keyword to deactivate writing of the binary grid file.",
+      "gwf-dis": "keyword to deactivate writing of the binary grid file.",
+      "gwf-disu": "keyword to deactivate writing of the binary grid file.",
+      "gwf-disv": "keyword to deactivate writing of the binary grid file.",
+      "gwt-dis": "keyword to deactivate writing of the binary grid file.",
+      "gwt-disu": "keyword to deactivate writing of the binary grid file.",
+      "gwt-disv": "keyword to deactivate writing of the binary grid file.",
+      "olf-dis2d": "keyword to deactivate writing of the binary grid file.",
+      "olf-disv1d": "keyword to deactivate writing of the binary grid file.",
+      "olf-disv2d": "keyword to deactivate writing of the binary grid file.",
+      "prt-dis": "keyword to deactivate writing of the binary grid file.",
+      "prt-disv": "keyword to deactivate writing of the binary grid file.",
+      "swf-dis2d": "keyword to deactivate writing of the binary grid file.",
+      "swf-disv1d": "keyword to deactivate writing of the binary grid file.",
+      "swf-disv2d": "keyword to deactivate writing of the binary grid file."
     }
   },
   "noutlets": {
     "dimensions": {
-      ".lak": "value specifying the number of outlets that will be simulated for all stress periods. If NOUTLETS is not specified, a default value of zero is used."
+      "gwf-lak": "value specifying the number of outlets that will be simulated for all stress periods. If NOUTLETS is not specified, a default value of zero is used."
     }
   },
   "nper": {
     "dimensions": {
-      ".tdis": "is the number of stress periods for the simulation."
+      "sim-tdis": "is the number of stress periods for the simulation."
     }
   },
   "npoints": {
     "dimensions": {
-      ".cxs": "integer value specifying the total number of cross-section points defined for all reaches.  There must be NPOINTS entries in the CROSSSECTIONDATA block."
+      "chf-cxs": "integer value specifying the total number of cross-section points defined for all reaches.  There must be NPOINTS entries in the CROSSSECTIONDATA block.",
+      "olf-cxs": "integer value specifying the total number of cross-section points defined for all reaches.  There must be NPOINTS entries in the CROSSSECTIONDATA block.",
+      "swf-cxs": "integer value specifying the total number of cross-section points defined for all reaches.  There must be NPOINTS entries in the CROSSSECTIONDATA block."
     }
   },
   "nreaches": {
     "dimensions": {
-      ".sfr": "integer value specifying the number of stream reaches.  There must be NREACHES entries in the PACKAGEDATA block."
+      "gwf-sfr": "integer value specifying the number of stream reaches.  There must be NREACHES entries in the PACKAGEDATA block."
     }
   },
   "nreleasepts": {
     "dimensions": {
-      ".prp": "is the number of particle release points."
+      "prt-prp": "is the number of particle release points."
     }
   },
   "nreleasetimes": {
     "dimensions": {
-      ".prp": "is the number of particle release times specified in the RELEASETIMES block. This is not necessarily the total number of release times; release times are the union of RELEASE\\_TIME\\_FREQUENCY, RELEASETIMES block, and PERIOD block RELEASESETTING selections."
+      "prt-prp": "is the number of particle release times specified in the RELEASETIMES block. This is not necessarily the total number of release times; release times are the union of RELEASE\\_TIME\\_FREQUENCY, RELEASETIMES block, and PERIOD block RELEASESETTING selections."
     }
   },
   "nrhospecies": {
     "dimensions": {
-      ".buy": "number of species used in density equation of state.  This value must be one or greater if the BUY package is activated.  "
+      "gwf-buy": "number of species used in density equation of state.  This value must be one or greater if the BUY package is activated.  "
     }
   },
   "nrow": {
     "dimensions": {
-      ".dis": "is the number of rows in the model grid.",
-      ".dis2d": "is the number of rows in the model grid.",
-      ".laktab": "integer value specifying the number of rows in the lake table. There must be NROW rows of data in the TABLE block.",
-      ".sfrtab": "integer value specifying the number of rows in the reach cross-section table. There must be NROW rows of data in the TABLE block."
+      "gwe-dis": "is the number of rows in the model grid.",
+      "gwf-dis": "is the number of rows in the model grid.",
+      "gwt-dis": "is the number of rows in the model grid.",
+      "olf-dis2d": "is the number of rows in the model grid.",
+      "prt-dis": "is the number of rows in the model grid.",
+      "swf-dis2d": "is the number of rows in the model grid.",
+      "utl-laktab": "integer value specifying the number of rows in the lake table. There must be NROW rows of data in the TABLE block.",
+      "utl-sfrtab": "integer value specifying the number of rows in the reach cross-section table. There must be NROW rows of data in the TABLE block."
     }
   },
   "nsections": {
     "dimensions": {
-      ".cxs": "integer value specifying the number of cross sections that will be defined.  There must be NSECTIONS entries in the PACKAGEDATA block."
+      "chf-cxs": "integer value specifying the number of cross sections that will be defined.  There must be NSECTIONS entries in the PACKAGEDATA block.",
+      "olf-cxs": "integer value specifying the number of cross sections that will be defined.  There must be NSECTIONS entries in the PACKAGEDATA block.",
+      "swf-cxs": "integer value specifying the number of cross sections that will be defined.  There must be NSECTIONS entries in the PACKAGEDATA block."
     }
   },
   "nseg": {
     "dimensions": {
-      ".evt": "number of ET segments.  Default is one.  When NSEG is greater than 1, the PXDP and PETM arrays must be of size NSEG - 1 and be listed in order from the uppermost segment down. Values for PXDP must be listed first followed by the values for PETM.  PXDP defines the extinction-depth proportion at the bottom of a segment. PETM defines the proportion of the maximum ET flux rate at the bottom of a segment."
+      "gwf-evt": "number of ET segments.  Default is one.  When NSEG is greater than 1, the PXDP and PETM arrays must be of size NSEG - 1 and be listed in order from the uppermost segment down. Values for PXDP must be listed first followed by the values for PETM.  PXDP defines the extinction-depth proportion at the bottom of a segment. PETM defines the proportion of the maximum ET flux rate at the bottom of a segment."
     }
   },
   "ntables": {
     "dimensions": {
-      ".lak": "value specifying the number of lakes tables that will be used to define the lake stage, volume relation, and surface area. If NTABLES is not specified, a default value of zero is used."
+      "gwf-lak": "value specifying the number of lakes tables that will be used to define the lake stage, volume relation, and surface area. If NTABLES is not specified, a default value of zero is used."
     }
   },
   "ntracktimes": {
     "dimensions": {
-      ".oc": "is the number of user-specified particle tracking times in the TRACKTIMES block."
+      "prt-oc": "is the number of user-specified particle tracking times in the TRACKTIMES block."
     }
   },
   "ntrailwaves": {
     "dimensions": {
-      ".uzf": "is the number of trailing waves.  A recommended value of 7 can be used for NTRAILWAVES.  This value can be increased to lower mass balance error in the unsaturated zone."
+      "gwf-uzf": "is the number of trailing waves.  A recommended value of 7 can be used for NTRAILWAVES.  This value can be increased to lower mass balance error in the unsaturated zone."
     }
   },
   "numalphaj": {
     "dimensions": {
-      ".gnc": "is the number of contributing factors."
+      "gwf-gnc": "is the number of contributing factors."
     }
   },
   "number_orthogonalizations": {
     "linear": {
-      ".ims": "optional integer value defining the interval used to explicitly recalculate the residual of the flow equation using the solver coefficient matrix, the latest dependent-variable (for example, head) estimates, and the right hand side. For problems that benefit from explicit recalculation of the residual, a number between 4 and 10 is appropriate. By default, NUMBER\\_ORTHOGONALIZATIONS is zero."
+      "sln-ims": "optional integer value defining the interval used to explicitly recalculate the residual of the flow equation using the solver coefficient matrix, the latest dependent-variable (for example, head) estimates, and the right hand side. For problems that benefit from explicit recalculation of the residual, a number between 4 and 10 is appropriate. By default, NUMBER\\_ORTHOGONALIZATIONS is zero."
     }
   },
   "numgnc": {
     "dimensions": {
-      ".gnc": "is the number of GNC entries."
+      "gwf-gnc": "is the number of GNC entries."
     }
   },
   "nuzfcells": {
     "dimensions": {
-      ".uzf": "is the number of UZF cells.  More than one UZF cell can be assigned to a GWF cell; however, only one GWF cell can be assigned to a single UZF cell. If more than one UZF cell is assigned to a GWF cell, then an auxiliary variable should be used to reduce the surface area of the UZF cell with the AUXMULTNAME option."
+      "gwf-uzf": "is the number of UZF cells.  More than one UZF cell can be assigned to a GWF cell; however, only one GWF cell can be assigned to a single UZF cell. If more than one UZF cell is assigned to a GWF cell, then an auxiliary variable should be used to reduce the surface area of the UZF cell with the AUXMULTNAME option."
     }
   },
   "nvert": {
     "dimensions": {
-      ".disu": "is the total number of (x, y) vertex pairs used to define the plan-view shape of each cell in the model grid.  If NVERT is not specified or is specified as zero, then the VERTICES and CELL2D blocks below are not read.  NVERT and the accompanying VERTICES and CELL2D blocks should be specified for most simulations.  If the XT3D or SAVE\\_SPECIFIC\\_DISCHARGE options are specified in the NPF Package, then this information is required.",
-      ".disv": "is the total number of (x, y) vertex pairs used to characterize the horizontal configuration of the model grid.",
-      ".disv1d": "is the total number of (x, y, z) vertex pairs used to characterize the model grid.",
-      ".disv2d": "is the total number of (x, y) vertex pairs used to characterize the horizontal configuration of the model grid."
+      "chf-disv1d": "is the total number of (x, y, z) vertex pairs used to characterize the model grid.",
+      "gwe-disu": "is the total number of (x, y) vertex pairs used to define the plan-view shape of each cell in the model grid.  If NVERT is not specified or is specified as zero, then the VERTICES and CELL2D blocks below are not read.  NVERT and the accompanying VERTICES and CELL2D blocks should be specified for most simulations.  If the XT3D or SAVE\\_SPECIFIC\\_DISCHARGE options are specified in the NPF Package, then this information is required.",
+      "gwe-disv": "is the total number of (x, y) vertex pairs used to characterize the horizontal configuration of the model grid.",
+      "gwf-disu": "is the total number of (x, y) vertex pairs used to define the plan-view shape of each cell in the model grid.  If NVERT is not specified or is specified as zero, then the VERTICES and CELL2D blocks below are not read.  NVERT and the accompanying VERTICES and CELL2D blocks should be specified for most simulations.  If the XT3D or SAVE\\_SPECIFIC\\_DISCHARGE options are specified in the NPF Package, then this information is required.",
+      "gwf-disv": "is the total number of (x, y) vertex pairs used to characterize the horizontal configuration of the model grid.",
+      "gwt-disu": "is the total number of (x, y) vertex pairs used to define the plan-view shape of each cell in the model grid.  If NVERT is not specified or is specified as zero, then the VERTICES and CELL2D blocks below are not read.  NVERT and the accompanying VERTICES and CELL2D blocks should be specified for most simulations.  If the XT3D or SAVE\\_SPECIFIC\\_DISCHARGE options are specified in the NPF Package, then this information is required.",
+      "gwt-disv": "is the total number of (x, y) vertex pairs used to characterize the horizontal configuration of the model grid.",
+      "olf-disv1d": "is the total number of (x, y, z) vertex pairs used to characterize the model grid.",
+      "olf-disv2d": "is the total number of (x, y) vertex pairs used to characterize the horizontal configuration of the model grid.",
+      "prt-disv": "is the total number of (x, y) vertex pairs used to characterize the horizontal configuration of the model grid.",
+      "swf-disv1d": "is the total number of (x, y, z) vertex pairs used to characterize the model grid.",
+      "swf-disv2d": "is the total number of (x, y) vertex pairs used to characterize the horizontal configuration of the model grid."
     }
   },
   "nviscspecies": {
     "dimensions": {
-      ".vsc": "number of species used in the viscosity equation of state.  If either concentrations or temperature (or both) are used to update viscosity then then nrhospecies needs to be at least one."
+      "gwf-vsc": "number of species used in the viscosity equation of state.  If either concentrations or temperature (or both) are used to update viscosity then then nrhospecies needs to be at least one."
     }
   },
   "nwavesets": {
     "dimensions": {
-      ".uzf": "is the number of wave sets.  A recommended value of 40 can be used for NWAVESETS.  This value can be increased if more waves are required to resolve variations in water content within the unsaturated zone."
+      "gwf-uzf": "is the number of wave sets.  A recommended value of 40 can be used for NWAVESETS.  This value can be increased if more waves are required to resolve variations in water content within the unsaturated zone."
     }
   },
   "obs6": {
     "options": {
-      ".api": "keyword to specify that record corresponds to an observations file.",
-      ".cdb": "keyword to specify that record corresponds to an observations file.",
-      ".chd": "keyword to specify that record corresponds to an observations file.",
-      ".chfgwf": "keyword to specify that record corresponds to an observations file.",
-      ".cnc": "keyword to specify that record corresponds to an observations file.",
-      ".csub": "keyword to specify that record corresponds to an observations file.",
-      ".ctp": "keyword to specify that record corresponds to an observations file.",
-      ".dfw": "keyword to specify that record corresponds to an observations file.",
-      ".drn": "keyword to specify that record corresponds to an observations file.",
-      ".esl": "keyword to specify that record corresponds to an observations file.",
-      ".evp": "keyword to specify that record corresponds to an observations file.",
-      ".evt": "keyword to specify that record corresponds to an observations file.",
-      ".evta": "keyword to specify that record corresponds to an observations file.",
-      ".flw": "keyword to specify that record corresponds to an observations file.",
-      ".ghb": "keyword to specify that record corresponds to an observations file.",
-      ".gwegwe": "keyword to specify that record corresponds to an observations file.",
-      ".gwfgwf": "keyword to specify that record corresponds to an observations file.",
-      ".gwtgwt": "keyword to specify that record corresponds to an observations file.",
-      ".lak": "keyword to specify that record corresponds to an observations file.",
-      ".lke": "keyword to specify that record corresponds to an observations file.",
-      ".lkt": "keyword to specify that record corresponds to an observations file.",
-      ".maw": "keyword to specify that record corresponds to an observations file.",
-      ".mwe": "keyword to specify that record corresponds to an observations file.",
-      ".mwt": "keyword to specify that record corresponds to an observations file.",
-      ".olfgwf": "keyword to specify that record corresponds to an observations file.",
-      ".pcp": "keyword to specify that record corresponds to an observations file.",
-      ".rch": "keyword to specify that record corresponds to an observations file.",
-      ".rcha": "keyword to specify that record corresponds to an observations file.",
-      ".riv": "keyword to specify that record corresponds to an observations file.",
-      ".sfe": "keyword to specify that record corresponds to an observations file.",
-      ".sfr": "keyword to specify that record corresponds to an observations file.",
-      ".sft": "keyword to specify that record corresponds to an observations file.",
-      ".src": "keyword to specify that record corresponds to an observations file.",
-      ".uze": "keyword to specify that record corresponds to an observations file.",
-      ".uzf": "keyword to specify that record corresponds to an observations file.",
-      ".uzt": "keyword to specify that record corresponds to an observations file.",
-      ".wel": "keyword to specify that record corresponds to an observations file.",
-      ".zdg": "keyword to specify that record corresponds to an observations file."
+      "chf-cdb": "keyword to specify that record corresponds to an observations file.",
+      "chf-chd": "keyword to specify that record corresponds to an observations file.",
+      "chf-dfw": "keyword to specify that record corresponds to an observations file.",
+      "chf-evp": "keyword to specify that record corresponds to an observations file.",
+      "chf-flw": "keyword to specify that record corresponds to an observations file.",
+      "chf-pcp": "keyword to specify that record corresponds to an observations file.",
+      "chf-zdg": "keyword to specify that record corresponds to an observations file.",
+      "exg-chfgwf": "keyword to specify that record corresponds to an observations file.",
+      "exg-gwegwe": "keyword to specify that record corresponds to an observations file.",
+      "exg-gwfgwf": "keyword to specify that record corresponds to an observations file.",
+      "exg-gwtgwt": "keyword to specify that record corresponds to an observations file.",
+      "exg-olfgwf": "keyword to specify that record corresponds to an observations file.",
+      "gwe-ctp": "keyword to specify that record corresponds to an observations file.",
+      "gwe-esl": "keyword to specify that record corresponds to an observations file.",
+      "gwe-lke": "keyword to specify that record corresponds to an observations file.",
+      "gwe-mwe": "keyword to specify that record corresponds to an observations file.",
+      "gwe-sfe": "keyword to specify that record corresponds to an observations file.",
+      "gwe-uze": "keyword to specify that record corresponds to an observations file.",
+      "gwf-api": "keyword to specify that record corresponds to an observations file.",
+      "gwf-chd": "keyword to specify that record corresponds to an observations file.",
+      "gwf-csub": "keyword to specify that record corresponds to an observations file.",
+      "gwf-drn": "keyword to specify that record corresponds to an observations file.",
+      "gwf-evt": "keyword to specify that record corresponds to an observations file.",
+      "gwf-evta": "keyword to specify that record corresponds to an observations file.",
+      "gwf-ghb": "keyword to specify that record corresponds to an observations file.",
+      "gwf-lak": "keyword to specify that record corresponds to an observations file.",
+      "gwf-maw": "keyword to specify that record corresponds to an observations file.",
+      "gwf-rch": "keyword to specify that record corresponds to an observations file.",
+      "gwf-rcha": "keyword to specify that record corresponds to an observations file.",
+      "gwf-riv": "keyword to specify that record corresponds to an observations file.",
+      "gwf-sfr": "keyword to specify that record corresponds to an observations file.",
+      "gwf-uzf": "keyword to specify that record corresponds to an observations file.",
+      "gwf-wel": "keyword to specify that record corresponds to an observations file.",
+      "gwt-api": "keyword to specify that record corresponds to an observations file.",
+      "gwt-cnc": "keyword to specify that record corresponds to an observations file.",
+      "gwt-lkt": "keyword to specify that record corresponds to an observations file.",
+      "gwt-mwt": "keyword to specify that record corresponds to an observations file.",
+      "gwt-sft": "keyword to specify that record corresponds to an observations file.",
+      "gwt-src": "keyword to specify that record corresponds to an observations file.",
+      "gwt-uzt": "keyword to specify that record corresponds to an observations file.",
+      "olf-cdb": "keyword to specify that record corresponds to an observations file.",
+      "olf-chd": "keyword to specify that record corresponds to an observations file.",
+      "olf-dfw": "keyword to specify that record corresponds to an observations file.",
+      "olf-evp": "keyword to specify that record corresponds to an observations file.",
+      "olf-flw": "keyword to specify that record corresponds to an observations file.",
+      "olf-pcp": "keyword to specify that record corresponds to an observations file.",
+      "olf-zdg": "keyword to specify that record corresponds to an observations file.",
+      "swf-cdb": "keyword to specify that record corresponds to an observations file.",
+      "swf-chd": "keyword to specify that record corresponds to an observations file.",
+      "swf-dfw": "keyword to specify that record corresponds to an observations file.",
+      "swf-evp": "keyword to specify that record corresponds to an observations file.",
+      "swf-flw": "keyword to specify that record corresponds to an observations file.",
+      "swf-pcp": "keyword to specify that record corresponds to an observations file.",
+      "swf-zdg": "keyword to specify that record corresponds to an observations file."
     }
   },
   "outer_dvclose": {
     "nonlinear": {
-      ".ims": "real value defining the dependent-variable (for example, head) change criterion for convergence of the outer (nonlinear) iterations, in units of the dependent-variable (for example, length for head). When the maximum absolute value of the dependent-variable change at all nodes during an iteration is less than or equal to OUTER\\_DVCLOSE, iteration stops. Commonly, OUTER\\_DVCLOSE equals 0.01. The keyword, OUTER\\_HCLOSE can be still be specified instead of OUTER\\_DVCLOSE for backward compatibility with previous versions of MODFLOW 6 but eventually OUTER\\_HCLOSE will be deprecated and specification of OUTER\\_HCLOSE will cause MODFLOW 6 to terminate with an error."
+      "sln-ims": "real value defining the dependent-variable (for example, head) change criterion for convergence of the outer (nonlinear) iterations, in units of the dependent-variable (for example, length for head). When the maximum absolute value of the dependent-variable change at all nodes during an iteration is less than or equal to OUTER\\_DVCLOSE, iteration stops. Commonly, OUTER\\_DVCLOSE equals 0.01. The keyword, OUTER\\_HCLOSE can be still be specified instead of OUTER\\_DVCLOSE for backward compatibility with previous versions of MODFLOW 6 but eventually OUTER\\_HCLOSE will be deprecated and specification of OUTER\\_HCLOSE will cause MODFLOW 6 to terminate with an error."
     }
   },
   "outer_hclose": {
     "nonlinear": {
-      ".ims": "real value defining the head change criterion for convergence of the outer (nonlinear) iterations, in units of length. When the maximum absolute value of the head change at all nodes during an iteration is less than or equal to OUTER\\_HCLOSE, iteration stops. Commonly, OUTER\\_HCLOSE equals 0.01.  The OUTER\\_HCLOSE option has been deprecated in favor of the more general OUTER\\_DVCLOSE (for dependent variable), however either one can be specified in order to maintain backward compatibility."
+      "sln-ims": "real value defining the head change criterion for convergence of the outer (nonlinear) iterations, in units of length. When the maximum absolute value of the head change at all nodes during an iteration is less than or equal to OUTER\\_HCLOSE, iteration stops. Commonly, OUTER\\_HCLOSE equals 0.01.  The OUTER\\_HCLOSE option has been deprecated in favor of the more general OUTER\\_DVCLOSE (for dependent variable), however either one can be specified in order to maintain backward compatibility."
     }
   },
   "outer_maximum": {
     "nonlinear": {
-      ".ims": "integer value defining the maximum number of outer (nonlinear) iterations -- that is, calls to the solution routine. For a linear problem OUTER\\_MAXIMUM should be 1."
+      "sln-ims": "integer value defining the maximum number of outer (nonlinear) iterations -- that is, calls to the solution routine. For a linear problem OUTER\\_MAXIMUM should be 1."
     }
   },
   "outer_rclosebnd": {
     "nonlinear": {
-      ".ims": "real value defining the residual tolerance for convergence of model packages that solve a separate equation not solved by the IMS linear solver. This value represents the maximum allowable residual between successive outer iterations at any single model package element. An example of a model package that would use OUTER\\_RCLOSEBND to evaluate convergence is the SFR package which solves a continuity equation for each reach.  The OUTER\\_RCLOSEBND option is deprecated and has no effect on simulation results as of version 6.1.1.  The keyword, OUTER\\_RCLOSEBND can be still be specified for backward compatibility with previous versions of MODFLOW 6 but eventually specification of OUTER\\_RCLOSEBND will cause MODFLOW 6 to terminate with an error."
+      "sln-ims": "real value defining the residual tolerance for convergence of model packages that solve a separate equation not solved by the IMS linear solver. This value represents the maximum allowable residual between successive outer iterations at any single model package element. An example of a model package that would use OUTER\\_RCLOSEBND to evaluate convergence is the SFR package which solves a continuity equation for each reach.  The OUTER\\_RCLOSEBND option is deprecated and has no effect on simulation results as of version 6.1.1.  The keyword, OUTER\\_RCLOSEBND can be still be specified for backward compatibility with previous versions of MODFLOW 6 but eventually specification of OUTER\\_RCLOSEBND will cause MODFLOW 6 to terminate with an error."
     }
   },
   "package_convergence": {
     "options": {
-      ".csub": "keyword to specify that record corresponds to the package convergence comma spaced values file. Package convergence data is for delay interbeds. A warning message will be issued if package convergence data is requested but delay interbeds are not included in the package.",
-      ".lak": "keyword to specify that record corresponds to the package convergence comma spaced values file.",
-      ".sfr": "keyword to specify that record corresponds to the package convergence comma spaced values file.",
-      ".uzf": "keyword to specify that record corresponds to the package convergence comma spaced values file."
+      "gwf-csub": "keyword to specify that record corresponds to the package convergence comma spaced values file. Package convergence data is for delay interbeds. A warning message will be issued if package convergence data is requested but delay interbeds are not included in the package.",
+      "gwf-lak": "keyword to specify that record corresponds to the package convergence comma spaced values file.",
+      "gwf-sfr": "keyword to specify that record corresponds to the package convergence comma spaced values file.",
+      "gwf-uzf": "keyword to specify that record corresponds to the package convergence comma spaced values file."
     }
   },
   "partitions": {
     "partitions": {
-      ".hpc": "is the list of zero-based partition numbers."
+      "utl-hpc": "is the list of zero-based partition numbers."
     }
   },
   "perched": {
     "options": {
-      ".npf": "keyword to indicate that when a cell is overlying a dewatered convertible cell, the head difference used in Darcy's Law is equal to the head in the overlying cell minus the bottom elevation of the overlying cell.  If not specified, then the default is to use the head difference between the two cells."
+      "gwf-npf": "keyword to indicate that when a cell is overlying a dewatered convertible cell, the head difference used in Darcy's Law is equal to the head in the overlying cell minus the bottom elevation of the overlying cell.  If not specified, then the default is to use the head difference between the two cells."
     }
   },
   "porosity": {
     "griddata": {
-      ".est": "is the mobile domain porosity, defined as the mobile domain pore volume per mobile domain volume.  The GWE model does not support the concept of an immobile domain in the context of heat transport. ",
-      ".ist": "porosity of the immobile domain specified as the immobile domain pore volume per immobile domain volume.",
-      ".mip": "is the aquifer porosity.",
-      ".mst": "is the mobile domain porosity, defined as the mobile domain pore volume per mobile domain volume.  Additional information on porosity within the context of mobile and immobile domain transport simulations is included in the MODFLOW 6 Supplemental Technical Information document. "
+      "gwe-est": "is the mobile domain porosity, defined as the mobile domain pore volume per mobile domain volume.  The GWE model does not support the concept of an immobile domain in the context of heat transport. ",
+      "gwt-ist": "porosity of the immobile domain specified as the immobile domain pore volume per immobile domain volume.",
+      "gwt-mst": "is the mobile domain porosity, defined as the mobile domain pore volume per mobile domain volume.  Additional information on porosity within the context of mobile and immobile domain transport simulations is included in the MODFLOW 6 Supplemental Technical Information document. ",
+      "prt-mip": "is the aquifer porosity."
     }
   },
   "preconditioner_drop_tolerance": {
     "linear": {
-      ".ims": "optional real value that defines the drop tolerance used to drop preconditioner terms based on the magnitude of matrix entries in the ILUT and MILUT preconditioners. A value of $10^{-4}$ works well for most problems. By default, PRECONDITIONER\\_DROP\\_TOLERANCE is zero and the zero-fill incomplete LU factorization preconditioners (ILU(0) and MILU(0)) are used."
+      "sln-ims": "optional real value that defines the drop tolerance used to drop preconditioner terms based on the magnitude of matrix entries in the ILUT and MILUT preconditioners. A value of $10^{-4}$ works well for most problems. By default, PRECONDITIONER\\_DROP\\_TOLERANCE is zero and the zero-fill incomplete LU factorization preconditioners (ILU(0) and MILU(0)) are used."
     }
   },
   "preconditioner_levels": {
     "linear": {
-      ".ims": "optional integer value defining the level of fill for ILU decomposition used in the ILUT and MILUT preconditioners. Higher levels of fill provide more robustness but also require more memory. For optimal performance, it is suggested that a large level of fill be applied (7 or 8) with use of a drop tolerance. Specification of a PRECONDITIONER\\_LEVELS value greater than zero results in use of the ILUT preconditioner. By default, PRECONDITIONER\\_LEVELS is zero and the zero-fill incomplete LU factorization preconditioners (ILU(0) and MILU(0)) are used."
+      "sln-ims": "optional integer value defining the level of fill for ILU decomposition used in the ILUT and MILUT preconditioners. Higher levels of fill provide more robustness but also require more memory. For optimal performance, it is suggested that a large level of fill be applied (7 or 8) with use of a drop tolerance. Specification of a PRECONDITIONER\\_LEVELS value greater than zero results in use of the ILUT preconditioner. By default, PRECONDITIONER\\_LEVELS is zero and the zero-fill incomplete LU factorization preconditioners (ILU(0) and MILU(0)) are used."
     }
   },
   "print": {
     "period": {
-      ".oc": "keyword to indicate that information will be printed this stress period."
+      "chf-oc": "keyword to indicate that information will be printed this stress period.",
+      "gwe-oc": "keyword to indicate that information will be printed this stress period.",
+      "gwf-oc": "keyword to indicate that information will be printed this stress period.",
+      "gwt-oc": "keyword to indicate that information will be printed this stress period.",
+      "olf-oc": "keyword to indicate that information will be printed this stress period.",
+      "prt-oc": "keyword to indicate that information will be printed this stress period.",
+      "swf-oc": "keyword to indicate that information will be printed this stress period."
     }
   },
   "print_concentration": {
     "options": {
-      ".lkt": "keyword to indicate that the list of lake concentration will be printed to the listing file for every stress period in which ``CONCENTRATION PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_CONCENTRATION is specified, then concentration are printed for the last time step of each stress period.",
-      ".mwt": "keyword to indicate that the list of well concentration will be printed to the listing file for every stress period in which ``CONCENTRATION PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_CONCENTRATION is specified, then concentration are printed for the last time step of each stress period.",
-      ".sft": "keyword to indicate that the list of reach concentration will be printed to the listing file for every stress period in which ``CONCENTRATION PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_CONCENTRATION is specified, then concentration are printed for the last time step of each stress period.",
-      ".uzt": "keyword to indicate that the list of UZF cell concentration will be printed to the listing file for every stress period in which ``CONCENTRATION PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_CONCENTRATION is specified, then concentration are printed for the last time step of each stress period."
+      "gwt-lkt": "keyword to indicate that the list of lake concentration will be printed to the listing file for every stress period in which ``CONCENTRATION PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_CONCENTRATION is specified, then concentration are printed for the last time step of each stress period.",
+      "gwt-mwt": "keyword to indicate that the list of well concentration will be printed to the listing file for every stress period in which ``CONCENTRATION PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_CONCENTRATION is specified, then concentration are printed for the last time step of each stress period.",
+      "gwt-sft": "keyword to indicate that the list of reach concentration will be printed to the listing file for every stress period in which ``CONCENTRATION PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_CONCENTRATION is specified, then concentration are printed for the last time step of each stress period.",
+      "gwt-uzt": "keyword to indicate that the list of UZF cell concentration will be printed to the listing file for every stress period in which ``CONCENTRATION PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_CONCENTRATION is specified, then concentration are printed for the last time step of each stress period."
     }
   },
   "print_flows": {
     "options": {
-      ".api": "keyword to indicate that the list of api boundary flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".cdb": "keyword to indicate that the list of critical depth boundary flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".chd": "keyword to indicate that the list of constant-head flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".chfgwf": "keyword to indicate that the list of exchange flow rates will be printed to the listing file for every stress period in which ``SAVE BUDGET'' is specified in Output Control.",
-      ".cnc": "keyword to indicate that the list of constant concentration flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".ctp": "keyword to indicate that the list of constant temperature flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".dfw": "keyword to indicate that calculated flows between cells will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control. If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.  This option can produce extremely large list files because all cell-by-cell flows are printed.  It should only be used with the DFW Package for models that have a small number of cells.",
-      ".drn": "keyword to indicate that the list of drain flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".esl": "keyword to indicate that the list of energy source loading flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".evp": "keyword to indicate that the list of evaporation flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".evt": "keyword to indicate that the list of evapotranspiration flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".evta": "keyword to indicate that the list of evapotranspiration flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".flw": "keyword to indicate that the list of inflow flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".ghb": "keyword to indicate that the list of general-head boundary flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".gnc": "keyword to indicate that the list of GNC flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".gwegwe": "keyword to indicate that the list of exchange flow rates will be printed to the listing file for every stress period in which ``SAVE BUDGET'' is specified in Output Control.",
-      ".gwfgwf": "keyword to indicate that the list of exchange flow rates will be printed to the listing file for every stress period in which ``SAVE BUDGET'' is specified in Output Control.",
-      ".gwtgwt": "keyword to indicate that the list of exchange flow rates will be printed to the listing file for every stress period in which ``SAVE BUDGET'' is specified in Output Control.",
-      ".lak": "keyword to indicate that the list of lake flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".lke": "keyword to indicate that the list of lake flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".lkt": "keyword to indicate that the list of lake flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".maw": "keyword to indicate that the list of multi-aquifer well flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".mve": "keyword to indicate that the list of lake flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".mvr": "keyword to indicate that the list of MVR flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".mvt": "keyword to indicate that the list of lake flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".mwe": "keyword to indicate that the list of well flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".mwt": "keyword to indicate that the list of well flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".nam": "keyword to indicate that the list of all model package flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".npf": "keyword to indicate that calculated flows between cells will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control. If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.  This option can produce extremely large list files because all cell-by-cell flows are printed.  It should only be used with the NPF Package for models that have a small number of cells.",
-      ".olfgwf": "keyword to indicate that the list of exchange flow rates will be printed to the listing file for every stress period in which ``SAVE BUDGET'' is specified in Output Control.",
-      ".pcp": "keyword to indicate that the list of precipitation flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".rch": "keyword to indicate that the list of recharge flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".rcha": "keyword to indicate that the list of recharge flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".riv": "keyword to indicate that the list of river flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".sfe": "keyword to indicate that the list of reach flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".sfr": "keyword to indicate that the list of stream reach flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".sft": "keyword to indicate that the list of reach flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".src": "keyword to indicate that the list of mass source flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".ssm": "keyword to indicate that the list of SSM flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".uze": "keyword to indicate that the list of unsaturated zone flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".uzf": "keyword to indicate that the list of UZF flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".uzt": "keyword to indicate that the list of unsaturated zone flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".wel": "keyword to indicate that the list of well flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
-      ".zdg": "keyword to indicate that the list of zero-depth-gradient boundary flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period."
+      "chf-cdb": "keyword to indicate that the list of critical depth boundary flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "chf-chd": "keyword to indicate that the list of constant-head flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "chf-dfw": "keyword to indicate that calculated flows between cells will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control. If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.  This option can produce extremely large list files because all cell-by-cell flows are printed.  It should only be used with the DFW Package for models that have a small number of cells.",
+      "chf-evp": "keyword to indicate that the list of evaporation flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "chf-flw": "keyword to indicate that the list of inflow flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "chf-nam": "keyword to indicate that the list of all model package flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "chf-pcp": "keyword to indicate that the list of precipitation flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "chf-zdg": "keyword to indicate that the list of zero-depth-gradient boundary flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "exg-chfgwf": "keyword to indicate that the list of exchange flow rates will be printed to the listing file for every stress period in which ``SAVE BUDGET'' is specified in Output Control.",
+      "exg-gwegwe": "keyword to indicate that the list of exchange flow rates will be printed to the listing file for every stress period in which ``SAVE BUDGET'' is specified in Output Control.",
+      "exg-gwfgwf": "keyword to indicate that the list of exchange flow rates will be printed to the listing file for every stress period in which ``SAVE BUDGET'' is specified in Output Control.",
+      "exg-gwtgwt": "keyword to indicate that the list of exchange flow rates will be printed to the listing file for every stress period in which ``SAVE BUDGET'' is specified in Output Control.",
+      "exg-olfgwf": "keyword to indicate that the list of exchange flow rates will be printed to the listing file for every stress period in which ``SAVE BUDGET'' is specified in Output Control.",
+      "gwe-ctp": "keyword to indicate that the list of constant temperature flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "gwe-esl": "keyword to indicate that the list of energy source loading flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "gwe-lke": "keyword to indicate that the list of lake flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "gwe-mve": "keyword to indicate that the list of lake flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "gwe-mwe": "keyword to indicate that the list of well flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "gwe-nam": "keyword to indicate that the list of all model package flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "gwe-sfe": "keyword to indicate that the list of reach flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "gwe-ssm": "keyword to indicate that the list of SSM flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "gwe-uze": "keyword to indicate that the list of unsaturated zone flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "gwf-api": "keyword to indicate that the list of api boundary flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "gwf-chd": "keyword to indicate that the list of constant-head flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "gwf-drn": "keyword to indicate that the list of drain flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "gwf-evt": "keyword to indicate that the list of evapotranspiration flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "gwf-evta": "keyword to indicate that the list of evapotranspiration flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "gwf-ghb": "keyword to indicate that the list of general-head boundary flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "gwf-gnc": "keyword to indicate that the list of GNC flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "gwf-lak": "keyword to indicate that the list of lake flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "gwf-maw": "keyword to indicate that the list of multi-aquifer well flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "gwf-mvr": "keyword to indicate that the list of MVR flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "gwf-nam": "keyword to indicate that the list of all model package flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "gwf-npf": "keyword to indicate that calculated flows between cells will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control. If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.  This option can produce extremely large list files because all cell-by-cell flows are printed.  It should only be used with the NPF Package for models that have a small number of cells.",
+      "gwf-rch": "keyword to indicate that the list of recharge flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "gwf-rcha": "keyword to indicate that the list of recharge flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "gwf-riv": "keyword to indicate that the list of river flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "gwf-sfr": "keyword to indicate that the list of stream reach flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "gwf-uzf": "keyword to indicate that the list of UZF flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "gwf-wel": "keyword to indicate that the list of well flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "gwt-api": "keyword to indicate that the list of api boundary flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "gwt-cnc": "keyword to indicate that the list of constant concentration flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "gwt-lkt": "keyword to indicate that the list of lake flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "gwt-mvt": "keyword to indicate that the list of lake flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "gwt-mwt": "keyword to indicate that the list of well flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "gwt-nam": "keyword to indicate that the list of all model package flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "gwt-sft": "keyword to indicate that the list of reach flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "gwt-src": "keyword to indicate that the list of mass source flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "gwt-ssm": "keyword to indicate that the list of SSM flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "gwt-uzt": "keyword to indicate that the list of unsaturated zone flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "olf-cdb": "keyword to indicate that the list of critical depth boundary flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "olf-chd": "keyword to indicate that the list of constant-head flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "olf-dfw": "keyword to indicate that calculated flows between cells will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control. If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.  This option can produce extremely large list files because all cell-by-cell flows are printed.  It should only be used with the DFW Package for models that have a small number of cells.",
+      "olf-evp": "keyword to indicate that the list of evaporation flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "olf-flw": "keyword to indicate that the list of inflow flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "olf-nam": "keyword to indicate that the list of all model package flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "olf-pcp": "keyword to indicate that the list of precipitation flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "olf-zdg": "keyword to indicate that the list of zero-depth-gradient boundary flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "prt-nam": "keyword to indicate that the list of all model package flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "swf-cdb": "keyword to indicate that the list of critical depth boundary flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "swf-chd": "keyword to indicate that the list of constant-head flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "swf-dfw": "keyword to indicate that calculated flows between cells will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control. If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.  This option can produce extremely large list files because all cell-by-cell flows are printed.  It should only be used with the DFW Package for models that have a small number of cells.",
+      "swf-evp": "keyword to indicate that the list of evaporation flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "swf-flw": "keyword to indicate that the list of inflow flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "swf-nam": "keyword to indicate that the list of all model package flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "swf-pcp": "keyword to indicate that the list of precipitation flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period.",
+      "swf-zdg": "keyword to indicate that the list of zero-depth-gradient boundary flow rates will be printed to the listing file for every stress period time step in which ``BUDGET PRINT'' is specified in Output Control.  If there is no Output Control option and ``PRINT\\_FLOWS'' is specified, then flow rates are printed for the last time step of each stress period."
     }
   },
   "print_format": {
     "options": {
-      ".ist": "keyword to specify format for printing to the listing file.",
-      ".oc": "keyword to specify format for printing to the listing file."
+      "chf-oc": "keyword to specify format for printing to the listing file.",
+      "gwe-oc": "keyword to specify format for printing to the listing file.",
+      "gwf-oc": "keyword to specify format for printing to the listing file.",
+      "gwt-ist": "keyword to specify format for printing to the listing file.",
+      "gwt-oc": "keyword to specify format for printing to the listing file.",
+      "olf-oc": "keyword to specify format for printing to the listing file.",
+      "swf-oc": "keyword to specify format for printing to the listing file."
     }
   },
   "print_head": {
     "options": {
-      ".maw": "keyword to indicate that the list of multi-aquifer well heads will be printed to the listing file for every stress period in which ``HEAD PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_HEAD is specified, then heads are printed for the last time step of each stress period."
+      "gwf-maw": "keyword to indicate that the list of multi-aquifer well heads will be printed to the listing file for every stress period in which ``HEAD PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_HEAD is specified, then heads are printed for the last time step of each stress period."
     }
   },
   "print_input": {
     "options": {
-      ".api": "keyword to indicate that the list of api boundary information will be written to the listing file immediately after it is read.",
-      ".cdb": "keyword to indicate that the list of critical depth boundary information will be written to the listing file immediately after it is read.",
-      ".chd": "keyword to indicate that the list of constant-head information will be written to the listing file immediately after it is read.",
-      ".chfgwf": "keyword to indicate that the list of exchange entries will be echoed to the listing file immediately after it is read.",
-      ".cnc": "keyword to indicate that the list of constant concentration information will be written to the listing file immediately after it is read.",
-      ".csub": "keyword to indicate that the list of CSUB information will be written to the listing file immediately after it is read.",
-      ".ctp": "keyword to indicate that the list of constant temperature information will be written to the listing file immediately after it is read.",
-      ".cxs": "keyword to indicate that the list of stream reach information will be written to the listing file immediately after it is read.",
-      ".drn": "keyword to indicate that the list of drain information will be written to the listing file immediately after it is read.",
-      ".esl": "keyword to indicate that the list of energy source loading information will be written to the listing file immediately after it is read.",
-      ".evp": "keyword to indicate that the list of evaporation information will be written to the listing file immediately after it is read.",
-      ".evt": "keyword to indicate that the list of evapotranspiration information will be written to the listing file immediately after it is read.",
-      ".evta": "keyword to indicate that the list of evapotranspiration information will be written to the listing file immediately after it is read.",
-      ".flw": "keyword to indicate that the list of inflow information will be written to the listing file immediately after it is read.",
-      ".ghb": "keyword to indicate that the list of general-head boundary information will be written to the listing file immediately after it is read.",
-      ".gnc": "keyword to indicate that the list of GNC information will be written to the listing file immediately after it is read.",
-      ".gwegwe": "keyword to indicate that the list of exchange entries will be echoed to the listing file immediately after it is read.",
-      ".gwfgwf": "keyword to indicate that the list of exchange entries will be echoed to the listing file immediately after it is read.",
-      ".gwtgwt": "keyword to indicate that the list of exchange entries will be echoed to the listing file immediately after it is read.",
-      ".hfb": "keyword to indicate that the list of horizontal flow barriers will be written to the listing file immediately after it is read.",
-      ".lak": "keyword to indicate that the list of lake information will be written to the listing file immediately after it is read.",
-      ".lke": "keyword to indicate that the list of lake information will be written to the listing file immediately after it is read.",
-      ".lkt": "keyword to indicate that the list of lake information will be written to the listing file immediately after it is read.",
-      ".maw": "keyword to indicate that the list of multi-aquifer well information will be written to the listing file immediately after it is read.",
-      ".mve": "keyword to indicate that the list of mover information will be written to the listing file immediately after it is read.",
-      ".mvr": "keyword to indicate that the list of MVR information will be written to the listing file immediately after it is read.",
-      ".mvt": "keyword to indicate that the list of mover information will be written to the listing file immediately after it is read.",
-      ".mwe": "keyword to indicate that the list of well information will be written to the listing file immediately after it is read.",
-      ".mwt": "keyword to indicate that the list of well information will be written to the listing file immediately after it is read.",
-      ".nam": "keyword to indicate that the list of all model stress package information will be written to the listing file immediately after it is read.",
-      ".obs": "keyword to indicate that the list of observation information will be written to the listing file immediately after it is read.",
-      ".olfgwf": "keyword to indicate that the list of exchange entries will be echoed to the listing file immediately after it is read.",
-      ".pcp": "keyword to indicate that the list of precipitation information will be written to the listing file immediately after it is read.",
-      ".prp": "keyword to indicate that the list of all model stress package information will be written to the listing file immediately after it is read.",
-      ".rch": "keyword to indicate that the list of recharge information will be written to the listing file immediately after it is read.",
-      ".rcha": "keyword to indicate that the list of recharge information will be written to the listing file immediately after it is read.",
-      ".riv": "keyword to indicate that the list of river information will be written to the listing file immediately after it is read.",
-      ".sfe": "keyword to indicate that the list of reach information will be written to the listing file immediately after it is read.",
-      ".sfr": "keyword to indicate that the list of stream reach information will be written to the listing file immediately after it is read.",
-      ".sft": "keyword to indicate that the list of reach information will be written to the listing file immediately after it is read.",
-      ".spc": "keyword to indicate that the list of spc information will be written to the listing file immediately after it is read.",
-      ".spca": "keyword to indicate that the list of spc information will be written to the listing file immediately after it is read.",
-      ".src": "keyword to indicate that the list of mass source information will be written to the listing file immediately after it is read.",
-      ".tvk": "keyword to indicate that information for each change to the hydraulic conductivity in a cell will be written to the model listing file.",
-      ".tvs": "keyword to indicate that information for each change to a storage property in a cell will be written to the model listing file.",
-      ".uze": "keyword to indicate that the list of unsaturated zone flow information will be written to the listing file immediately after it is read.",
-      ".uzf": "keyword to indicate that the list of UZF information will be written to the listing file immediately after it is read.",
-      ".uzt": "keyword to indicate that the list of unsaturated zone flow information will be written to the listing file immediately after it is read.",
-      ".wel": "keyword to indicate that the list of well information will be written to the listing file immediately after it is read.",
-      ".zdg": "keyword to indicate that the list of zero-depth-gradient boundary information will be written to the listing file immediately after it is read."
+      "chf-cdb": "keyword to indicate that the list of critical depth boundary information will be written to the listing file immediately after it is read.",
+      "chf-chd": "keyword to indicate that the list of constant-head information will be written to the listing file immediately after it is read.",
+      "chf-cxs": "keyword to indicate that the list of stream reach information will be written to the listing file immediately after it is read.",
+      "chf-evp": "keyword to indicate that the list of evaporation information will be written to the listing file immediately after it is read.",
+      "chf-flw": "keyword to indicate that the list of inflow information will be written to the listing file immediately after it is read.",
+      "chf-nam": "keyword to indicate that the list of all model stress package information will be written to the listing file immediately after it is read.",
+      "chf-pcp": "keyword to indicate that the list of precipitation information will be written to the listing file immediately after it is read.",
+      "chf-zdg": "keyword to indicate that the list of zero-depth-gradient boundary information will be written to the listing file immediately after it is read.",
+      "exg-chfgwf": "keyword to indicate that the list of exchange entries will be echoed to the listing file immediately after it is read.",
+      "exg-gwegwe": "keyword to indicate that the list of exchange entries will be echoed to the listing file immediately after it is read.",
+      "exg-gwfgwf": "keyword to indicate that the list of exchange entries will be echoed to the listing file immediately after it is read.",
+      "exg-gwtgwt": "keyword to indicate that the list of exchange entries will be echoed to the listing file immediately after it is read.",
+      "exg-olfgwf": "keyword to indicate that the list of exchange entries will be echoed to the listing file immediately after it is read.",
+      "gwe-ctp": "keyword to indicate that the list of constant temperature information will be written to the listing file immediately after it is read.",
+      "gwe-esl": "keyword to indicate that the list of energy source loading information will be written to the listing file immediately after it is read.",
+      "gwe-lke": "keyword to indicate that the list of lake information will be written to the listing file immediately after it is read.",
+      "gwe-mve": "keyword to indicate that the list of mover information will be written to the listing file immediately after it is read.",
+      "gwe-mwe": "keyword to indicate that the list of well information will be written to the listing file immediately after it is read.",
+      "gwe-nam": "keyword to indicate that the list of all model stress package information will be written to the listing file immediately after it is read.",
+      "gwe-sfe": "keyword to indicate that the list of reach information will be written to the listing file immediately after it is read.",
+      "gwe-uze": "keyword to indicate that the list of unsaturated zone flow information will be written to the listing file immediately after it is read.",
+      "gwf-api": "keyword to indicate that the list of api boundary information will be written to the listing file immediately after it is read.",
+      "gwf-chd": "keyword to indicate that the list of constant-head information will be written to the listing file immediately after it is read.",
+      "gwf-csub": "keyword to indicate that the list of CSUB information will be written to the listing file immediately after it is read.",
+      "gwf-drn": "keyword to indicate that the list of drain information will be written to the listing file immediately after it is read.",
+      "gwf-evt": "keyword to indicate that the list of evapotranspiration information will be written to the listing file immediately after it is read.",
+      "gwf-evta": "keyword to indicate that the list of evapotranspiration information will be written to the listing file immediately after it is read.",
+      "gwf-ghb": "keyword to indicate that the list of general-head boundary information will be written to the listing file immediately after it is read.",
+      "gwf-gnc": "keyword to indicate that the list of GNC information will be written to the listing file immediately after it is read.",
+      "gwf-hfb": "keyword to indicate that the list of horizontal flow barriers will be written to the listing file immediately after it is read.",
+      "gwf-lak": "keyword to indicate that the list of lake information will be written to the listing file immediately after it is read.",
+      "gwf-maw": "keyword to indicate that the list of multi-aquifer well information will be written to the listing file immediately after it is read.",
+      "gwf-mvr": "keyword to indicate that the list of MVR information will be written to the listing file immediately after it is read.",
+      "gwf-nam": "keyword to indicate that the list of all model stress package information will be written to the listing file immediately after it is read.",
+      "gwf-rch": "keyword to indicate that the list of recharge information will be written to the listing file immediately after it is read.",
+      "gwf-rcha": "keyword to indicate that the list of recharge information will be written to the listing file immediately after it is read.",
+      "gwf-riv": "keyword to indicate that the list of river information will be written to the listing file immediately after it is read.",
+      "gwf-sfr": "keyword to indicate that the list of stream reach information will be written to the listing file immediately after it is read.",
+      "gwf-uzf": "keyword to indicate that the list of UZF information will be written to the listing file immediately after it is read.",
+      "gwf-wel": "keyword to indicate that the list of well information will be written to the listing file immediately after it is read.",
+      "gwt-api": "keyword to indicate that the list of api boundary information will be written to the listing file immediately after it is read.",
+      "gwt-cnc": "keyword to indicate that the list of constant concentration information will be written to the listing file immediately after it is read.",
+      "gwt-lkt": "keyword to indicate that the list of lake information will be written to the listing file immediately after it is read.",
+      "gwt-mvt": "keyword to indicate that the list of mover information will be written to the listing file immediately after it is read.",
+      "gwt-mwt": "keyword to indicate that the list of well information will be written to the listing file immediately after it is read.",
+      "gwt-nam": "keyword to indicate that the list of all model stress package information will be written to the listing file immediately after it is read.",
+      "gwt-sft": "keyword to indicate that the list of reach information will be written to the listing file immediately after it is read.",
+      "gwt-src": "keyword to indicate that the list of mass source information will be written to the listing file immediately after it is read.",
+      "gwt-uzt": "keyword to indicate that the list of unsaturated zone flow information will be written to the listing file immediately after it is read.",
+      "olf-cdb": "keyword to indicate that the list of critical depth boundary information will be written to the listing file immediately after it is read.",
+      "olf-chd": "keyword to indicate that the list of constant-head information will be written to the listing file immediately after it is read.",
+      "olf-cxs": "keyword to indicate that the list of stream reach information will be written to the listing file immediately after it is read.",
+      "olf-evp": "keyword to indicate that the list of evaporation information will be written to the listing file immediately after it is read.",
+      "olf-flw": "keyword to indicate that the list of inflow information will be written to the listing file immediately after it is read.",
+      "olf-nam": "keyword to indicate that the list of all model stress package information will be written to the listing file immediately after it is read.",
+      "olf-pcp": "keyword to indicate that the list of precipitation information will be written to the listing file immediately after it is read.",
+      "olf-zdg": "keyword to indicate that the list of zero-depth-gradient boundary information will be written to the listing file immediately after it is read.",
+      "prt-nam": "keyword to indicate that the list of all model stress package information will be written to the listing file immediately after it is read.",
+      "prt-prp": "keyword to indicate that the list of all model stress package information will be written to the listing file immediately after it is read.",
+      "sim-nam": "keyword to activate printing of simulation input summaries to the simulation list file (mfsim.lst). With this keyword, input summaries will be written for those packages that support newer input data model routines.  Not all packages are supported yet by the newer input data model routines.",
+      "swf-cdb": "keyword to indicate that the list of critical depth boundary information will be written to the listing file immediately after it is read.",
+      "swf-chd": "keyword to indicate that the list of constant-head information will be written to the listing file immediately after it is read.",
+      "swf-cxs": "keyword to indicate that the list of stream reach information will be written to the listing file immediately after it is read.",
+      "swf-evp": "keyword to indicate that the list of evaporation information will be written to the listing file immediately after it is read.",
+      "swf-flw": "keyword to indicate that the list of inflow information will be written to the listing file immediately after it is read.",
+      "swf-nam": "keyword to indicate that the list of all model stress package information will be written to the listing file immediately after it is read.",
+      "swf-pcp": "keyword to indicate that the list of precipitation information will be written to the listing file immediately after it is read.",
+      "swf-zdg": "keyword to indicate that the list of zero-depth-gradient boundary information will be written to the listing file immediately after it is read.",
+      "utl-obs": "keyword to indicate that the list of observation information will be written to the listing file immediately after it is read.",
+      "utl-spc": "keyword to indicate that the list of spc information will be written to the listing file immediately after it is read.",
+      "utl-spca": "keyword to indicate that the list of spc information will be written to the listing file immediately after it is read.",
+      "utl-tvk": "keyword to indicate that information for each change to the hydraulic conductivity in a cell will be written to the model listing file.",
+      "utl-tvs": "keyword to indicate that information for each change to a storage property in a cell will be written to the model listing file."
     }
   },
   "print_option": {
     "options": {
-      ".ims": "is a flag that controls printing of convergence information from the solver.  NONE means print nothing. SUMMARY means print only the total number of iterations and nonlinear residual reduction summaries. ALL means print linear matrix solver convergence information to the solution listing file and model specific linear matrix solver convergence information to each model listing file in addition to SUMMARY information. NONE is default if PRINT\\_OPTION is not specified.",
-      ".pts": "is a flag that controls printing of convergence information from the solver.  NONE means print nothing. SUMMARY means print only the total number of iterations and nonlinear residual reduction summaries. ALL means print linear matrix solver convergence information to the solution listing file and model specific linear matrix solver convergence information to each model listing file in addition to SUMMARY information. NONE is default if PRINT\\_OPTION is not specified."
+      "sln-ims": "is a flag that controls printing of convergence information from the solver.  NONE means print nothing. SUMMARY means print only the total number of iterations and nonlinear residual reduction summaries. ALL means print linear matrix solver convergence information to the solution listing file and model specific linear matrix solver convergence information to each model listing file in addition to SUMMARY information. NONE is default if PRINT\\_OPTION is not specified.",
+      "sln-pts": "is a flag that controls printing of convergence information from the solver.  NONE means print nothing. SUMMARY means print only the total number of iterations and nonlinear residual reduction summaries. ALL means print linear matrix solver convergence information to the solution listing file and model specific linear matrix solver convergence information to each model listing file in addition to SUMMARY information. NONE is default if PRINT\\_OPTION is not specified."
     }
   },
   "print_stage": {
     "options": {
-      ".lak": "keyword to indicate that the list of lake stages will be printed to the listing file for every stress period in which ``HEAD PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_STAGE is specified, then stages are printed for the last time step of each stress period.",
-      ".sfr": "keyword to indicate that the list of stream reach stages will be printed to the listing file for every stress period in which ``HEAD PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_STAGE is specified, then stages are printed for the last time step of each stress period."
+      "gwf-lak": "keyword to indicate that the list of lake stages will be printed to the listing file for every stress period in which ``HEAD PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_STAGE is specified, then stages are printed for the last time step of each stress period.",
+      "gwf-sfr": "keyword to indicate that the list of stream reach stages will be printed to the listing file for every stress period in which ``HEAD PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_STAGE is specified, then stages are printed for the last time step of each stress period."
     }
   },
   "print_table": {
     "options": {
-      ".hpc": "keyword to indicate that the partition table will be printed to the listing file."
+      "utl-hpc": "keyword to indicate that the partition table will be printed to the listing file."
     }
   },
   "print_temperature": {
     "options": {
-      ".lke": "keyword to indicate that the list of lake temperature will be printed to the listing file for every stress period in which ``TEMPERATURE PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_TEMPERATURE is specified, then temperature are printed for the last time step of each stress period.",
-      ".mwe": "keyword to indicate that the list of well temperature will be printed to the listing file for every stress period in which ``TEMPERATURE PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_TEMPERATURE is specified, then temperature are printed for the last time step of each stress period.",
-      ".sfe": "keyword to indicate that the list of reach temperatures will be printed to the listing file for every stress period in which ``TEMPERATURE PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_TEMPERATURE is specified, then temperatures are printed for the last time step of each stress period.",
-      ".uze": "keyword to indicate that the list of UZF cell temperatures will be printed to the listing file for every stress period in which ``TEMPERATURE PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_TEMPERATURE is specified, then temperatures are printed for the last time step of each stress period."
+      "gwe-lke": "keyword to indicate that the list of lake temperature will be printed to the listing file for every stress period in which ``TEMPERATURE PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_TEMPERATURE is specified, then temperature are printed for the last time step of each stress period.",
+      "gwe-mwe": "keyword to indicate that the list of well temperature will be printed to the listing file for every stress period in which ``TEMPERATURE PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_TEMPERATURE is specified, then temperature are printed for the last time step of each stress period.",
+      "gwe-sfe": "keyword to indicate that the list of reach temperatures will be printed to the listing file for every stress period in which ``TEMPERATURE PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_TEMPERATURE is specified, then temperatures are printed for the last time step of each stress period.",
+      "gwe-uze": "keyword to indicate that the list of UZF cell temperatures will be printed to the listing file for every stress period in which ``TEMPERATURE PRINT'' is specified in Output Control.  If there is no Output Control option and PRINT\\_TEMPERATURE is specified, then temperatures are printed for the last time step of each stress period."
     }
   },
   "profile_option": {
     "options": {
-      ".nam": "is a flag that controls performance profiling and reporting.  NONE disables profiling. SUMMARY means to measure and print a coarse performance profile. DETAIL means collect and print information with the highest resolution available. NONE is default if PROFILE\\_OPTION is not specified."
+      "sim-nam": "is a flag that controls performance profiling and reporting.  NONE disables profiling. SUMMARY means to measure and print a coarse performance profile. DETAIL means collect and print information with the highest resolution available. NONE is default if PROFILE\\_OPTION is not specified."
     }
   },
   "qoutflow": {
     "options": {
-      ".oc": "keyword to specify that record corresponds to qoutflow."
+      "chf-oc": "keyword to specify that record corresponds to qoutflow.",
+      "olf-oc": "keyword to specify that record corresponds to qoutflow.",
+      "swf-oc": "keyword to specify that record corresponds to qoutflow."
     }
   },
   "rainfall": {
     "period": {
-      ".lak": "real or character value that defines the rainfall rate $(LT^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      ".lke": "real or character value that defines the rainfall temperature for the lake. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      ".lkt": "real or character value that defines the rainfall solute concentration $(ML^{-3})$ for the lake. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      ".sfe": "real or character value that defines the rainfall temperature $(e.g.,\\:^{\\circ}C\\:or\\:^{\\circ}F)$ for the reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      ".sfr": "real or character value that defines the  volumetric rate per unit area of water added by precipitation directly on the streamflow routing reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, rainfall  rates are zero for each reach.",
-      ".sft": "real or character value that defines the rainfall solute concentration $(ML^{-3})$ for the reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+      "gwe-lke": "real or character value that defines the rainfall temperature for the lake. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      "gwe-sfe": "real or character value that defines the rainfall temperature $(e.g.,\\:^{\\circ}C\\:or\\:^{\\circ}F)$ for the reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      "gwf-lak": "real or character value that defines the rainfall rate $(LT^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      "gwf-sfr": "real or character value that defines the  volumetric rate per unit area of water added by precipitation directly on the streamflow routing reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, rainfall  rates are zero for each reach.",
+      "gwt-lkt": "real or character value that defines the rainfall solute concentration $(ML^{-3})$ for the lake. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      "gwt-sft": "real or character value that defines the rainfall solute concentration $(ML^{-3})$ for the reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
     }
   },
   "rate": {
     "period": {
-      ".evta": "is the maximum ET flux rate ($LT^{-1}$).",
-      ".lak": "real or character value that defines the extraction rate for the lake outflow. A positive value indicates inflow and a negative value indicates outflow from the lake. RATE only applies to outlets associated with active lakes (STATUS is ACTIVE). A specified RATE is only applied if COUTTYPE for the OUTLETNO is SPECIFIED. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, the RATE for each SPECIFIED lake outlet is zero.",
-      ".maw": "is the volumetric pumping rate for the multi-aquifer well. A positive value indicates recharge and a negative value indicates discharge (pumping). RATE only applies to active (STATUS is ACTIVE) multi-aquifer wells. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, the RATE for each multi-aquifer well is zero.",
-      ".mwe": "real or character value that defines the injection temperature $(e.g.,\\:^{\\circ}C\\:or\\:^{\\circ}F)$ for the well. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      ".mwt": "real or character value that defines the injection solute concentration $(ML^{-3})$ for the well. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+      "gwe-mwe": "real or character value that defines the injection temperature $(e.g.,\\:^{\\circ}C\\:or\\:^{\\circ}F)$ for the well. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      "gwf-evta": "is the maximum ET flux rate ($LT^{-1}$).",
+      "gwf-lak": "real or character value that defines the extraction rate for the lake outflow. A positive value indicates inflow and a negative value indicates outflow from the lake. RATE only applies to outlets associated with active lakes (STATUS is ACTIVE). A specified RATE is only applied if COUTTYPE for the OUTLETNO is SPECIFIED. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, the RATE for each SPECIFIED lake outlet is zero.",
+      "gwf-maw": "is the volumetric pumping rate for the multi-aquifer well. A positive value indicates recharge and a negative value indicates discharge (pumping). RATE only applies to active (STATUS is ACTIVE) multi-aquifer wells. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, the RATE for each multi-aquifer well is zero.",
+      "gwt-mwt": "real or character value that defines the injection solute concentration $(ML^{-3})$ for the well. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
     }
   },
   "rate_scaling": {
     "period": {
-      ".maw": "activate rate scaling.  If RATE\\_SCALING is specified, both PUMP\\_ELEVATION and SCALING\\_LENGTH must be specified. RATE\\_SCALING cannot be used with HEAD\\_LIMIT.  RATE\\_SCALING can be used for extraction or injection wells.  For extraction wells, the extraction rate will start to decrease once the head in the well lowers to a level equal to the pump elevation plus the scaling length.  If the head in the well drops below the pump elevation, then the extraction rate is calculated to be zero.  For an injection well, the injection rate will begin to decrease once the head in the well rises above the specified pump elevation.  If the head in the well rises above the pump elevation plus the scaling length, then the injection rate will be set to zero."
+      "gwf-maw": "activate rate scaling.  If RATE\\_SCALING is specified, both PUMP\\_ELEVATION and SCALING\\_LENGTH must be specified. RATE\\_SCALING cannot be used with HEAD\\_LIMIT.  RATE\\_SCALING can be used for extraction or injection wells.  For extraction wells, the extraction rate will start to decrease once the head in the well lowers to a level equal to the pump elevation plus the scaling length.  If the head in the well drops below the pump elevation, then the extraction rate is calculated to be zero.  For an injection well, the injection rate will begin to decrease once the head in the well rises above the specified pump elevation.  If the head in the well rises above the pump elevation plus the scaling length, then the injection rate will be set to zero."
     }
   },
   "readasarrays": {
     "options": {
-      ".evta": "indicates that array-based input will be used for the Evapotranspiration Package.  This keyword must be specified to use array-based input.  When READASARRAYS is specified, values must be provided for every cell within a model layer, even those cells that have an IDOMAIN value less than one.  Values assigned to cells with IDOMAIN values less than one are not used and have no effect on simulation results.",
-      ".rcha": "indicates that array-based input will be used for the Recharge Package.  This keyword must be specified to use array-based input.  When READASARRAYS is specified, values must be provided for every cell within a model layer, even those cells that have an IDOMAIN value less than one.  Values assigned to cells with IDOMAIN values less than one are not used and have no effect on simulation results. ",
-      ".spca": "indicates that array-based input will be used for the SPC Package.  This keyword must be specified to use array-based input.  When READASARRAYS is specified, values must be provided for every cell within a model layer, even those cells that have an IDOMAIN value less than one.  Values assigned to cells with IDOMAIN values less than one are not used and have no effect on simulation results."
+      "gwf-evta": "indicates that array-based input will be used for the Evapotranspiration Package.  This keyword must be specified to use array-based input.  When READASARRAYS is specified, values must be provided for every cell within a model layer, even those cells that have an IDOMAIN value less than one.  Values assigned to cells with IDOMAIN values less than one are not used and have no effect on simulation results.",
+      "gwf-rcha": "indicates that array-based input will be used for the Recharge Package.  This keyword must be specified to use array-based input.  When READASARRAYS is specified, values must be provided for every cell within a model layer, even those cells that have an IDOMAIN value less than one.  Values assigned to cells with IDOMAIN values less than one are not used and have no effect on simulation results. ",
+      "utl-spca": "indicates that array-based input will be used for the SPC Package.  This keyword must be specified to use array-based input.  When READASARRAYS is specified, values must be provided for every cell within a model layer, even those cells that have an IDOMAIN value less than one.  Values assigned to cells with IDOMAIN values less than one are not used and have no effect on simulation results."
     }
   },
   "recharge": {
     "period": {
-      ".rcha": "is the recharge flux rate ($LT^{-1}$).  This rate is multiplied inside the program by the surface area of the cell to calculate the volumetric recharge rate. The recharge array may be defined by a time-array series (see the ``Using Time-Array Series in a Package'' section)."
+      "gwf-rcha": "is the recharge flux rate ($LT^{-1}$).  This rate is multiplied inside the program by the surface area of the cell to calculate the volumetric recharge rate. The recharge array may be defined by a time-array series (see the ``Using Time-Array Series in a Package'' section)."
     }
   },
   "relaxation_factor": {
     "linear": {
-      ".ims": "optional real value that defines the relaxation factor used by the incomplete LU factorization preconditioners (MILU(0) and MILUT). RELAXATION\\_FACTOR is unitless and should be greater than or equal to 0.0 and less than or equal to 1.0. RELAXATION\\_FACTOR values of about 1.0 are commonly used, and experience suggests that convergence can be optimized in some cases with relax values of 0.97. A RELAXATION\\_FACTOR value of 0.0 will result in either ILU(0) or ILUT preconditioning (depending on the value specified for PRECONDITIONER\\_LEVELS and/or PRECONDITIONER\\_DROP\\_TOLERANCE). By default,  RELAXATION\\_FACTOR is zero."
+      "sln-ims": "optional real value that defines the relaxation factor used by the incomplete LU factorization preconditioners (MILU(0) and MILUT). RELAXATION\\_FACTOR is unitless and should be greater than or equal to 0.0 and less than or equal to 1.0. RELAXATION\\_FACTOR values of about 1.0 are commonly used, and experience suggests that convergence can be optimized in some cases with relax values of 0.97. A RELAXATION\\_FACTOR value of 0.0 will result in either ILU(0) or ILUT preconditioning (depending on the value specified for PRECONDITIONER\\_LEVELS and/or PRECONDITIONER\\_DROP\\_TOLERANCE). By default,  RELAXATION\\_FACTOR is zero."
     }
   },
   "release_time_frequency": {
     "options": {
-      ".prp": "real number indicating the time frequency at which to release particles. This option can be used to schedule releases at a regular interval for the duration of the simulation, starting at the simulation start time. The release schedule is the union of this option, the RELEASETIMES block, and PERIOD block RELEASESETTING selections. If none of these are provided, a single release time is configured at the beginning of the first time step of the simulation's first stress period."
+      "prt-prp": "real number indicating the time frequency at which to release particles. This option can be used to schedule releases at a regular interval for the duration of the simulation, starting at the simulation start time. The release schedule is the union of this option, the RELEASETIMES block, and PERIOD block RELEASESETTING selections. If none of these are provided, a single release time is configured at the beginning of the first time step of the simulation's first stress period."
     }
   },
   "release_time_tolerance": {
     "options": {
-      ".prp": "real number indicating the tolerance within which to consider consecutive release times coincident. Coincident release times will be merged into a single release time. The default is $\\epsilon \\times 10^{11}$, where $\\epsilon$ is machine precision."
+      "prt-prp": "real number indicating the tolerance within which to consider consecutive release times coincident. Coincident release times will be merged into a single release time. The default is $\\epsilon \\times 10^{11}$, where $\\epsilon$ is machine precision."
     }
   },
   "reordering_method": {
     "linear": {
-      ".ims": "an optional keyword that defines the matrix reordering approach used. By default, matrix reordering is not applied.  NONE - original ordering.  RCM - reverse Cuthill McKee ordering.  MD - minimum degree ordering."
+      "sln-ims": "an optional keyword that defines the matrix reordering approach used. By default, matrix reordering is not applied.  NONE - original ordering.  RCM - reverse Cuthill McKee ordering.  MD - minimum degree ordering."
     }
   },
   "retfactor": {
     "griddata": {
-      ".mip": "is a real value by which velocity is divided within a given cell.  RETFACTOR can be used to account for solute retardation, i.e., the apparent effect of linear sorption on the velocity of particles that track solute advection.  RETFACTOR may be assigned any real value.  A RETFACTOR value greater than 1 represents particle retardation (slowing), and a value of 1 represents no retardation.  The effect of specifying a RETFACTOR value for each cell is the same as the effect of directly multiplying the POROSITY in each cell by the proposed RETFACTOR value for each cell.  RETFACTOR allows conceptual isolation of effects such as retardation from the effect of porosity.  The default value is 1."
+      "prt-mip": "is a real value by which velocity is divided within a given cell.  RETFACTOR can be used to account for solute retardation, i.e., the apparent effect of linear sorption on the velocity of particles that track solute advection.  RETFACTOR may be assigned any real value.  A RETFACTOR value greater than 1 represents particle retardation (slowing), and a value of 1 represents no retardation.  The effect of specifying a RETFACTOR value for each cell is the same as the effect of directly multiplying the POROSITY in each cell by the proposed RETFACTOR value for each cell.  RETFACTOR allows conceptual isolation of effects such as retardation from the effect of porosity.  The default value is 1."
     }
   },
   "rewet": {
     "options": {
-      ".npf": "activates model rewetting.  Rewetting is off by default."
+      "gwf-npf": "activates model rewetting.  Rewetting is off by default."
     }
   },
   "rhs": {
     "options": {
-      ".npf": "If the RHS keyword is also included, then the XT3D additional terms will be added to the right-hand side.  If the RHS keyword is excluded, then the XT3D terms will be put into the coefficient matrix."
+      "gwf-npf": "If the RHS keyword is also included, then the XT3D additional terms will be added to the right-hand side.  If the RHS keyword is excluded, then the XT3D terms will be put into the coefficient matrix."
     }
   },
   "rough": {
     "period": {
-      ".lak": "real value that defines the roughness coefficient for the lake outlet. Any value can be specified if COUTTYPE is not MANNING. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+      "gwf-lak": "real value that defines the roughness coefficient for the lake outlet. Any value can be specified if COUTTYPE is not MANNING. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
     }
   },
   "runoff": {
     "period": {
-      ".lak": "real or character value that defines the runoff rate $(L^3 T^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      ".lkt": "real or character value that defines the concentration of runoff $(ML^{-3})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      ".sfe": "real or character value that defines the temperature of runoff $(e.g.,\\:^{\\circ}C\\:or\\:^{\\circ}F)$ for the reach.  Users are free to use whatever temperature scale they want, which might include negative temperatures.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      ".sfr": "real or character value that defines the volumetric rate of diffuse overland runoff that enters the streamflow routing reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. If the volumetric runoff rate for a reach is negative and exceeds inflows to the reach (upstream and specified inflows, and rainfall but excluding groundwater leakage into the reach) the volumetric runoff rate is limited to inflows to the reach and the volumetric evaporation rate for the reach is set to zero. By default, runoff rates are zero for each reach.",
-      ".sft": "real or character value that defines the concentration of runoff $(ML^{-3})$ for the reach. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+      "gwe-sfe": "real or character value that defines the temperature of runoff $(e.g.,\\:^{\\circ}C\\:or\\:^{\\circ}F)$ for the reach.  Users are free to use whatever temperature scale they want, which might include negative temperatures.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      "gwf-lak": "real or character value that defines the runoff rate $(L^3 T^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      "gwf-sfr": "real or character value that defines the volumetric rate of diffuse overland runoff that enters the streamflow routing reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. If the volumetric runoff rate for a reach is negative and exceeds inflows to the reach (upstream and specified inflows, and rainfall but excluding groundwater leakage into the reach) the volumetric runoff rate is limited to inflows to the reach and the volumetric evaporation rate for the reach is set to zero. By default, runoff rates are zero for each reach.",
+      "gwt-lkt": "real or character value that defines the concentration of runoff $(ML^{-3})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      "gwt-sft": "real or character value that defines the concentration of runoff $(ML^{-3})$ for the reach. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
     }
   },
   "save": {
     "period": {
-      ".oc": "keyword to indicate that information will be saved this stress period."
+      "chf-oc": "keyword to indicate that information will be saved this stress period.",
+      "gwe-oc": "keyword to indicate that information will be saved this stress period.",
+      "gwf-oc": "keyword to indicate that information will be saved this stress period.",
+      "gwt-oc": "keyword to indicate that information will be saved this stress period.",
+      "olf-oc": "keyword to indicate that information will be saved this stress period.",
+      "prt-oc": "keyword to indicate that information will be saved this stress period.",
+      "swf-oc": "keyword to indicate that information will be saved this stress period."
     }
   },
   "save_flows": {
     "options": {
-      ".api": "keyword to indicate that api boundary flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".cdb": "keyword to indicate that critical depth boundary flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".chd": "keyword to indicate that constant-head flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".cnc": "keyword to indicate that constant concentration flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".csub": "keyword to indicate that cell-by-cell flow terms will be written to the file specified with ``BUDGET SAVE FILE'' in Output Control.",
-      ".ctp": "keyword to indicate that constant temperature flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".dfw": "keyword to indicate that budget flow terms will be written to the file specified with ``BUDGET SAVE FILE'' in Output Control.",
-      ".drn": "keyword to indicate that drain flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".esl": "keyword to indicate that energy source loading flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".est": "keyword to indicate that EST flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".evp": "keyword to indicate that evaporation flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".evt": "keyword to indicate that evapotranspiration flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".evta": "keyword to indicate that evapotranspiration flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".flw": "keyword to indicate that inflow flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".fmi": "keyword to indicate that FMI flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".ghb": "keyword to indicate that general-head boundary flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".gwegwe": "keyword to indicate that cell-by-cell flow terms will be written to the budget file for each model provided that the Output Control for the models are set up with the ``BUDGET SAVE FILE'' option.",
-      ".gwfgwf": "keyword to indicate that cell-by-cell flow terms will be written to the budget file for each model provided that the Output Control for the models are set up with the ``BUDGET SAVE FILE'' option.",
-      ".gwtgwt": "keyword to indicate that cell-by-cell flow terms will be written to the budget file for each model provided that the Output Control for the models are set up with the ``BUDGET SAVE FILE'' option.",
-      ".ist": "keyword to indicate that IST flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".lak": "keyword to indicate that lake flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".lke": "keyword to indicate that lake flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".lkt": "keyword to indicate that lake flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".maw": "keyword to indicate that multi-aquifer well flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".mst": "keyword to indicate that MST flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".mve": "keyword to indicate that lake flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".mvt": "keyword to indicate that lake flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".mwe": "keyword to indicate that well flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".mwt": "keyword to indicate that well flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".nam": "keyword to indicate that all model package flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".npf": "keyword to indicate that budget flow terms will be written to the file specified with ``BUDGET SAVE FILE'' in Output Control.",
-      ".pcp": "keyword to indicate that precipitation flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".rch": "keyword to indicate that recharge flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".rcha": "keyword to indicate that recharge flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".riv": "keyword to indicate that river flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".sfe": "keyword to indicate that reach flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".sfr": "keyword to indicate that stream reach flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".sft": "keyword to indicate that reach flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".src": "keyword to indicate that mass source flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".ssm": "keyword to indicate that SSM flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".sto": "keyword to indicate that cell-by-cell flow terms will be written to the file specified with ``BUDGET SAVE FILE'' in Output Control.",
-      ".uze": "keyword to indicate that unsaturated zone flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".uzf": "keyword to indicate that UZF flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".uzt": "keyword to indicate that unsaturated zone flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".wel": "keyword to indicate that well flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
-      ".zdg": "keyword to indicate that zero-depth-gradient boundary flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control."
+      "chf-cdb": "keyword to indicate that critical depth boundary flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "chf-chd": "keyword to indicate that constant-head flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "chf-dfw": "keyword to indicate that budget flow terms will be written to the file specified with ``BUDGET SAVE FILE'' in Output Control.",
+      "chf-evp": "keyword to indicate that evaporation flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "chf-flw": "keyword to indicate that inflow flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "chf-nam": "keyword to indicate that all model package flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "chf-pcp": "keyword to indicate that precipitation flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "chf-sto": "keyword to indicate that cell-by-cell flow terms will be written to the file specified with ``BUDGET SAVE FILE'' in Output Control.",
+      "chf-zdg": "keyword to indicate that zero-depth-gradient boundary flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "exg-gwegwe": "keyword to indicate that cell-by-cell flow terms will be written to the budget file for each model provided that the Output Control for the models are set up with the ``BUDGET SAVE FILE'' option.",
+      "exg-gwfgwf": "keyword to indicate that cell-by-cell flow terms will be written to the budget file for each model provided that the Output Control for the models are set up with the ``BUDGET SAVE FILE'' option.",
+      "exg-gwtgwt": "keyword to indicate that cell-by-cell flow terms will be written to the budget file for each model provided that the Output Control for the models are set up with the ``BUDGET SAVE FILE'' option.",
+      "gwe-ctp": "keyword to indicate that constant temperature flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "gwe-esl": "keyword to indicate that energy source loading flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "gwe-est": "keyword to indicate that EST flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "gwe-fmi": "keyword to indicate that FMI flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "gwe-lke": "keyword to indicate that lake flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "gwe-mve": "keyword to indicate that lake flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "gwe-mwe": "keyword to indicate that well flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "gwe-nam": "keyword to indicate that all model package flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "gwe-sfe": "keyword to indicate that reach flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "gwe-ssm": "keyword to indicate that SSM flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "gwe-uze": "keyword to indicate that unsaturated zone flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "gwf-api": "keyword to indicate that api boundary flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "gwf-chd": "keyword to indicate that constant-head flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "gwf-csub": "keyword to indicate that cell-by-cell flow terms will be written to the file specified with ``BUDGET SAVE FILE'' in Output Control.",
+      "gwf-drn": "keyword to indicate that drain flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "gwf-evt": "keyword to indicate that evapotranspiration flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "gwf-evta": "keyword to indicate that evapotranspiration flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "gwf-ghb": "keyword to indicate that general-head boundary flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "gwf-lak": "keyword to indicate that lake flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "gwf-maw": "keyword to indicate that multi-aquifer well flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "gwf-nam": "keyword to indicate that all model package flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "gwf-npf": "keyword to indicate that budget flow terms will be written to the file specified with ``BUDGET SAVE FILE'' in Output Control.",
+      "gwf-rch": "keyword to indicate that recharge flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "gwf-rcha": "keyword to indicate that recharge flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "gwf-riv": "keyword to indicate that river flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "gwf-sfr": "keyword to indicate that stream reach flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "gwf-sto": "keyword to indicate that cell-by-cell flow terms will be written to the file specified with ``BUDGET SAVE FILE'' in Output Control.",
+      "gwf-uzf": "keyword to indicate that UZF flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "gwf-wel": "keyword to indicate that well flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "gwt-api": "keyword to indicate that api boundary flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "gwt-cnc": "keyword to indicate that constant concentration flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "gwt-fmi": "keyword to indicate that FMI flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "gwt-ist": "keyword to indicate that IST flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "gwt-lkt": "keyword to indicate that lake flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "gwt-mst": "keyword to indicate that MST flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "gwt-mvt": "keyword to indicate that lake flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "gwt-mwt": "keyword to indicate that well flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "gwt-nam": "keyword to indicate that all model package flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "gwt-sft": "keyword to indicate that reach flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "gwt-src": "keyword to indicate that mass source flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "gwt-ssm": "keyword to indicate that SSM flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "gwt-uzt": "keyword to indicate that unsaturated zone flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "olf-cdb": "keyword to indicate that critical depth boundary flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "olf-chd": "keyword to indicate that constant-head flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "olf-dfw": "keyword to indicate that budget flow terms will be written to the file specified with ``BUDGET SAVE FILE'' in Output Control.",
+      "olf-evp": "keyword to indicate that evaporation flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "olf-flw": "keyword to indicate that inflow flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "olf-nam": "keyword to indicate that all model package flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "olf-pcp": "keyword to indicate that precipitation flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "olf-sto": "keyword to indicate that cell-by-cell flow terms will be written to the file specified with ``BUDGET SAVE FILE'' in Output Control.",
+      "olf-zdg": "keyword to indicate that zero-depth-gradient boundary flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "prt-fmi": "keyword to indicate that FMI flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "prt-nam": "keyword to indicate that all model package flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "swf-cdb": "keyword to indicate that critical depth boundary flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "swf-chd": "keyword to indicate that constant-head flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "swf-dfw": "keyword to indicate that budget flow terms will be written to the file specified with ``BUDGET SAVE FILE'' in Output Control.",
+      "swf-evp": "keyword to indicate that evaporation flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "swf-flw": "keyword to indicate that inflow flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "swf-nam": "keyword to indicate that all model package flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "swf-pcp": "keyword to indicate that precipitation flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control.",
+      "swf-sto": "keyword to indicate that cell-by-cell flow terms will be written to the file specified with ``BUDGET SAVE FILE'' in Output Control.",
+      "swf-zdg": "keyword to indicate that zero-depth-gradient boundary flow terms will be written to the file specified with ``BUDGET FILEOUT'' in Output Control."
     }
   },
   "save_saturation": {
     "options": {
-      ".npf": "keyword to indicate that cell saturation will be written to the budget file, which is specified with ``BUDGET SAVE FILE'' in Output Control.  Saturation will be saved to the budget file as an auxiliary variable saved with the DATA-SAT text label.  Saturation is a cell variable that ranges from zero to one and can be used by post processing programs to determine how much of a cell volume is saturated.  If ICELLTYPE is 0, then saturation is always one."
+      "gwf-npf": "keyword to indicate that cell saturation will be written to the budget file, which is specified with ``BUDGET SAVE FILE'' in Output Control.  Saturation will be saved to the budget file as an auxiliary variable saved with the DATA-SAT text label.  Saturation is a cell variable that ranges from zero to one and can be used by post processing programs to determine how much of a cell volume is saturated.  If ICELLTYPE is 0, then saturation is always one."
     }
   },
   "save_specific_discharge": {
     "options": {
-      ".npf": "keyword to indicate that x, y, and z components of specific discharge will be calculated at cell centers and written to the budget file, which is specified with ``BUDGET SAVE FILE'' in Output Control.  If this option is activated, then additional information may be required in the discretization packages and the GWF Exchange package (if GWF models are coupled).  Specifically, ANGLDEGX must be specified in the CONNECTIONDATA block of the DISU Package; ANGLDEGX must also be specified for the GWF Exchange as an auxiliary variable."
+      "gwf-npf": "keyword to indicate that x, y, and z components of specific discharge will be calculated at cell centers and written to the budget file, which is specified with ``BUDGET SAVE FILE'' in Output Control.  If this option is activated, then additional information may be required in the discretization packages and the GWF Exchange package (if GWF models are coupled).  Specifically, ANGLDEGX must be specified in the CONNECTIONDATA block of the DISU Package; ANGLDEGX must also be specified for the GWF Exchange as an auxiliary variable."
     }
   },
   "save_velocity": {
     "options": {
-      ".dfw": "keyword to indicate that x, y, and z components of velocity will be calculated at cell centers and written to the budget file, which is specified with ``BUDGET SAVE FILE'' in Output Control.  If this option is activated, then additional information may be required in the discretization packages and the GWF Exchange package (if GWF models are coupled).  Specifically, ANGLDEGX must be specified in the CONNECTIONDATA block of the DISU Package; ANGLDEGX must also be specified for the GWF Exchange as an auxiliary variable."
+      "chf-dfw": "keyword to indicate that x, y, and z components of velocity will be calculated at cell centers and written to the budget file, which is specified with ``BUDGET SAVE FILE'' in Output Control.  If this option is activated, then additional information may be required in the discretization packages and the GWF Exchange package (if GWF models are coupled).  Specifically, ANGLDEGX must be specified in the CONNECTIONDATA block of the DISU Package; ANGLDEGX must also be specified for the GWF Exchange as an auxiliary variable.",
+      "olf-dfw": "keyword to indicate that x, y, and z components of velocity will be calculated at cell centers and written to the budget file, which is specified with ``BUDGET SAVE FILE'' in Output Control.  If this option is activated, then additional information may be required in the discretization packages and the GWF Exchange package (if GWF models are coupled).  Specifically, ANGLDEGX must be specified in the CONNECTIONDATA block of the DISU Package; ANGLDEGX must also be specified for the GWF Exchange as an auxiliary variable.",
+      "swf-dfw": "keyword to indicate that x, y, and z components of velocity will be calculated at cell centers and written to the budget file, which is specified with ``BUDGET SAVE FILE'' in Output Control.  If this option is activated, then additional information may be required in the discretization packages and the GWF Exchange package (if GWF models are coupled).  Specifically, ANGLDEGX must be specified in the CONNECTIONDATA block of the DISU Package; ANGLDEGX must also be specified for the GWF Exchange as an auxiliary variable."
     }
   },
   "scaling_method": {
     "linear": {
-      ".ims": "an optional keyword that defines the matrix scaling approach used. By default, matrix scaling is not applied.  NONE - no matrix scaling applied.  DIAGONAL - symmetric matrix scaling using the POLCG preconditioner scaling method in Hill (1992).  L2NORM - symmetric matrix scaling using the L2 norm."
+      "sln-ims": "an optional keyword that defines the matrix scaling approach used. By default, matrix scaling is not applied.  NONE - no matrix scaling applied.  DIAGONAL - symmetric matrix scaling using the POLCG preconditioner scaling method in Hill (1992).  L2NORM - symmetric matrix scaling using the L2 norm."
     }
   },
   "scheme": {
     "options": {
-      ".adv": "scheme used to solve the advection term.  Can be upstream, central, or TVD.  If not specified, upstream weighting is the default weighting scheme."
+      "gwe-adv": "scheme used to solve the advection term.  Can be upstream, central, or TVD.  If not specified, upstream weighting is the default weighting scheme.",
+      "gwt-adv": "scheme used to solve the advection term.  Can be upstream, central, or TVD.  If not specified, upstream weighting is the default weighting scheme."
     }
   },
   "sfac": {
     "attributes": {
-      ".tas": "xxx"
+      "utl-tas": "xxx"
     }
   },
   "sfacs": {
     "attributes": {
-      ".ts": "xxx"
+      "utl-ts": "xxx"
     }
   },
   "sgm": {
     "griddata": {
-      ".csub": "is the specific gravity of moist or unsaturated sediments.  If not specified, then a default value of 1.7 is assigned."
+      "gwf-csub": "is the specific gravity of moist or unsaturated sediments.  If not specified, then a default value of 1.7 is assigned."
     }
   },
   "sgs": {
     "griddata": {
-      ".csub": "is the specific gravity of saturated sediments. If not specified, then a default value of 2.0 is assigned."
+      "gwf-csub": "is the specific gravity of saturated sediments. If not specified, then a default value of 2.0 is assigned."
     }
   },
   "shuffle": {
     "options": {
-      ".ncf": "is the keyword used to turn on the netcdf variable shuffle filter when the deflate option is also set. The shuffle filter has the effect of storing the first byte of all of a variable's values in a chunk contiguously, followed by all the second bytes, etc. This can be an optimization for compression with certain types of data."
+      "utl-ncf": "is the keyword used to turn on the netcdf variable shuffle filter when the deflate option is also set. The shuffle filter has the effect of storing the first byte of all of a variable's values in a chunk contiguously, followed by all the second bytes, etc. This can be an optimization for compression with certain types of data."
     }
   },
   "shut_off": {
     "period": {
-      ".maw": "keyword for activating well shut off capability.  Subsequent values define the minimum and maximum pumping rate that a well must exceed to shutoff or reactivate a well, respectively, during a stress period. SHUT\\_OFF is only applied to injection wells (RATE$<0$) and if HEAD\\_LIMIT is specified (not set to `OFF').  If HEAD\\_LIMIT is specified, SHUT\\_OFF can be deactivated by specifying a minimum value equal to zero. The SHUT\\_OFF option is based on the SHUT\\_OFF functionality available in the MNW2~\\citep{konikow2009} package for MODFLOW-2005. The SHUT\\_OFF option has been included to facilitate backward compatibility with previous versions of MODFLOW but use of the RATE\\_SCALING option instead of the SHUT\\_OFF option is recommended. By default, SHUT\\_OFF is not used."
+      "gwf-maw": "keyword for activating well shut off capability.  Subsequent values define the minimum and maximum pumping rate that a well must exceed to shutoff or reactivate a well, respectively, during a stress period. SHUT\\_OFF is only applied to injection wells (RATE$<0$) and if HEAD\\_LIMIT is specified (not set to `OFF').  If HEAD\\_LIMIT is specified, SHUT\\_OFF can be deactivated by specifying a minimum value equal to zero. The SHUT\\_OFF option is based on the SHUT\\_OFF functionality available in the MNW2~\\citep{konikow2009} package for MODFLOW-2005. The SHUT\\_OFF option has been included to facilitate backward compatibility with previous versions of MODFLOW but use of the RATE\\_SCALING option instead of the SHUT\\_OFF option is recommended. By default, SHUT\\_OFF is not used."
     }
   },
   "shutdown_kappa": {
     "options": {
-      ".maw": "value that defines the weight applied to discharge rate for wells that limit the water level in a discharging well (defined using the HEAD\\_LIMIT keyword in the stress period data). SHUTDOWN\\_KAPPA is used to control discharge rate oscillations when the flow rate from the aquifer is less than the specified flow rate from the aquifer to the well. Values range between 0.0 and 1.0, and larger values increase the weight applied to the well discharge rate. The HEAD\\_LIMIT option has been included to facilitate backward compatibility with previous versions of MODFLOW but use of the RATE\\_SCALING option instead of the HEAD\\_LIMIT option is recommended. By default, SHUTDOWN\\_KAPPA is 0.0001."
+      "gwf-maw": "value that defines the weight applied to discharge rate for wells that limit the water level in a discharging well (defined using the HEAD\\_LIMIT keyword in the stress period data). SHUTDOWN\\_KAPPA is used to control discharge rate oscillations when the flow rate from the aquifer is less than the specified flow rate from the aquifer to the well. Values range between 0.0 and 1.0, and larger values increase the weight applied to the well discharge rate. The HEAD\\_LIMIT option has been included to facilitate backward compatibility with previous versions of MODFLOW but use of the RATE\\_SCALING option instead of the HEAD\\_LIMIT option is recommended. By default, SHUTDOWN\\_KAPPA is 0.0001."
     }
   },
   "shutdown_theta": {
     "options": {
-      ".maw": "value that defines the weight applied to discharge rate for wells that limit the water level in a discharging well (defined using the HEAD\\_LIMIT keyword in the stress period data). SHUTDOWN\\_THETA is used to control discharge rate oscillations when the flow rate from the aquifer is less than the specified flow rate from the aquifer to the well. Values range between 0.0 and 1.0, and larger values increase the weight (decrease under-relaxation) applied to the well discharge rate. The HEAD\\_LIMIT option has been included to facilitate backward compatibility with previous versions of MODFLOW but use of the RATE\\_SCALING option instead of the HEAD\\_LIMIT option is recommended. By default, SHUTDOWN\\_THETA is 0.7."
+      "gwf-maw": "value that defines the weight applied to discharge rate for wells that limit the water level in a discharging well (defined using the HEAD\\_LIMIT keyword in the stress period data). SHUTDOWN\\_THETA is used to control discharge rate oscillations when the flow rate from the aquifer is less than the specified flow rate from the aquifer to the well. Values range between 0.0 and 1.0, and larger values increase the weight (decrease under-relaxation) applied to the well discharge rate. The HEAD\\_LIMIT option has been included to facilitate backward compatibility with previous versions of MODFLOW but use of the RATE\\_SCALING option instead of the HEAD\\_LIMIT option is recommended. By default, SHUTDOWN\\_THETA is 0.7."
     }
   },
   "simulate_et": {
     "options": {
-      ".uzf": "keyword specifying that ET in the unsaturated (UZF) and saturated zones (GWF) will be simulated. ET can be simulated in the UZF cell and not the GWF cell by omitting keywords LINEAR\\_GWET and SQUARE\\_GWET."
+      "gwf-uzf": "keyword specifying that ET in the unsaturated (UZF) and saturated zones (GWF) will be simulated. ET can be simulated in the UZF cell and not the GWF cell by omitting keywords LINEAR\\_GWET and SQUARE\\_GWET."
     }
   },
   "simulate_gwseep": {
     "options": {
-      ".uzf": "keyword specifying that groundwater discharge (GWSEEP) to land surface will be simulated. Groundwater discharge is nonzero when groundwater head is greater than land surface.  This option is no longer recommended; a better approach is to use the Drain Package with discharge scaling as a way to handle seepage to land surface.  The Drain Package with discharge scaling is described in Chapter 3 of the Supplemental Technical Information. "
+      "gwf-uzf": "keyword specifying that groundwater discharge (GWSEEP) to land surface will be simulated. Groundwater discharge is nonzero when groundwater head is greater than land surface.  This option is no longer recommended; a better approach is to use the Drain Package with discharge scaling as a way to handle seepage to land surface.  The Drain Package with discharge scaling is described in Chapter 3 of the Supplemental Technical Information. "
     }
   },
   "slope": {
     "period": {
-      ".lak": "real or character value that defines the bed slope for the lake outlet. A specified SLOPE value is only used for active lakes if COUTTYPE for lake outlet OUTLETNO is MANNING. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+      "gwf-lak": "real or character value that defines the bed slope for the lake outlet. A specified SLOPE value is only used for active lakes if COUTTYPE for lake outlet OUTLETNO is MANNING. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
     }
   },
   "solutiongroup": {
     "solutiongroup": {
-      ".nam": "is the list of solution types and models in the solution."
+      "sim-nam": "is the list of solution types and models in the solution."
     }
   },
   "sorbate": {
     "options": {
-      ".ist": "keyword to specify that record corresponds to immobile sorbate concentration.",
-      ".mst": "keyword to specify that record corresponds to sorbate concentration."
+      "gwt-ist": "keyword to specify that record corresponds to immobile sorbate concentration.",
+      "gwt-mst": "keyword to specify that record corresponds to sorbate concentration."
     }
   },
   "sorption": {
     "options": {
-      ".ist": "is a text keyword to indicate that sorption will be activated.  Valid sorption options include LINEAR, FREUNDLICH, and LANGMUIR.  Use of this keyword requires that BULK\\_DENSITY and DISTCOEF are specified in the GRIDDATA block.  If sorption is specified as FREUNDLICH or LANGMUIR then SP2 is also required in the GRIDDATA block.  The sorption option must be consistent with the sorption option specified in the MST Package or the program will terminate with an error.",
-      ".mst": "is a text keyword to indicate that sorption will be activated.  Valid sorption options include LINEAR, FREUNDLICH, and LANGMUIR.  Use of this keyword requires that BULK\\_DENSITY and DISTCOEF are specified in the GRIDDATA block.  If sorption is specified as FREUNDLICH or LANGMUIR then SP2 is also required in the GRIDDATA block."
+      "gwt-ist": "is a text keyword to indicate that sorption will be activated.  Valid sorption options include LINEAR, FREUNDLICH, and LANGMUIR.  Use of this keyword requires that BULK\\_DENSITY and DISTCOEF are specified in the GRIDDATA block.  If sorption is specified as FREUNDLICH or LANGMUIR then SP2 is also required in the GRIDDATA block.  The sorption option must be consistent with the sorption option specified in the MST Package or the program will terminate with an error.",
+      "gwt-mst": "is a text keyword to indicate that sorption will be activated.  Valid sorption options include LINEAR, FREUNDLICH, and LANGMUIR.  Use of this keyword requires that BULK\\_DENSITY and DISTCOEF are specified in the GRIDDATA block.  If sorption is specified as FREUNDLICH or LANGMUIR then SP2 is also required in the GRIDDATA block."
     }
   },
   "sp2": {
     "griddata": {
-      ".ist": "is the exponent for the Freundlich isotherm and the sorption capacity for the Langmuir isotherm.  sp2 is not required unless the SORPTION keyword is specified in the options block and sorption is specified as FREUNDLICH or LANGMUIR. If the SORPTION keyword is not specified in the options block, or if sorption is specified as LINEAR, sp2 will have no effect on simulation results. ",
-      ".mst": "is the exponent for the Freundlich isotherm and the sorption capacity for the Langmuir isotherm.  sp2 is not required unless the SORPTION keyword is specified in the options block.  If the SORPTION keyword is not specified in the options block, sp2 will have no effect on simulation results. "
+      "gwt-ist": "is the exponent for the Freundlich isotherm and the sorption capacity for the Langmuir isotherm.  sp2 is not required unless the SORPTION keyword is specified in the options block and sorption is specified as FREUNDLICH or LANGMUIR. If the SORPTION keyword is not specified in the options block, or if sorption is specified as LINEAR, sp2 will have no effect on simulation results. ",
+      "gwt-mst": "is the exponent for the Freundlich isotherm and the sorption capacity for the Langmuir isotherm.  sp2 is not required unless the SORPTION keyword is specified in the options block.  If the SORPTION keyword is not specified in the options block, sp2 will have no effect on simulation results. "
     }
   },
   "specified_initial_delay_head": {
     "options": {
-      ".csub": "keyword to indicate that absolute initial delay bed head will be specified for interbeds defined in the PACKAGEDATA block. If SPECIFIED\\_INITIAL\\_DELAY\\_HEAD and SPECIFIED\\_INITIAL\\_INTERBED\\_STATE are not specified then delay bed head values specified in the PACKAGEDATA block are relative to simulated values if the first stress period is steady-state or initial GWF heads if the first stress period is transient."
+      "gwf-csub": "keyword to indicate that absolute initial delay bed head will be specified for interbeds defined in the PACKAGEDATA block. If SPECIFIED\\_INITIAL\\_DELAY\\_HEAD and SPECIFIED\\_INITIAL\\_INTERBED\\_STATE are not specified then delay bed head values specified in the PACKAGEDATA block are relative to simulated values if the first stress period is steady-state or initial GWF heads if the first stress period is transient."
     }
   },
   "specified_initial_interbed_state": {
     "options": {
-      ".csub": "keyword to indicate that absolute preconsolidation stresses (heads) and delay bed heads will be specified for interbeds defined in the PACKAGEDATA block. The SPECIFIED\\_INITIAL\\_INTERBED\\_STATE option is equivalent to specifying the SPECIFIED\\_INITIAL\\_PRECONSOLITATION\\_STRESS and SPECIFIED\\_INITIAL\\_DELAY\\_HEAD. If SPECIFIED\\_INITIAL\\_INTERBED\\_STATE is not specified then preconsolidation stress (head) and delay bed head values specified in the PACKAGEDATA block are relative to simulated values of the first stress period if steady-state or initial stresses and GWF heads if the first stress period is transient."
+      "gwf-csub": "keyword to indicate that absolute preconsolidation stresses (heads) and delay bed heads will be specified for interbeds defined in the PACKAGEDATA block. The SPECIFIED\\_INITIAL\\_INTERBED\\_STATE option is equivalent to specifying the SPECIFIED\\_INITIAL\\_PRECONSOLITATION\\_STRESS and SPECIFIED\\_INITIAL\\_DELAY\\_HEAD. If SPECIFIED\\_INITIAL\\_INTERBED\\_STATE is not specified then preconsolidation stress (head) and delay bed head values specified in the PACKAGEDATA block are relative to simulated values of the first stress period if steady-state or initial stresses and GWF heads if the first stress period is transient."
     }
   },
   "specified_initial_preconsolidation_stress": {
     "options": {
-      ".csub": "keyword to indicate that absolute preconsolidation stresses (heads) will be specified for interbeds defined in the PACKAGEDATA block. If SPECIFIED\\_INITIAL\\_PRECONSOLITATION\\_STRESS and SPECIFIED\\_INITIAL\\_INTERBED\\_STATE are not specified then preconsolidation stress (head) values specified in the PACKAGEDATA block are relative to simulated values if the first stress period is steady-state or initial stresses (heads) if the first stress period is transient."
+      "gwf-csub": "keyword to indicate that absolute preconsolidation stresses (heads) will be specified for interbeds defined in the PACKAGEDATA block. If SPECIFIED\\_INITIAL\\_PRECONSOLITATION\\_STRESS and SPECIFIED\\_INITIAL\\_INTERBED\\_STATE are not specified then preconsolidation stress (head) values specified in the PACKAGEDATA block are relative to simulated values if the first stress period is steady-state or initial stresses (heads) if the first stress period is transient."
     }
   },
   "square_gwet": {
     "options": {
-      ".uzf": "keyword specifying that groundwater ET will be simulated by assuming a constant ET rate for groundwater levels between land surface (TOP) and land surface minus the ET extinction depth (TOP-EXTDP). Groundwater ET is smoothly reduced from the PET rate to zero over a nominal interval at TOP-EXTDP."
+      "gwf-uzf": "keyword specifying that groundwater ET will be simulated by assuming a constant ET rate for groundwater levels between land surface (TOP) and land surface minus the ET extinction depth (TOP-EXTDP). Groundwater ET is smoothly reduced from the PET rate to zero over a nominal interval at TOP-EXTDP."
     }
   },
   "ss": {
     "griddata": {
-      ".sto": "is specific storage (or the storage coefficient if STORAGECOEFFICIENT is specified as an option). Specific storage values must be greater than or equal to 0. If the CSUB Package is included in the GWF model, specific storage must be zero for every cell."
+      "gwf-sto": "is specific storage (or the storage coefficient if STORAGECOEFFICIENT is specified as an option). Specific storage values must be greater than or equal to 0. If the CSUB Package is included in the GWF model, specific storage must be zero for every cell."
     },
     "period": {
-      ".tvs": "is the new value to be assigned as the cell's specific storage (or storage coefficient if the STORAGECOEFFICIENT STO package option is specified) from the start of the specified stress period, as per SS in the STO package.  Specific storage values must be greater than or equal to 0.  If the OPTIONS block includes a TS6 entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+      "utl-tvs": "is the new value to be assigned as the cell's specific storage (or storage coefficient if the STORAGECOEFFICIENT STO package option is specified) from the start of the specified stress period, as per SS in the STO package.  Specific storage values must be greater than or equal to 0.  If the OPTIONS block includes a TS6 entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
     }
   },
   "ss_confined_only": {
     "options": {
-      ".sto": "keyword to indicate that compressible storage is only calculated for a convertible cell (ICONVERT>0) when the cell is under confined conditions (head greater than or equal to the top of the cell). This option has no effect on cells that are marked as being always confined (ICONVERT=0).  This option is identical to the approach used to calculate storage changes under confined conditions in MODFLOW-2005."
+      "gwf-sto": "keyword to indicate that compressible storage is only calculated for a convertible cell (ICONVERT>0) when the cell is under confined conditions (head greater than or equal to the top of the cell). This option has no effect on cells that are marked as being always confined (ICONVERT=0).  This option is identical to the approach used to calculate storage changes under confined conditions in MODFLOW-2005."
     }
   },
   "stage": {
     "options": {
-      ".lak": "keyword to specify that record corresponds to stage.",
-      ".oc": "keyword to specify that record corresponds to stage.",
-      ".sfr": "keyword to specify that record corresponds to stage."
+      "chf-oc": "keyword to specify that record corresponds to stage.",
+      "gwf-lak": "keyword to specify that record corresponds to stage.",
+      "gwf-sfr": "keyword to specify that record corresponds to stage.",
+      "olf-oc": "keyword to specify that record corresponds to stage.",
+      "swf-oc": "keyword to specify that record corresponds to stage."
     },
     "period": {
-      ".lak": "real or character value that defines the stage for the lake. The specified STAGE is only applied if the lake is a constant stage lake. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      ".sfr": "real or character value that defines the stage for the reach. The specified STAGE is only applied if the reach uses the simple routing option. If STAGE is not specified for reaches that use the simple routing option, the specified stage is set to the top of the reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+      "gwf-lak": "real or character value that defines the stage for the lake. The specified STAGE is only applied if the lake is a constant stage lake. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      "gwf-sfr": "real or character value that defines the stage for the reach. The specified STAGE is only applied if the reach uses the simple routing option. If STAGE is not specified for reaches that use the simple routing option, the specified stage is set to the top of the reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
     }
   },
   "start_date_time": {
     "options": {
-      ".tdis": "is the starting date and time of the simulation.  This is a text string that is used as a label within the simulation list file.  The value has no effect on the simulation.  The recommended format for the starting date and time is described at https://www.w3.org/TR/NOTE-datetime."
+      "sim-tdis": "is the starting date and time of the simulation.  This is a text string that is used as a label within the simulation list file.  The value has no effect on the simulation.  The recommended format for the starting date and time is described at https://www.w3.org/TR/NOTE-datetime."
     }
   },
   "status": {
     "period": {
-      ".lak": "keyword option to define lake status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE.",
-      ".lke": "keyword option to define lake status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that temperature will be calculated for the lake.  If a lake is inactive, then there will be no energy fluxes into or out of the lake and the inactive value will be written for the lake temperature.  If a lake is constant, then the temperature for the lake will be fixed at the user specified value.",
-      ".lkt": "keyword option to define lake status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that concentration will be calculated for the lake.  If a lake is inactive, then there will be no solute mass fluxes into or out of the lake and the inactive value will be written for the lake concentration.  If a lake is constant, then the concentration for the lake will be fixed at the user specified value.",
-      ".maw": "keyword option to define well status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE.",
-      ".mwe": "keyword option to define well status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that temperature will be calculated for the well.  If a well is inactive, then there will be no solute mass fluxes into or out of the well and the inactive value will be written for the well temperature.  If a well is constant, then the temperature for the well will be fixed at the user specified value.",
-      ".mwt": "keyword option to define well status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that concentration will be calculated for the well.  If a well is inactive, then there will be no solute mass fluxes into or out of the well and the inactive value will be written for the well concentration.  If a well is constant, then the concentration for the well will be fixed at the user specified value.",
-      ".sfe": "keyword option to define reach status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that temperature will be calculated for the reach.  If a reach is inactive, then there will be no energy fluxes into or out of the reach and the inactive value will be written for the reach temperature.  If a reach is constant, then the temperature for the reach will be fixed at the user specified value.",
-      ".sfr": "keyword option to define stream reach status.  STATUS can be ACTIVE, INACTIVE, or SIMPLE. The SIMPLE STATUS option simulates streamflow using a user-specified stage for a reach or a stage set to the top of the reach (depth = 0). In cases where the simulated leakage calculated using the specified stage exceeds the sum of inflows to the reach, the stage is set to the top of the reach and leakage is set equal to the sum of inflows. Upstream fractions should be changed using the UPSTREAM\\_FRACTION SFRSETTING if the status for one or more reaches is changed to ACTIVE or INACTIVE. For example, if one of two downstream connections for a reach is inactivated, the upstream fraction for the active and inactive downstream reach should be changed to 1.0 and 0.0, respectively, to ensure that the active reach receives all of the downstream outflow from the upstream reach. By default, STATUS is ACTIVE.",
-      ".sft": "keyword option to define reach status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that concentration will be calculated for the reach.  If a reach is inactive, then there will be no solute mass fluxes into or out of the reach and the inactive value will be written for the reach concentration.  If a reach is constant, then the concentration for the reach will be fixed at the user specified value.",
-      ".uze": "keyword option to define UZF cell status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that temperature will be calculated for the UZF cell.  If a UZF cell is inactive, then there will be no energy fluxes into or out of the UZF cell and the inactive value will be written for the UZF cell temperature.  If a UZF cell is constant, then the temperature for the UZF cell will be fixed at the user specified value.",
-      ".uzt": "keyword option to define UZF cell status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that concentration will be calculated for the UZF cell.  If a UZF cell is inactive, then there will be no solute mass fluxes into or out of the UZF cell and the inactive value will be written for the UZF cell concentration.  If a UZF cell is constant, then the concentration for the UZF cell will be fixed at the user specified value."
+      "gwe-lke": "keyword option to define lake status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that temperature will be calculated for the lake.  If a lake is inactive, then there will be no energy fluxes into or out of the lake and the inactive value will be written for the lake temperature.  If a lake is constant, then the temperature for the lake will be fixed at the user specified value.",
+      "gwe-mwe": "keyword option to define well status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that temperature will be calculated for the well.  If a well is inactive, then there will be no solute mass fluxes into or out of the well and the inactive value will be written for the well temperature.  If a well is constant, then the temperature for the well will be fixed at the user specified value.",
+      "gwe-sfe": "keyword option to define reach status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that temperature will be calculated for the reach.  If a reach is inactive, then there will be no energy fluxes into or out of the reach and the inactive value will be written for the reach temperature.  If a reach is constant, then the temperature for the reach will be fixed at the user specified value.",
+      "gwe-uze": "keyword option to define UZF cell status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that temperature will be calculated for the UZF cell.  If a UZF cell is inactive, then there will be no energy fluxes into or out of the UZF cell and the inactive value will be written for the UZF cell temperature.  If a UZF cell is constant, then the temperature for the UZF cell will be fixed at the user specified value.",
+      "gwf-lak": "keyword option to define lake status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE.",
+      "gwf-maw": "keyword option to define well status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE.",
+      "gwf-sfr": "keyword option to define stream reach status.  STATUS can be ACTIVE, INACTIVE, or SIMPLE. The SIMPLE STATUS option simulates streamflow using a user-specified stage for a reach or a stage set to the top of the reach (depth = 0). In cases where the simulated leakage calculated using the specified stage exceeds the sum of inflows to the reach, the stage is set to the top of the reach and leakage is set equal to the sum of inflows. Upstream fractions should be changed using the UPSTREAM\\_FRACTION SFRSETTING if the status for one or more reaches is changed to ACTIVE or INACTIVE. For example, if one of two downstream connections for a reach is inactivated, the upstream fraction for the active and inactive downstream reach should be changed to 1.0 and 0.0, respectively, to ensure that the active reach receives all of the downstream outflow from the upstream reach. By default, STATUS is ACTIVE.",
+      "gwt-lkt": "keyword option to define lake status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that concentration will be calculated for the lake.  If a lake is inactive, then there will be no solute mass fluxes into or out of the lake and the inactive value will be written for the lake concentration.  If a lake is constant, then the concentration for the lake will be fixed at the user specified value.",
+      "gwt-mwt": "keyword option to define well status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that concentration will be calculated for the well.  If a well is inactive, then there will be no solute mass fluxes into or out of the well and the inactive value will be written for the well concentration.  If a well is constant, then the concentration for the well will be fixed at the user specified value.",
+      "gwt-sft": "keyword option to define reach status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that concentration will be calculated for the reach.  If a reach is inactive, then there will be no solute mass fluxes into or out of the reach and the inactive value will be written for the reach concentration.  If a reach is constant, then the concentration for the reach will be fixed at the user specified value.",
+      "gwt-uzt": "keyword option to define UZF cell status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that concentration will be calculated for the UZF cell.  If a UZF cell is inactive, then there will be no solute mass fluxes into or out of the UZF cell and the inactive value will be written for the UZF cell concentration.  If a UZF cell is constant, then the concentration for the UZF cell will be fixed at the user specified value."
     }
   },
   "steady-state": {
     "period": {
-      ".sto": "keyword to indicate that stress period IPER is steady-state. Steady-state conditions will apply until the TRANSIENT keyword is specified in a subsequent BEGIN PERIOD block."
+      "chf-sto": "keyword to indicate that stress period IPER is steady-state. Steady-state conditions will apply until the TRANSIENT keyword is specified in a subsequent BEGIN PERIOD block.",
+      "gwf-sto": "keyword to indicate that stress period IPER is steady-state. Steady-state conditions will apply until the TRANSIENT keyword is specified in a subsequent BEGIN PERIOD block. If the CSUB Package is included in the GWF model, only the first and last stress period can be steady-state.",
+      "olf-sto": "keyword to indicate that stress period IPER is steady-state. Steady-state conditions will apply until the TRANSIENT keyword is specified in a subsequent BEGIN PERIOD block.",
+      "swf-sto": "keyword to indicate that stress period IPER is steady-state. Steady-state conditions will apply until the TRANSIENT keyword is specified in a subsequent BEGIN PERIOD block."
     }
   },
   "steps": {
     "period": {
-      ".oc": "save for each step specified in STEPS. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
-      ".prp": "release at the start of each step specified in STEPS. This option may be used in conjunction with other RELEASESETTING options."
+      "chf-oc": "save for each step specified in STEPS. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
+      "gwe-oc": "save for each step specified in STEPS. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
+      "gwf-oc": "save for each step specified in STEPS. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
+      "gwt-oc": "save for each step specified in STEPS. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
+      "olf-oc": "save for each step specified in STEPS. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
+      "prt-oc": "save for each step specified in STEPS. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps.",
+      "prt-prp": "release at the start of each step specified in STEPS. This option may be used in conjunction with other RELEASESETTING options.",
+      "swf-oc": "save for each step specified in STEPS. This keyword may be used in conjunction with other keywords to print or save results for multiple time steps."
     }
   },
   "stop_at_weak_sink": {
     "options": {
-      ".prp": "is a text keyword to indicate that a particle is to terminate when it enters a cell that is a weak sink.  By default, particles are allowed to pass though cells that are weak sinks."
+      "prt-prp": "is a text keyword to indicate that a particle is to terminate when it enters a cell that is a weak sink.  By default, particles are allowed to pass though cells that are weak sinks."
     }
   },
   "stoptime": {
     "options": {
-      ".prp": "real value defining the maximum simulation time to which particles in the package can be tracked.  Particles that have not terminated earlier due to another termination condition will terminate when simulation time STOPTIME is reached.  If the last stress period in the simulation consists of more than one time step, particles will not be tracked past the ending time of the last stress period, regardless of STOPTIME.  If the EXTEND\\_TRACKING option is enabled and the last stress period in the simulation is steady-state, the simulation ending time will not limit the time to which particles can be tracked, but STOPTIME and STOPTRAVELTIME will continue to apply.  If STOPTIME and STOPTRAVELTIME are both provided, particles will be stopped if either is reached."
+      "prt-prp": "real value defining the maximum simulation time to which particles in the package can be tracked.  Particles that have not terminated earlier due to another termination condition will terminate when simulation time STOPTIME is reached.  If the last stress period in the simulation consists of more than one time step, particles will not be tracked past the ending time of the last stress period, regardless of STOPTIME.  If the EXTEND\\_TRACKING option is enabled and the last stress period in the simulation is steady-state, the simulation ending time will not limit the time to which particles can be tracked, but STOPTIME and STOPTRAVELTIME will continue to apply.  If STOPTIME and STOPTRAVELTIME are both provided, particles will be stopped if either is reached."
     }
   },
   "stoptraveltime": {
     "options": {
-      ".prp": "real value defining the maximum travel time over which particles in the model can be tracked.  Particles that have not terminated earlier due to another termination condition will terminate when their travel time reaches STOPTRAVELTIME.  If the last stress period in the simulation consists of more than one time step, particles will not be tracked past the ending time of the last stress period, regardless of STOPTRAVELTIME.  If the EXTEND\\_TRACKING option is enabled and the last stress period in the simulation is steady-state, the simulation ending time will not limit the time to which particles can be tracked, but STOPTIME and STOPTRAVELTIME will continue to apply.  If STOPTIME and STOPTRAVELTIME are both provided, particles will be stopped if either is reached."
+      "prt-prp": "real value defining the maximum travel time over which particles in the model can be tracked.  Particles that have not terminated earlier due to another termination condition will terminate when their travel time reaches STOPTRAVELTIME.  If the last stress period in the simulation consists of more than one time step, particles will not be tracked past the ending time of the last stress period, regardless of STOPTRAVELTIME.  If the EXTEND\\_TRACKING option is enabled and the last stress period in the simulation is steady-state, the simulation ending time will not limit the time to which particles can be tracked, but STOPTIME and STOPTRAVELTIME will continue to apply.  If STOPTIME and STOPTRAVELTIME are both provided, particles will be stopped if either is reached."
     }
   },
   "storage": {
     "options": {
-      ".sfr": "keyword that activates storage contributions to the stream-flow routing package continuity equation."
+      "gwf-sfr": "keyword that activates storage contributions to the stream-flow routing package continuity equation."
     }
   },
   "storagecoefficient": {
     "options": {
-      ".sto": "keyword to indicate that the SS array is read as storage coefficient rather than specific storage."
+      "gwf-sto": "keyword to indicate that the SS array is read as storage coefficient rather than specific storage."
     }
   },
   "strain_csv_coarse": {
     "options": {
-      ".csub": "keyword to specify the record that corresponds to final coarse-grained material strain output."
+      "gwf-csub": "keyword to specify the record that corresponds to final coarse-grained material strain output."
     }
   },
   "strain_csv_interbed": {
     "options": {
-      ".csub": "keyword to specify the record that corresponds to final interbed strain output."
+      "gwf-csub": "keyword to specify the record that corresponds to final interbed strain output."
     }
   },
   "strt": {
     "griddata": {
-      ".ic": "is the initial (starting) concentration---that is, concentration at the beginning of the GWT Model simulation.  STRT must be specified for all GWT Model simulations. One value is read for every model cell."
+      "chf-ic": "is the initial (starting) stage---that is, stage at the beginning of the CHF Model simulation.  STRT must be specified for all CHF Model simulations. One value is read for every model reach.",
+      "gwe-ic": "is the initial (starting) temperature---that is, the temperature at the beginning of the GWE Model simulation.  STRT must be specified for all GWE Model simulations. One value is read for every model cell.",
+      "gwf-ic": "is the initial (starting) head---that is, head at the beginning of the GWF Model simulation.  STRT must be specified for all simulations, including steady-state simulations. One value is read for every model cell. For simulations in which the first stress period is steady state, the values used for STRT generally do not affect the simulation (exceptions may occur if cells go dry and (or) rewet). The execution time, however, will be less if STRT includes hydraulic heads that are close to the steady-state solution.  A head value lower than the cell bottom can be provided if a cell should start as dry.",
+      "gwt-ic": "is the initial (starting) concentration---that is, concentration at the beginning of the GWT Model simulation.  STRT must be specified for all GWT Model simulations. One value is read for every model cell.",
+      "olf-ic": "is the initial (starting) stage---that is, stage at the beginning of the OLF Model simulation.  STRT must be specified for all OLF Model simulations. One value is read for every model reach.",
+      "swf-ic": "is the initial (starting) stage---that is, stage at the beginning of the SWF Model simulation.  STRT must be specified for all SWF Model simulations. One value is read for every model reach."
     }
   },
   "surf_rate_specified": {
     "options": {
-      ".evt": "indicates that the proportion of the evapotranspiration rate at the ET surface will be specified as PETM0 in list input."
+      "gwf-evt": "indicates that the proportion of the evapotranspiration rate at the ET surface will be specified as PETM0 in list input."
     }
   },
   "surface": {
     "period": {
-      ".evta": "is the elevation of the ET surface ($L$)."
+      "gwf-evta": "is the elevation of the ET surface ($L$)."
     }
   },
   "surfdep": {
     "options": {
-      ".lak": "real value that defines the surface depression depth for VERTICAL lake-GWF connections. If specified, SURFDEP must be greater than or equal to zero. If SURFDEP is not specified, a default value of zero is used for all vertical lake-GWF connections."
+      "gwf-lak": "real value that defines the surface depression depth for VERTICAL lake-GWF connections. If specified, SURFDEP must be greater than or equal to zero. If SURFDEP is not specified, a default value of zero is used for all vertical lake-GWF connections."
     }
   },
   "sy": {
     "griddata": {
-      ".sto": "is specific yield. Specific yield values must be greater than or equal to 0. Specific yield does not have to be specified if there are no convertible cells (ICONVERT=0 in every cell)."
+      "gwf-sto": "is specific yield. Specific yield values must be greater than or equal to 0. Specific yield does not have to be specified if there are no convertible cells (ICONVERT=0 in every cell)."
     },
     "period": {
-      ".tvs": "is the new value to be assigned as the cell's specific yield from the start of the specified stress period, as per SY in the STO package.  Specific yield values must be greater than or equal to 0.  If the OPTIONS block includes a TS6 entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+      "utl-tvs": "is the new value to be assigned as the cell's specific yield from the start of the specified stress period, as per SY in the STO package.  Specific yield values must be greater than or equal to 0.  If the OPTIONS block includes a TS6 entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
     }
   },
   "tab6": {
     "crosssections": {
-      ".sfr": "keyword to specify that record corresponds to a cross-section table file."
+      "gwf-sfr": "keyword to specify that record corresponds to a cross-section table file."
     },
     "period": {
-      ".sfr": "keyword to specify that record corresponds to a cross-section table file."
+      "gwf-sfr": "keyword to specify that record corresponds to a cross-section table file."
     },
     "tables": {
-      ".lak": "keyword to specify that record corresponds to a table file."
+      "gwf-lak": "keyword to specify that record corresponds to a table file."
     }
   },
   "tas6": {
     "options": {
-      ".evta": "keyword to specify that record corresponds to a time-array-series file.",
-      ".rcha": "keyword to specify that record corresponds to a time-array-series file.",
-      ".spca": "keyword to specify that record corresponds to a time-array-series file."
+      "gwf-evta": "keyword to specify that record corresponds to a time-array-series file.",
+      "gwf-rcha": "keyword to specify that record corresponds to a time-array-series file.",
+      "utl-spca": "keyword to specify that record corresponds to a time-array-series file."
     }
   },
   "tdis6": {
     "timing": {
-      ".nam": "is the name of the Temporal Discretization (TDIS) Input File."
+      "sim-nam": "is the name of the Temporal Discretization (TDIS) Input File."
     }
   },
   "temperature": {
     "options": {
-      ".lke": "keyword to specify that record corresponds to temperature.",
-      ".mwe": "keyword to specify that record corresponds to temperature.",
-      ".oc": "keyword to specify that record corresponds to temperature.",
-      ".sfe": "keyword to specify that record corresponds to temperature.",
-      ".uze": "keyword to specify that record corresponds to temperature."
+      "gwe-lke": "keyword to specify that record corresponds to temperature.",
+      "gwe-mwe": "keyword to specify that record corresponds to temperature.",
+      "gwe-oc": "keyword to specify that record corresponds to temperature.",
+      "gwe-sfe": "keyword to specify that record corresponds to temperature.",
+      "gwe-uze": "keyword to specify that record corresponds to temperature."
     },
     "period": {
-      ".lke": "real or character value that defines the temperature for the lake. The specified TEMPERATURE is only applied if the lake is a constant temperature lake. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      ".mwe": "real or character value that defines the temperature for the well. The specified TEMPERATURE is only applied if the well is a constant temperature well. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      ".sfe": "real or character value that defines the temperature for the reach. The specified TEMPERATURE is only applied if the reach is a constant temperature reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      ".spc": "is the user-supplied boundary temperature. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, the TEMPERATURE for each boundary feature is zero.",
-      ".spca": "is the temperature of the associated Recharge or Evapotranspiration stress package.  The temperature array may be defined by a time-array series (see the \"Using Time-Array Series in a Package\" section).",
-      ".uze": "real or character value that defines the temperature for the unsaturated zone flow cell. The specified TEMPERATURE is only applied if the unsaturated zone flow cell is a constant temperature cell. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+      "gwe-lke": "real or character value that defines the temperature for the lake. The specified TEMPERATURE is only applied if the lake is a constant temperature lake. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      "gwe-mwe": "real or character value that defines the temperature for the well. The specified TEMPERATURE is only applied if the well is a constant temperature well. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      "gwe-sfe": "real or character value that defines the temperature for the reach. The specified TEMPERATURE is only applied if the reach is a constant temperature reach. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      "gwe-uze": "real or character value that defines the temperature for the unsaturated zone flow cell. The specified TEMPERATURE is only applied if the unsaturated zone flow cell is a constant temperature cell. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      "utl-spc": "is the user-supplied boundary temperature. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, the TEMPERATURE for each boundary feature is zero.",
+      "utl-spca": "is the temperature of the associated Recharge or Evapotranspiration stress package.  The temperature array may be defined by a time-array series (see the \"Using Time-Array Series in a Package\" section)."
     }
   },
   "temperature_species_name": {
     "options": {
-      ".vsc": "string used to identify the auxspeciesname in PACKAGEDATA that corresponds to the temperature species.  There can be only one occurrence of this temperature species name in the PACKAGEDATA block or the program will terminate with an error.  This value has no effect if viscosity does not depend on temperature."
+      "gwf-vsc": "string used to identify the auxspeciesname in PACKAGEDATA that corresponds to the temperature species.  There can be only one occurrence of this temperature species name in the PACKAGEDATA block or the program will terminate with an error.  This value has no effect if viscosity does not depend on temperature."
     }
   },
   "thermal_a2": {
     "options": {
-      ".vsc": "is an empirical parameter specified by the user for calculating viscosity using a nonlinear formulation.  If A2 is not specified, a default value of 10.0 is assigned (Voss, 1984). "
+      "gwf-vsc": "is an empirical parameter specified by the user for calculating viscosity using a nonlinear formulation.  If A2 is not specified, a default value of 10.0 is assigned (Voss, 1984). "
     }
   },
   "thermal_a3": {
     "options": {
-      ".vsc": "is an empirical parameter specified by the user for calculating viscosity using a nonlinear formulation.  If A3 is not specified, a default value of 248.37 is assigned (Voss, 1984). "
+      "gwf-vsc": "is an empirical parameter specified by the user for calculating viscosity using a nonlinear formulation.  If A3 is not specified, a default value of 248.37 is assigned (Voss, 1984). "
     }
   },
   "thermal_a4": {
     "options": {
-      ".vsc": "is an empirical parameter specified by the user for calculating viscosity using a nonlinear formulation.  If A4 is not specified, a default value of 133.15 is assigned (Voss, 1984). "
+      "gwf-vsc": "is an empirical parameter specified by the user for calculating viscosity using a nonlinear formulation.  If A4 is not specified, a default value of 133.15 is assigned (Voss, 1984). "
     }
   },
   "thermal_formulation": {
     "options": {
-      ".vsc": "may be used for specifying which viscosity formulation to use for the temperature species. Can be either LINEAR or NONLINEAR. The LINEAR viscosity formulation is the default."
+      "gwf-vsc": "may be used for specifying which viscosity formulation to use for the temperature species. Can be either LINEAR or NONLINEAR. The LINEAR viscosity formulation is the default."
     }
   },
   "thickstrt": {
     "options": {
-      ".npf": "indicates that cells having a negative ICELLTYPE are confined, and their cell thickness for conductance calculations will be computed as STRT-BOT rather than TOP-BOT.  This option should be used with caution as it only affects conductance calculations in the NPF Package."
+      "gwf-npf": "indicates that cells having a negative ICELLTYPE are confined, and their cell thickness for conductance calculations will be computed as STRT-BOT rather than TOP-BOT.  This option should be used with caution as it only affects conductance calculations in the NPF Package."
     }
   },
   "time_conversion": {
     "options": {
-      ".dfw": "real value that is used to convert user-specified Manning's roughness coefficients from seconds to model time units. TIME\\_CONVERSION should be set to 1.0, 60.0, 3,600.0, 86,400.0, and 31,557,600.0 when using time units (TIME\\_UNITS) of seconds, minutes, hours, days, or years in the simulation, respectively. TIME\\_CONVERSION does not need to be specified if TIME\\_UNITS are seconds.",
-      ".lak": "real value that is used to convert user-specified Manning's roughness coefficients or gravitational acceleration used to calculate outlet flows from seconds to model time units. TIME\\_CONVERSION should be set to 1.0, 60.0, 3,600.0, 86,400.0, and 31,557,600.0 when using time units (TIME\\_UNITS) of seconds, minutes, hours, days, or years in the simulation, respectively. CONVTIME does not need to be specified if no lake outlets are specified or TIME\\_UNITS are seconds.",
-      ".sfr": "real value that is used to convert user-specified Manning's roughness coefficients from seconds to model time units. TIME\\_CONVERSION should be set to 1.0, 60.0, 3,600.0, 86,400.0, and 31,557,600.0 when using time units (TIME\\_UNITS) of seconds, minutes, hours, days, or years in the simulation, respectively. TIME\\_CONVERSION does not need to be specified if TIME\\_UNITS are seconds."
+      "chf-dfw": "real value that is used to convert user-specified Manning's roughness coefficients from seconds to model time units. TIME\\_CONVERSION should be set to 1.0, 60.0, 3,600.0, 86,400.0, and 31,557,600.0 when using time units (TIME\\_UNITS) of seconds, minutes, hours, days, or years in the simulation, respectively. TIME\\_CONVERSION does not need to be specified if TIME\\_UNITS are seconds.",
+      "gwf-lak": "real value that is used to convert user-specified Manning's roughness coefficients or gravitational acceleration used to calculate outlet flows from seconds to model time units. TIME\\_CONVERSION should be set to 1.0, 60.0, 3,600.0, 86,400.0, and 31,557,600.0 when using time units (TIME\\_UNITS) of seconds, minutes, hours, days, or years in the simulation, respectively. CONVTIME does not need to be specified if no lake outlets are specified or TIME\\_UNITS are seconds.",
+      "gwf-sfr": "real value that is used to convert user-specified Manning's roughness coefficients from seconds to model time units. TIME\\_CONVERSION should be set to 1.0, 60.0, 3,600.0, 86,400.0, and 31,557,600.0 when using time units (TIME\\_UNITS) of seconds, minutes, hours, days, or years in the simulation, respectively. TIME\\_CONVERSION does not need to be specified if TIME\\_UNITS are seconds.",
+      "olf-dfw": "real value that is used to convert user-specified Manning's roughness coefficients from seconds to model time units. TIME\\_CONVERSION should be set to 1.0, 60.0, 3,600.0, 86,400.0, and 31,557,600.0 when using time units (TIME\\_UNITS) of seconds, minutes, hours, days, or years in the simulation, respectively. TIME\\_CONVERSION does not need to be specified if TIME\\_UNITS are seconds.",
+      "swf-dfw": "real value that is used to convert user-specified Manning's roughness coefficients from seconds to model time units. TIME\\_CONVERSION should be set to 1.0, 60.0, 3,600.0, 86,400.0, and 31,557,600.0 when using time units (TIME\\_UNITS) of seconds, minutes, hours, days, or years in the simulation, respectively. TIME\\_CONVERSION does not need to be specified if TIME\\_UNITS are seconds."
     }
   },
   "time_units": {
     "options": {
-      ".tdis": "is the time units of the simulation.  This is a text string that is used as a label within model output files.  Values for time\\_units may be ``unknown'',  ``seconds'', ``minutes'', ``hours'', ``days'', or ``years''.  The default time unit is ``unknown''."
+      "sim-tdis": "is the time units of the simulation.  This is a text string that is used as a label within model output files.  Values for time\\_units may be ``unknown'',  ``seconds'', ``minutes'', ``hours'', ``days'', or ``years''.  The default time unit is ``unknown''."
     }
   },
   "timeseries": {
     "timeseries": {
-      ".ts": "xxx"
+      "utl-ts": "xxx"
     }
   },
   "top": {
     "griddata": {
-      ".dis": "is the top elevation for each cell in the top model layer.",
-      ".disu": "is the top elevation for each cell in the model grid.",
-      ".disv": "is the top elevation for each cell in the top model layer."
+      "gwe-dis": "is the top elevation for each cell in the top model layer.",
+      "gwe-disu": "is the top elevation for each cell in the model grid.",
+      "gwe-disv": "is the top elevation for each cell in the top model layer.",
+      "gwf-dis": "is the top elevation for each cell in the top model layer.",
+      "gwf-disu": "is the top elevation for each cell in the model grid.",
+      "gwf-disv": "is the top elevation for each cell in the top model layer.",
+      "gwt-dis": "is the top elevation for each cell in the top model layer.",
+      "gwt-disu": "is the top elevation for each cell in the model grid.",
+      "gwt-disv": "is the top elevation for each cell in the top model layer.",
+      "prt-dis": "is the top elevation for each cell in the top model layer.",
+      "prt-disv": "is the top elevation for each cell in the top model layer."
     }
   },
   "track": {
     "options": {
-      ".oc": "keyword to specify that record corresponds to a binary track file.  Each PRT Model's OC Package may have only one binary track output file.",
-      ".prp": "keyword to specify that record corresponds to a binary track output file.  Each PRP Package may have a distinct binary track output file."
+      "prt-oc": "keyword to specify that record corresponds to a binary track file.  Each PRT Model's OC Package may have only one binary track output file.",
+      "prt-prp": "keyword to specify that record corresponds to a binary track output file.  Each PRP Package may have a distinct binary track output file."
     }
   },
   "track_exit": {
     "options": {
-      ".oc": "keyword to indicate that particle tracking output is to be written when a particle exits a feature (a model, cell, or subcell)"
+      "prt-oc": "keyword to indicate that particle tracking output is to be written when a particle exits a feature (a model, cell, or subcell)"
     }
   },
   "track_release": {
     "options": {
-      ".oc": "keyword to indicate that particle tracking output is to be written when a particle is released"
+      "prt-oc": "keyword to indicate that particle tracking output is to be written when a particle is released"
     }
   },
   "track_terminate": {
     "options": {
-      ".oc": "keyword to indicate that particle tracking output is to be written when a particle terminates for any reason"
+      "prt-oc": "keyword to indicate that particle tracking output is to be written when a particle terminates for any reason"
     }
   },
   "track_timestep": {
     "options": {
-      ".oc": "keyword to indicate that particle tracking output is to be written at the end of each time step"
+      "prt-oc": "keyword to indicate that particle tracking output is to be written at the end of each time step"
     }
   },
   "track_usertime": {
     "options": {
-      ".oc": "keyword to indicate that particle tracking output is to be written at user-specified times, provided as double precision values in the TRACKTIMES block."
+      "prt-oc": "keyword to indicate that particle tracking output is to be written at user-specified times, provided as double precision values in the TRACKTIMES block."
     }
   },
   "track_weaksink": {
     "options": {
-      ".oc": "keyword to indicate that particle tracking output is to be written when a particle exits a weak sink (a cell which removes some but not all inflow from adjacent cells)"
+      "prt-oc": "keyword to indicate that particle tracking output is to be written when a particle exits a weak sink (a cell which removes some but not all inflow from adjacent cells)"
     }
   },
   "trackcsv": {
     "options": {
-      ".oc": "keyword to specify that record corresponds to a CSV track file.  Each PRT Model's OC Package may have only one CSV track file.",
-      ".prp": "keyword to specify that record corresponds to a CSV track output file.  Each PRP Package may have a distinct CSV track output file."
+      "prt-oc": "keyword to specify that record corresponds to a CSV track file.  Each PRT Model's OC Package may have only one CSV track file.",
+      "prt-prp": "keyword to specify that record corresponds to a CSV track output file.  Each PRP Package may have a distinct CSV track output file."
     }
   },
   "transient": {
     "period": {
-      ".sto": "keyword to indicate that stress period IPER is transient. Transient conditions will apply until the STEADY-STATE keyword is specified in a subsequent BEGIN PERIOD block."
+      "chf-sto": "keyword to indicate that stress period IPER is transient. Transient conditions will apply until the STEADY-STATE keyword is specified in a subsequent BEGIN PERIOD block.",
+      "gwf-sto": "keyword to indicate that stress period IPER is transient. Transient conditions will apply until the STEADY-STATE keyword is specified in a subsequent BEGIN PERIOD block.",
+      "olf-sto": "keyword to indicate that stress period IPER is transient. Transient conditions will apply until the STEADY-STATE keyword is specified in a subsequent BEGIN PERIOD block.",
+      "swf-sto": "keyword to indicate that stress period IPER is transient. Transient conditions will apply until the STEADY-STATE keyword is specified in a subsequent BEGIN PERIOD block."
     }
   },
   "ts6": {
     "options": {
-      ".chd": "keyword to specify that record corresponds to a time-series file.",
-      ".cnc": "keyword to specify that record corresponds to a time-series file.",
-      ".csub": "keyword to specify that record corresponds to a time-series file.",
-      ".ctp": "keyword to specify that record corresponds to a time-series file.",
-      ".drn": "keyword to specify that record corresponds to a time-series file.",
-      ".esl": "keyword to specify that record corresponds to a time-series file.",
-      ".evp": "keyword to specify that record corresponds to a time-series file.",
-      ".evt": "keyword to specify that record corresponds to a time-series file.",
-      ".flw": "keyword to specify that record corresponds to a time-series file.",
-      ".ghb": "keyword to specify that record corresponds to a time-series file.",
-      ".lak": "keyword to specify that record corresponds to a time-series file.",
-      ".lke": "keyword to specify that record corresponds to a time-series file.",
-      ".lkt": "keyword to specify that record corresponds to a time-series file.",
-      ".maw": "keyword to specify that record corresponds to a time-series file.",
-      ".mwe": "keyword to specify that record corresponds to a time-series file.",
-      ".mwt": "keyword to specify that record corresponds to a time-series file.",
-      ".pcp": "keyword to specify that record corresponds to a time-series file.",
-      ".rch": "keyword to specify that record corresponds to a time-series file.",
-      ".riv": "keyword to specify that record corresponds to a time-series file.",
-      ".sfe": "keyword to specify that record corresponds to a time-series file.",
-      ".sfr": "keyword to specify that record corresponds to a time-series file.",
-      ".sft": "keyword to specify that record corresponds to a time-series file.",
-      ".spc": "keyword to specify that record corresponds to a time-series file.",
-      ".src": "keyword to specify that record corresponds to a time-series file.",
-      ".tvk": "keyword to specify that record corresponds to a time-series file.",
-      ".tvs": "keyword to specify that record corresponds to a time-series file.",
-      ".uze": "keyword to specify that record corresponds to a time-series file.",
-      ".uzf": "keyword to specify that record corresponds to a time-series file.",
-      ".uzt": "keyword to specify that record corresponds to a time-series file.",
-      ".wel": "keyword to specify that record corresponds to a time-series file.",
-      ".zdg": "keyword to specify that record corresponds to a time-series file."
+      "chf-chd": "keyword to specify that record corresponds to a time-series file.",
+      "chf-evp": "keyword to specify that record corresponds to a time-series file.",
+      "chf-flw": "keyword to specify that record corresponds to a time-series file.",
+      "chf-pcp": "keyword to specify that record corresponds to a time-series file.",
+      "chf-zdg": "keyword to specify that record corresponds to a time-series file.",
+      "gwe-ctp": "keyword to specify that record corresponds to a time-series file.",
+      "gwe-esl": "keyword to specify that record corresponds to a time-series file.",
+      "gwe-lke": "keyword to specify that record corresponds to a time-series file.",
+      "gwe-mwe": "keyword to specify that record corresponds to a time-series file.",
+      "gwe-sfe": "keyword to specify that record corresponds to a time-series file.",
+      "gwe-uze": "keyword to specify that record corresponds to a time-series file.",
+      "gwf-chd": "keyword to specify that record corresponds to a time-series file.",
+      "gwf-csub": "keyword to specify that record corresponds to a time-series file.",
+      "gwf-drn": "keyword to specify that record corresponds to a time-series file.",
+      "gwf-evt": "keyword to specify that record corresponds to a time-series file.",
+      "gwf-ghb": "keyword to specify that record corresponds to a time-series file.",
+      "gwf-lak": "keyword to specify that record corresponds to a time-series file.",
+      "gwf-maw": "keyword to specify that record corresponds to a time-series file.",
+      "gwf-rch": "keyword to specify that record corresponds to a time-series file.",
+      "gwf-riv": "keyword to specify that record corresponds to a time-series file.",
+      "gwf-sfr": "keyword to specify that record corresponds to a time-series file.",
+      "gwf-uzf": "keyword to specify that record corresponds to a time-series file.",
+      "gwf-wel": "keyword to specify that record corresponds to a time-series file.",
+      "gwt-cnc": "keyword to specify that record corresponds to a time-series file.",
+      "gwt-lkt": "keyword to specify that record corresponds to a time-series file.",
+      "gwt-mwt": "keyword to specify that record corresponds to a time-series file.",
+      "gwt-sft": "keyword to specify that record corresponds to a time-series file.",
+      "gwt-src": "keyword to specify that record corresponds to a time-series file.",
+      "gwt-uzt": "keyword to specify that record corresponds to a time-series file.",
+      "olf-chd": "keyword to specify that record corresponds to a time-series file.",
+      "olf-evp": "keyword to specify that record corresponds to a time-series file.",
+      "olf-flw": "keyword to specify that record corresponds to a time-series file.",
+      "olf-pcp": "keyword to specify that record corresponds to a time-series file.",
+      "olf-zdg": "keyword to specify that record corresponds to a time-series file.",
+      "swf-chd": "keyword to specify that record corresponds to a time-series file.",
+      "swf-evp": "keyword to specify that record corresponds to a time-series file.",
+      "swf-flw": "keyword to specify that record corresponds to a time-series file.",
+      "swf-pcp": "keyword to specify that record corresponds to a time-series file.",
+      "swf-zdg": "keyword to specify that record corresponds to a time-series file.",
+      "utl-spc": "keyword to specify that record corresponds to a time-series file.",
+      "utl-tvk": "keyword to specify that record corresponds to a time-series file.",
+      "utl-tvs": "keyword to specify that record corresponds to a time-series file."
     }
   },
   "tvk6": {
     "options": {
-      ".npf": "keyword to specify that record corresponds to a time-varying hydraulic conductivity (TVK) file.  The behavior of TVK and a description of the input file is provided separately."
+      "gwf-npf": "keyword to specify that record corresponds to a time-varying hydraulic conductivity (TVK) file.  The behavior of TVK and a description of the input file is provided separately."
     }
   },
   "tvs6": {
     "options": {
-      ".sto": "keyword to specify that record corresponds to a time-varying storage (TVS) file.  The behavior of TVS and a description of the input file is provided separately."
+      "gwf-sto": "keyword to specify that record corresponds to a time-varying storage (TVS) file.  The behavior of TVS and a description of the input file is provided separately."
     }
   },
   "under_relaxation": {
     "nonlinear": {
-      ".ims": "is an optional keyword that defines the nonlinear under-relaxation schemes used. Under-relaxation is also known as dampening, and is used to reduce the size of the calculated dependent variable before proceeding to the next outer iteration.  Under-relaxation can be an effective tool for highly nonlinear models when there are large and often counteracting changes in the calculated dependent variable between successive outer iterations.  By default under-relaxation is not used.  NONE - under-relaxation is not used (default). SIMPLE - Simple under-relaxation scheme with a fixed relaxation factor (UNDER\\_RELAXATION\\_GAMMA) is used.  COOLEY - Cooley under-relaxation scheme is used.  DBD - delta-bar-delta under-relaxation is used.  Note that the under-relaxation schemes are often used in conjunction with problems that use the Newton-Raphson formulation, however, experience has indicated that they also work well for non-Newton problems, such as those with the wet/dry options of MODFLOW 6."
+      "sln-ims": "is an optional keyword that defines the nonlinear under-relaxation schemes used. Under-relaxation is also known as dampening, and is used to reduce the size of the calculated dependent variable before proceeding to the next outer iteration.  Under-relaxation can be an effective tool for highly nonlinear models when there are large and often counteracting changes in the calculated dependent variable between successive outer iterations.  By default under-relaxation is not used.  NONE - under-relaxation is not used (default). SIMPLE - Simple under-relaxation scheme with a fixed relaxation factor (UNDER\\_RELAXATION\\_GAMMA) is used.  COOLEY - Cooley under-relaxation scheme is used.  DBD - delta-bar-delta under-relaxation is used.  Note that the under-relaxation schemes are often used in conjunction with problems that use the Newton-Raphson formulation, however, experience has indicated that they also work well for non-Newton problems, such as those with the wet/dry options of MODFLOW 6."
     },
     "options": {
-      ".nam": "keyword that indicates whether the surface water stage in a reach will be under-relaxed when water levels fall below the bottom of the model below any given cell. By default, Newton-Raphson UNDER\\_RELAXATION is not applied."
+      "chf-nam": "keyword that indicates whether the surface water stage in a reach will be under-relaxed when water levels fall below the bottom of the model below any given cell. By default, Newton-Raphson UNDER\\_RELAXATION is not applied.",
+      "gwf-nam": "keyword that indicates whether the groundwater head in a cell will be under-relaxed when water levels fall below the bottom of the model below any given cell. By default, Newton-Raphson UNDER\\_RELAXATION is not applied.",
+      "olf-nam": "keyword that indicates whether the surface water stage in a reach will be under-relaxed when water levels fall below the bottom of the model below any given cell. By default, Newton-Raphson UNDER\\_RELAXATION is not applied.",
+      "swf-nam": "keyword that indicates whether the surface water stage in a reach will be under-relaxed when water levels fall below the bottom of the model below any given cell. By default, Newton-Raphson UNDER\\_RELAXATION is not applied."
     }
   },
   "under_relaxation_gamma": {
     "nonlinear": {
-      ".ims": "real value defining either the relaxation factor for the SIMPLE scheme or the history or memory term factor of the Cooley and delta-bar-delta algorithms. For the SIMPLE scheme, a value of one indicates that there is no under-relaxation and the full head change is applied.  This value can be gradually reduced from one as a way to improve convergence; for well behaved problems, using a value less than one can increase the number of outer iterations required for convergence and needlessly increase run times.  UNDER\\_RELAXATION\\_GAMMA must be greater than zero for the SIMPLE scheme or the program will terminate with an error.  For the Cooley and delta-bar-delta schemes, UNDER\\_RELAXATION\\_GAMMA is a memory term that can range between zero and one. When UNDER\\_RELAXATION\\_GAMMA is zero, only the most recent history (previous iteration value) is maintained. As UNDER\\_RELAXATION\\_GAMMA is increased, past history of iteration changes has greater influence on the memory term. The memory term is maintained as an exponential average of past changes. Retaining some past history can overcome granular behavior in the calculated function surface and therefore helps to overcome cyclic patterns of non-convergence. The value usually ranges from 0.1 to 0.3; a value of 0.2 works well for most problems. UNDER\\_RELAXATION\\_GAMMA only needs to be specified if UNDER\\_RELAXATION is not NONE."
+      "sln-ims": "real value defining either the relaxation factor for the SIMPLE scheme or the history or memory term factor of the Cooley and delta-bar-delta algorithms. For the SIMPLE scheme, a value of one indicates that there is no under-relaxation and the full head change is applied.  This value can be gradually reduced from one as a way to improve convergence; for well behaved problems, using a value less than one can increase the number of outer iterations required for convergence and needlessly increase run times.  UNDER\\_RELAXATION\\_GAMMA must be greater than zero for the SIMPLE scheme or the program will terminate with an error.  For the Cooley and delta-bar-delta schemes, UNDER\\_RELAXATION\\_GAMMA is a memory term that can range between zero and one. When UNDER\\_RELAXATION\\_GAMMA is zero, only the most recent history (previous iteration value) is maintained. As UNDER\\_RELAXATION\\_GAMMA is increased, past history of iteration changes has greater influence on the memory term. The memory term is maintained as an exponential average of past changes. Retaining some past history can overcome granular behavior in the calculated function surface and therefore helps to overcome cyclic patterns of non-convergence. The value usually ranges from 0.1 to 0.3; a value of 0.2 works well for most problems. UNDER\\_RELAXATION\\_GAMMA only needs to be specified if UNDER\\_RELAXATION is not NONE."
     }
   },
   "under_relaxation_kappa": {
     "nonlinear": {
-      ".ims": "real value defining the increment for the learning rate (under-relaxation term) of the delta-bar-delta algorithm. The value of UNDER\\_RELAXATION\\_kappa is between zero and one. If the change in the dependent-variable (for example, head) is of the same sign to that of the previous iteration, the under-relaxation term is increased by an increment of UNDER\\_RELAXATION\\_KAPPA. The value usually ranges from 0.03 to 0.3; a value of 0.1 works well for most problems. UNDER\\_RELAXATION\\_KAPPA only needs to be specified if UNDER\\_RELAXATION is DBD."
+      "sln-ims": "real value defining the increment for the learning rate (under-relaxation term) of the delta-bar-delta algorithm. The value of UNDER\\_RELAXATION\\_kappa is between zero and one. If the change in the dependent-variable (for example, head) is of the same sign to that of the previous iteration, the under-relaxation term is increased by an increment of UNDER\\_RELAXATION\\_KAPPA. The value usually ranges from 0.03 to 0.3; a value of 0.1 works well for most problems. UNDER\\_RELAXATION\\_KAPPA only needs to be specified if UNDER\\_RELAXATION is DBD."
     }
   },
   "under_relaxation_momentum": {
     "nonlinear": {
-      ".ims": "real value defining the fraction of past history changes that is added as a momentum term to the step change for a nonlinear iteration. The value of UNDER\\_RELAXATION\\_MOMENTUM is between zero and one. A large momentum term should only be used when small learning rates are expected. Small amounts of the momentum term help convergence. The value usually ranges from 0.0001 to 0.1; a value of 0.001 works well for most problems. UNDER\\_RELAXATION\\_MOMENTUM only needs to be specified if UNDER\\_RELAXATION is DBD."
+      "sln-ims": "real value defining the fraction of past history changes that is added as a momentum term to the step change for a nonlinear iteration. The value of UNDER\\_RELAXATION\\_MOMENTUM is between zero and one. A large momentum term should only be used when small learning rates are expected. Small amounts of the momentum term help convergence. The value usually ranges from 0.0001 to 0.1; a value of 0.001 works well for most problems. UNDER\\_RELAXATION\\_MOMENTUM only needs to be specified if UNDER\\_RELAXATION is DBD."
     }
   },
   "under_relaxation_theta": {
     "nonlinear": {
-      ".ims": "real value defining the reduction factor for the learning rate (under-relaxation term) of the delta-bar-delta algorithm. The value of UNDER\\_RELAXATION\\_THETA is between zero and one. If the change in the dependent-variable (for example, head) is of opposite sign to that of the previous iteration, the under-relaxation term is reduced by a factor of UNDER\\_RELAXATION\\_THETA. The value usually ranges from 0.3 to 0.9; a value of 0.7 works well for most problems. UNDER\\_RELAXATION\\_THETA only needs to be specified if UNDER\\_RELAXATION is DBD."
+      "sln-ims": "real value defining the reduction factor for the learning rate (under-relaxation term) of the delta-bar-delta algorithm. The value of UNDER\\_RELAXATION\\_THETA is between zero and one. If the change in the dependent-variable (for example, head) is of opposite sign to that of the previous iteration, the under-relaxation term is reduced by a factor of UNDER\\_RELAXATION\\_THETA. The value usually ranges from 0.3 to 0.9; a value of 0.7 works well for most problems. UNDER\\_RELAXATION\\_THETA only needs to be specified if UNDER\\_RELAXATION is DBD."
     }
   },
   "unit_conversion": {
     "options": {
-      ".sfr": "real value that is used to convert user-specified Manning's roughness coefficients from seconds per meters$^{1/3}$ to model length and time units. A constant of 1.486 is used for flow units of cubic feet per second, and a constant of 1.0 is used for units of cubic meters per second. The constant must be multiplied by 86,400 when using time units of days in the simulation."
+      "gwf-sfr": "real value that is used to convert user-specified Manning's roughness coefficients from seconds per meters$^{1/3}$ to model length and time units. A constant of 1.486 is used for flow units of cubic feet per second, and a constant of 1.0 is used for units of cubic meters per second. The constant must be multiplied by 86,400 when using time units of days in the simulation."
     }
   },
   "unsat_etae": {
     "options": {
-      ".uzf": "keyword specifying that ET in the unsaturated zone will be simulated using a capillary pressure based formulation. Capillary pressure is calculated using the Brooks-Corey retention function."
+      "gwf-uzf": "keyword specifying that ET in the unsaturated zone will be simulated using a capillary pressure based formulation. Capillary pressure is calculated using the Brooks-Corey retention function."
     }
   },
   "unsat_etwc": {
     "options": {
-      ".uzf": "keyword specifying that ET in the unsaturated zone will be simulated as a function of the specified PET rate while the water content (THETA) is greater than the ET extinction water content (EXTWC)."
+      "gwf-uzf": "keyword specifying that ET in the unsaturated zone will be simulated as a function of the specified PET rate while the water content (THETA) is greater than the ET extinction water content (EXTWC)."
     }
   },
   "update_material_properties": {
     "options": {
-      ".csub": "keyword to indicate that the thickness and void ratio of coarse-grained and interbed sediments (delay and no-delay) will vary during the simulation. If not specified, the thickness and void ratio of coarse-grained and interbed sediments will not vary during the simulation."
+      "gwf-csub": "keyword to indicate that the thickness and void ratio of coarse-grained and interbed sediments (delay and no-delay) will vary during the simulation. If not specified, the thickness and void ratio of coarse-grained and interbed sediments will not vary during the simulation."
     }
   },
   "upstream_fraction": {
     "period": {
-      ".sfr": "real value that defines the fraction of upstream flow (USTRF) from each upstream reach that is applied as upstream inflow to the reach. The sum of all USTRF values for all reaches connected to the same upstream reach must be equal to one."
+      "gwf-sfr": "real value that defines the fraction of upstream flow (USTRF) from each upstream reach that is applied as upstream inflow to the reach. The sum of all USTRF values for all reaches connected to the same upstream reach must be equal to one."
     }
   },
   "uzet": {
     "period": {
-      ".uze": "real or character value that states what fraction of the simulated unsaturated zone evapotranspiration is associated with evaporation.  The evaporative losses from the unsaturated zone moisture content will have an evaporative cooling effect on the GWE cell from which the evaporation originated. If this value is larger than 1, then it will be reset to 1.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-      ".uzt": "real or character value that defines the concentration of unsaturated zone evapotranspiration water $(ML^{-3})$ for the UZF cell. If this concentration value is larger than the simulated concentration in the UZF cell, then the unsaturated zone ET water will be removed at the same concentration as the UZF cell.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+      "gwe-uze": "real or character value that states what fraction of the simulated unsaturated zone evapotranspiration is associated with evaporation.  The evaporative losses from the unsaturated zone moisture content will have an evaporative cooling effect on the GWE cell from which the evaporation originated. If this value is larger than 1, then it will be reset to 1.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+      "gwt-uzt": "real or character value that defines the concentration of unsaturated zone evapotranspiration water $(ML^{-3})$ for the UZF cell. If this concentration value is larger than the simulated concentration in the UZF cell, then the unsaturated zone ET water will be removed at the same concentration as the UZF cell.  If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
     }
   },
   "variablecv": {
     "options": {
-      ".gwfgwf": "keyword to indicate that the vertical conductance will be calculated using the saturated thickness and properties of the overlying cell and the thickness and properties of the underlying cell.  If the DEWATERED keyword is also specified, then the vertical conductance is calculated using only the saturated thickness and properties of the overlying cell if the head in the underlying cell is below its top.  If these keywords are not specified, then the default condition is to calculate the vertical conductance at the start of the simulation using the initial head and the cell properties.  The vertical conductance remains constant for the entire simulation.",
-      ".npf": "keyword to indicate that the vertical conductance will be calculated using the saturated thickness and properties of the overlying cell and the thickness and properties of the underlying cell.  If the DEWATERED keyword is also specified, then the vertical conductance is calculated using only the saturated thickness and properties of the overlying cell if the head in the underlying cell is below its top.  If these keywords are not specified, then the default condition is to calculate the vertical conductance at the start of the simulation using the initial head and the cell properties.  The vertical conductance remains constant for the entire simulation."
+      "exg-gwfgwf": "keyword to indicate that the vertical conductance will be calculated using the saturated thickness and properties of the overlying cell and the thickness and properties of the underlying cell.  If the DEWATERED keyword is also specified, then the vertical conductance is calculated using only the saturated thickness and properties of the overlying cell if the head in the underlying cell is below its top.  If these keywords are not specified, then the default condition is to calculate the vertical conductance at the start of the simulation using the initial head and the cell properties.  The vertical conductance remains constant for the entire simulation.",
+      "gwf-npf": "keyword to indicate that the vertical conductance will be calculated using the saturated thickness and properties of the overlying cell and the thickness and properties of the underlying cell.  If the DEWATERED keyword is also specified, then the vertical conductance is calculated using only the saturated thickness and properties of the overlying cell if the head in the underlying cell is below its top.  If these keywords are not specified, then the default condition is to calculate the vertical conductance at the start of the simulation using the initial head and the cell properties.  The vertical conductance remains constant for the entire simulation."
     }
   },
   "vertical_offset_tolerance": {
     "options": {
-      ".disu": "checks are performed to ensure that the top of a cell is not higher than the bottom of an overlying cell.  This option can be used to specify the tolerance that is used for checking.  If top of a cell is above the bottom of an overlying cell by a value less than this tolerance, then the program will not terminate with an error.  The default value is zero.  This option should generally not be used."
+      "gwe-disu": "checks are performed to ensure that the top of a cell is not higher than the bottom of an overlying cell.  This option can be used to specify the tolerance that is used for checking.  If top of a cell is above the bottom of an overlying cell by a value less than this tolerance, then the program will not terminate with an error.  The default value is zero.  This option should generally not be used.",
+      "gwf-disu": "checks are performed to ensure that the top of a cell is not higher than the bottom of an overlying cell.  This option can be used to specify the tolerance that is used for checking.  If top of a cell is above the bottom of an overlying cell by a value less than this tolerance, then the program will not terminate with an error.  The default value is zero.  This option should generally not be used.",
+      "gwt-disu": "checks are performed to ensure that the top of a cell is not higher than the bottom of an overlying cell.  This option can be used to specify the tolerance that is used for checking.  If top of a cell is above the bottom of an overlying cell by a value less than this tolerance, then the program will not terminate with an error.  The default value is zero.  This option should generally not be used."
     }
   },
   "viscosity": {
     "options": {
-      ".vsc": "keyword to specify that record corresponds to viscosity."
+      "gwf-vsc": "keyword to specify that record corresponds to viscosity."
     }
   },
   "viscref": {
     "options": {
-      ".vsc": "fluid reference viscosity used in the equation of state.  This value is set to 1.0 if not specified as an option."
+      "gwf-vsc": "fluid reference viscosity used in the equation of state.  This value is set to 1.0 if not specified as an option."
     }
   },
   "volfrac": {
     "griddata": {
-      ".ist": "fraction of the cell volume that consists of this immobile domain.  The sum of all immobile domain volume fractions must be less than one."
+      "gwt-ist": "fraction of the cell volume that consists of this immobile domain.  The sum of all immobile domain volume fractions must be less than one."
     }
   },
   "water_content": {
     "options": {
-      ".uzf": "keyword to specify that record corresponds to unsaturated zone water contents."
+      "gwf-uzf": "keyword to specify that record corresponds to unsaturated zone water contents."
     }
   },
   "well_head": {
     "period": {
-      ".maw": "is the head in the multi-aquifer well. WELL\\_HEAD is only applied to constant head (STATUS is CONSTANT) and inactive (STATUS is INACTIVE) multi-aquifer wells. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. The program will terminate with an error if WELL\\_HEAD is less than the bottom of the well."
+      "gwf-maw": "is the head in the multi-aquifer well. WELL\\_HEAD is only applied to constant head (STATUS is CONSTANT) and inactive (STATUS is INACTIVE) multi-aquifer wells. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. The program will terminate with an error if WELL\\_HEAD is less than the bottom of the well."
     }
   },
   "wetdry": {
     "griddata": {
-      ".npf": "is a combination of the wetting threshold and a flag to indicate which neighboring cells can cause a cell to become wet. If WETDRY $<$ 0, only a cell below a dry cell can cause the cell to become wet. If WETDRY $>$ 0, the cell below a dry cell and horizontally adjacent cells can cause a cell to become wet. If WETDRY is 0, the cell cannot be wetted. The absolute value of WETDRY is the wetting threshold. When the sum of BOT and the absolute value of WETDRY at a dry cell is equaled or exceeded by the head at an adjacent cell, the cell is wetted.  WETDRY must be specified if ``REWET'' is specified in the OPTIONS block.  If ``REWET'' is not specified in the options block, then WETDRY can be entered, and memory will be allocated for it, even though it is not used."
+      "gwf-npf": "is a combination of the wetting threshold and a flag to indicate which neighboring cells can cause a cell to become wet. If WETDRY $<$ 0, only a cell below a dry cell can cause the cell to become wet. If WETDRY $>$ 0, the cell below a dry cell and horizontally adjacent cells can cause a cell to become wet. If WETDRY is 0, the cell cannot be wetted. The absolute value of WETDRY is the wetting threshold. When the sum of BOT and the absolute value of WETDRY at a dry cell is equaled or exceeded by the head at an adjacent cell, the cell is wetted.  WETDRY must be specified if ``REWET'' is specified in the OPTIONS block.  If ``REWET'' is not specified in the options block, then WETDRY can be entered, and memory will be allocated for it, even though it is not used."
     }
   },
   "wetfct": {
     "options": {
-      ".npf": "is a keyword and factor that is included in the calculation of the head that is initially established at a cell when that cell is converted from dry to wet."
+      "gwf-npf": "is a keyword and factor that is included in the calculation of the head that is initially established at a cell when that cell is converted from dry to wet."
     }
   },
   "width": {
     "griddata": {
-      ".disv1d": "real value that defines the width for each one-dimensional cell. WIDTH must be greater than zero.  If the Cross Section (CXS) Package is used, then the WIDTH value will be multiplied by the specified cross section x-fraction values."
+      "chf-disv1d": "real value that defines the width for each one-dimensional cell. WIDTH must be greater than zero.  If the Cross Section (CXS) Package is used, then the WIDTH value will be multiplied by the specified cross section x-fraction values.",
+      "olf-disv1d": "real value that defines the width for each one-dimensional cell. WIDTH must be greater than zero.  If the Cross Section (CXS) Package is used, then the WIDTH value will be multiplied by the specified cross section x-fraction values.",
+      "swf-disv1d": "real value that defines the width for each one-dimensional cell. WIDTH must be greater than zero.  If the Cross Section (CXS) Package is used, then the WIDTH value will be multiplied by the specified cross section x-fraction values."
     },
     "options": {
-      ".ist": "width for writing each number.",
-      ".oc": "width for writing each number."
+      "chf-oc": "width for writing each number.",
+      "gwe-oc": "width for writing each number.",
+      "gwf-oc": "width for writing each number.",
+      "gwt-ist": "width for writing each number.",
+      "gwt-oc": "width for writing each number.",
+      "olf-oc": "width for writing each number.",
+      "swf-oc": "width for writing each number."
     },
     "period": {
-      ".lak": "real or character value that defines the width of the lake outlet. A specified WIDTH value is only used for active lakes if COUTTYPE for lake outlet OUTLETNO is not SPECIFIED. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+      "gwf-lak": "real or character value that defines the width of the lake outlet. A specified WIDTH value is only used for active lakes if COUTTYPE for lake outlet OUTLETNO is not SPECIFIED. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
     }
   },
   "withdrawal": {
     "period": {
-      ".lak": "real or character value that defines the maximum withdrawal rate $(L^3 T^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+      "gwf-lak": "real or character value that defines the maximum withdrawal rate $(L^3 T^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the ``Time-Variable Input'' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
     }
   },
   "wkt": {
     "options": {
-      ".ncf": "is the coordinate reference system (CRS) well-known text (WKT) string."
+      "utl-ncf": "is the coordinate reference system (CRS) well-known text (WKT) string."
     }
   },
   "xorigin": {
     "options": {
-      ".dis": "x-position of the lower-left corner of the model grid.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      ".dis2d": "x-position of the lower-left corner of the model grid.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      ".disu": "x-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      ".disv": "x-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      ".disv1d": "x-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      ".disv2d": "x-position of the lower-left corner of the model grid.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space."
+      "chf-disv1d": "x-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      "gwe-dis": "x-position of the lower-left corner of the model grid.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      "gwe-disu": "x-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      "gwe-disv": "x-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      "gwf-dis": "x-position of the lower-left corner of the model grid.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      "gwf-disu": "x-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      "gwf-disv": "x-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      "gwt-dis": "x-position of the lower-left corner of the model grid.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      "gwt-disu": "x-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      "gwt-disv": "x-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      "olf-dis2d": "x-position of the lower-left corner of the model grid.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      "olf-disv1d": "x-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      "olf-disv2d": "x-position of the lower-left corner of the model grid.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      "prt-dis": "x-position of the lower-left corner of the model grid.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      "prt-disv": "x-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      "swf-dis2d": "x-position of the lower-left corner of the model grid.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      "swf-disv1d": "x-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      "swf-disv2d": "x-position of the lower-left corner of the model grid.  A default value of zero is assigned if not specified.  The value for XORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space."
     }
   },
   "xt3d": {
     "options": {
-      ".gwfgwf": "keyword that activates the XT3D formulation between the cells connected with this GWF-GWF Exchange.",
-      ".npf": "keyword indicating that the XT3D formulation will be used.  If the RHS keyword is also included, then the XT3D additional terms will be added to the right-hand side.  If the RHS keyword is excluded, then the XT3D terms will be put into the coefficient matrix.  Use of XT3D will substantially increase the computational effort, but will result in improved accuracy for anisotropic conductivity fields and for unstructured grids in which the CVFD requirement is violated.  XT3D requires additional information about the shapes of grid cells.  If XT3D is active and the DISU Package is used, then the user will need to provide in the DISU Package the angldegx array in the CONNECTIONDATA block and the VERTICES and CELL2D blocks."
+      "exg-gwfgwf": "keyword that activates the XT3D formulation between the cells connected with this GWF-GWF Exchange.",
+      "gwf-npf": "keyword indicating that the XT3D formulation will be used.  If the RHS keyword is also included, then the XT3D additional terms will be added to the right-hand side.  If the RHS keyword is excluded, then the XT3D terms will be put into the coefficient matrix.  Use of XT3D will substantially increase the computational effort, but will result in improved accuracy for anisotropic conductivity fields and for unstructured grids in which the CVFD requirement is violated.  XT3D requires additional information about the shapes of grid cells.  If XT3D is active and the DISU Package is used, then the user will need to provide in the DISU Package the angldegx array in the CONNECTIONDATA block and the VERTICES and CELL2D blocks."
     }
   },
   "xt3d_off": {
     "options": {
-      ".cnd": "deactivate the xt3d method and use the faster and less accurate approximation.  This option may provide a fast and accurate solution under some circumstances, such as when flow aligns with the model grid, there is no mechanical dispersion, or when the longitudinal and transverse dispersivities are equal.  This option may also be used to assess the computational demand of the XT3D approach by noting the run time differences with and without this option on.",
-      ".dsp": "deactivate the xt3d method and use the faster and less accurate approximation.  This option may provide a fast and accurate solution under some circumstances, such as when flow aligns with the model grid, there is no mechanical dispersion, or when the longitudinal and transverse dispersivities are equal.  This option may also be used to assess the computational demand of the XT3D approach by noting the run time differences with and without this option on."
+      "gwe-cnd": "deactivate the xt3d method and use the faster and less accurate approximation.  This option may provide a fast and accurate solution under some circumstances, such as when flow aligns with the model grid, there is no mechanical dispersion, or when the longitudinal and transverse dispersivities are equal.  This option may also be used to assess the computational demand of the XT3D approach by noting the run time differences with and without this option on.",
+      "gwt-dsp": "deactivate the xt3d method and use the faster and less accurate approximation.  This option may provide a fast and accurate solution under some circumstances, such as when flow aligns with the model grid, there is no mechanical dispersion, or when the longitudinal and transverse dispersivities are equal.  This option may also be used to assess the computational demand of the XT3D approach by noting the run time differences with and without this option on."
     }
   },
   "xt3d_rhs": {
     "options": {
-      ".cnd": "add xt3d terms to right-hand side, when possible.  This option uses less memory, but may require more iterations.",
-      ".dsp": "add xt3d terms to right-hand side, when possible.  This option uses less memory, but may require more iterations."
+      "gwe-cnd": "add xt3d terms to right-hand side, when possible.  This option uses less memory, but may require more iterations.",
+      "gwt-dsp": "add xt3d terms to right-hand side, when possible.  This option uses less memory, but may require more iterations."
     }
   },
   "xt3doptions": {
     "options": {
-      ".npf": "none"
+      "gwf-npf": "none"
     }
   },
   "yorigin": {
     "options": {
-      ".dis": "y-position of the lower-left corner of the model grid.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      ".dis2d": "y-position of the lower-left corner of the model grid.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      ".disu": "y-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      ".disv": "y-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      ".disv1d": "y-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
-      ".disv2d": "y-position of the lower-left corner of the model grid.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space."
+      "chf-disv1d": "y-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      "gwe-dis": "y-position of the lower-left corner of the model grid.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      "gwe-disu": "y-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      "gwe-disv": "y-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      "gwf-dis": "y-position of the lower-left corner of the model grid.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      "gwf-disu": "y-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      "gwf-disv": "y-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      "gwt-dis": "y-position of the lower-left corner of the model grid.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      "gwt-disu": "y-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      "gwt-disv": "y-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      "olf-dis2d": "y-position of the lower-left corner of the model grid.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      "olf-disv1d": "y-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      "olf-disv2d": "y-position of the lower-left corner of the model grid.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      "prt-dis": "y-position of the lower-left corner of the model grid.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      "prt-disv": "y-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      "swf-dis2d": "y-position of the lower-left corner of the model grid.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      "swf-disv1d": "y-position of the origin used for model grid vertices.  This value should be provided in a real-world coordinate system.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space.",
+      "swf-disv2d": "y-position of the lower-left corner of the model grid.  If not specified, then a default value equal to zero is used.  The value for YORIGIN does not affect the model simulation, but it is written to the binary grid file so that postprocessors can locate the grid in space."
     }
   },
   "zdisplacement": {
     "options": {
-      ".csub": "keyword to specify that record corresponds to the z-displacement binary file."
+      "gwf-csub": "keyword to specify that record corresponds to the z-displacement binary file."
     }
   },
   "zero_order_decay": {
     "options": {
-      ".ist": "is a text keyword to indicate that zero-order decay will occur.  Use of this keyword requires that DECAY and DECAY\\_SORBED (if sorption is active) are specified in the GRIDDATA block.",
-      ".mst": "is a text keyword to indicate that zero-order decay will occur.  Use of this keyword requires that DECAY and DECAY\\_SORBED (if sorption is active) are specified in the GRIDDATA block."
+      "gwt-ist": "is a text keyword to indicate that zero-order decay will occur.  Use of this keyword requires that DECAY and DECAY\\_SORBED (if sorption is active) are specified in the GRIDDATA block.",
+      "gwt-mst": "is a text keyword to indicate that zero-order decay will occur.  Use of this keyword requires that DECAY and DECAY\\_SORBED (if sorption is active) are specified in the GRIDDATA block."
     }
   },
   "zero_order_decay_solid": {
     "options": {
-      ".est": "is a text keyword to indicate that zero-order decay will occur in the solid phase. That is, decay occurs in the solid and is a rate per mass (not volume) of solid only.  Use of this keyword requires that DECAY\\_SOLID is specified in the GRIDDATA block."
+      "gwe-est": "is a text keyword to indicate that zero-order decay will occur in the solid phase. That is, decay occurs in the solid and is a rate per mass (not volume) of solid only.  Use of this keyword requires that DECAY\\_SOLID is specified in the GRIDDATA block."
     }
   },
   "zero_order_decay_water": {
     "options": {
-      ".est": "is a text keyword to indicate that zero-order decay will occur in the aqueous phase. That is, decay occurs in the water and is a rate per volume of water only, not per volume of aquifer (i.e., grid cell).  Use of this keyword requires that DECAY\\_WATER is specified in the GRIDDATA block."
+      "gwe-est": "is a text keyword to indicate that zero-order decay will occur in the aqueous phase. That is, decay occurs in the water and is a rate per volume of water only, not per volume of aquifer (i.e., grid cell).  Use of this keyword requires that DECAY\\_WATER is specified in the GRIDDATA block."
     }
   },
   "zetaim": {
     "griddata": {
-      ".ist": "mass transfer rate coefficient between the mobile and immobile domains, in dimensions of per time."
+      "gwt-ist": "mass transfer rate coefficient between the mobile and immobile domains, in dimensions of per time."
     }
   }
 }

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -1,0 +1,100 @@
+import * as vscode from "vscode";
+import * as fs from "fs/promises";
+import * as path from "path";
+
+interface HoverData {
+  [keyword: string]: {
+    [block: string]: {
+      [description: string]: string; // dfn_name
+    };
+  };
+}
+
+export class MF6HoverProvider implements vscode.HoverProvider {
+  private hoverData: HoverData = {};
+
+  constructor() {
+    this.loadHoverData();
+  }
+
+  private async loadHoverData() {
+    const filePath = path.resolve(__dirname, "../../src/providers/hover.json");
+    const fileContent = await fs.readFile(filePath, "utf-8");
+    this.hoverData = JSON.parse(fileContent);
+  }
+
+  public async provideHover(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+  ) {
+    const wordRange = document.getWordRangeAtPosition(position, /\S+/);
+    if (!wordRange) {
+      return null;
+    }
+    const keyword = document.getText(wordRange).toLowerCase();
+
+    // Traverse backward line-per-line to find the enclosing block
+    let block: string | null = null;
+    for (let line = position.line - 1; line >= 0; line--) {
+      const lineText = document.lineAt(line).text.trim();
+      if (lineText.toLowerCase().startsWith("begin")) {
+        const parts = lineText.split(/\s+/);
+        if (parts.length > 1) {
+          block = parts[1];
+        }
+        break;
+      }
+    }
+
+    if (
+      keyword in this.hoverData &&
+      block &&
+      this.hoverData[keyword]?.[block]
+    ) {
+      let hoverValue: string | undefined = undefined;
+
+      const blockData = this.hoverData[keyword][block];
+      const fileExtension = path.extname(document.fileName).slice(1);
+      let matchingKeys = Object.keys(blockData).filter((key) => {
+        const value = blockData[key];
+        return (
+          Array.isArray(value) &&
+          value.some((item) => {
+            const parts = item.split("-");
+            return parts[parts.length - 1] === fileExtension;
+          })
+        );
+      });
+
+      if (matchingKeys.length === 1) {
+        hoverValue = `- ${matchingKeys[0]}`;
+      } else {
+        if (matchingKeys.length === 0) {
+          // Fallback to all keys
+          matchingKeys = Object.keys(blockData);
+        }
+        const matchingValues = matchingKeys.map((key) => blockData[key]);
+        hoverValue = matchingKeys
+          .map((key, index) => {
+            const values = matchingValues[index];
+            const formattedValues = Array.isArray(values)
+              ? values.map((value) => `*${value}*`).join(", ")
+              : `*${values}*`;
+            return `${formattedValues}\n- ${key}`;
+          })
+          .join("\n\n");
+      }
+
+      return new vscode.Hover(
+        new vscode.MarkdownString(
+          `**${keyword.toUpperCase()}**&nbsp;&nbsp;(block: *${
+            block?.toUpperCase() ?? "unknown"
+          }*)\n\n${hoverValue ?? "No description available"}`,
+          true,
+        ),
+      );
+    } else {
+      return null;
+    }
+  }
+}

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -5,7 +5,7 @@ import * as path from "path";
 interface HoverData {
   [keyword: string]: {
     [block: string]: {
-      [description: string]: string; // dfn_name
+      [description: string]: string[]; // dfn_name
     };
   };
 }
@@ -57,13 +57,10 @@ export class MF6HoverProvider implements vscode.HoverProvider {
       const fileExtension = path.extname(document.fileName).slice(1);
       let matchingKeys = Object.keys(blockData).filter((key) => {
         const value = blockData[key];
-        return (
-          Array.isArray(value) &&
-          value.some((item) => {
-            const parts = item.split("-");
-            return parts[parts.length - 1] === fileExtension;
-          })
-        );
+        return value.some((item) => {
+          const parts = item.split("-");
+          return parts[parts.length - 1] === fileExtension;
+        });
       });
 
       if (matchingKeys.length === 1) {
@@ -77,9 +74,9 @@ export class MF6HoverProvider implements vscode.HoverProvider {
         hoverValue = matchingKeys
           .map((key, index) => {
             const values = matchingValues[index];
-            const formattedValues = Array.isArray(values)
-              ? values.map((value) => `*${value}*`).join(", ")
-              : `*${values}*`;
+            const formattedValues = values
+              .map((value) => `*${value}*`)
+              .join(", ");
             return `${formattedValues}\n- ${key}`;
           })
           .join("\n\n");

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -1,8 +1,8 @@
 import * as vscode from "vscode";
-import * as fs from "fs/promises";
 import * as path from "path";
+import * as hoverDataJson from "./hover.json";
 
-interface HoverData {
+interface HoverDataStructure {
   [keyword: string]: {
     [block: string]: {
       [description: string]: string[]; // dfn_name
@@ -11,17 +11,7 @@ interface HoverData {
 }
 
 export class MF6HoverProvider implements vscode.HoverProvider {
-  private hoverData: HoverData = {};
-
-  constructor() {
-    this.loadHoverData();
-  }
-
-  private async loadHoverData() {
-    const filePath = path.resolve(__dirname, "../../src/providers/hover.json");
-    const fileContent = await fs.readFile(filePath, "utf-8");
-    this.hoverData = JSON.parse(fileContent);
-  }
+  hoverData: HoverDataStructure = hoverDataJson as HoverDataStructure;
 
   public async provideHover(
     document: vscode.TextDocument,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "resolveJsonModule": true
   },
   "include": ["src"]
 }

--- a/utils/gen_from_dfn.py
+++ b/utils/gen_from_dfn.py
@@ -191,13 +191,14 @@ if __name__ == "__main__":
             if section.tagged and (description := section.description):
                 if "REPLACE" in description:  # Replace placeholders from common
                     keyword = keyword_alias.get(section.keyword, section.keyword)
-                    description = common[keyword]
                     # Create replacement dictionary from the description
                     replacement = ast.literal_eval(
                         section.description.strip(f"REPLACE {keyword} ")
                     )
-                    for key, value in replacement.items():
-                        description = description.replace(key, value)
+                    # Replace text from common
+                    description = common[keyword].format_map(
+                        {k.strip("{}"): v for k, v in replacement.items()}
+                    )
                 description = description.replace("``", "`").replace("''", "`")
                 hover[section.keyword][section.block][description].append(dfn.path.stem)
 

--- a/utils/gen_from_dfn.py
+++ b/utils/gen_from_dfn.py
@@ -178,7 +178,7 @@ if __name__ == "__main__":
             continue
         common[name.split(maxsplit=1)[-1]] = description.split(maxsplit=1)[-1]
 
-    hover = defaultdict(lambda: defaultdict(lambda: defaultdict(dict)))
+    hover = defaultdict(lambda: defaultdict(lambda: defaultdict(list)))
     # Some dfn keywords have to be replaced with a different keyword from common.dfn
     # e.g. see  gwe-ctp.dfn, "auxiliary" keyword is replaced with "auxnames" from common
     keyword_alias = {"auxiliary": "auxnames", "print_stage": "print_head"}
@@ -194,12 +194,12 @@ if __name__ == "__main__":
                     replacement = eval(section.description.strip(f"REPLACE {keyword} "))
                     for key, value in replacement.items():
                         description = description.replace(key, value)
-                hover[section.keyword][section.block][dfn.path.stem] = description
+                hover[section.keyword][section.block][description].append(dfn.path.stem)
 
     # Sort hover before exporting
     sorted_hover = {
         key: {
-            subkey: dict(sorted(subval.items()))
+            subkey: {desc: sorted(paths) for desc, paths in sorted(subval.items())}
             for subkey, subval in sorted(val.items())
         }
         for key, val in sorted(hover.items())

--- a/utils/gen_from_dfn.py
+++ b/utils/gen_from_dfn.py
@@ -194,6 +194,7 @@ if __name__ == "__main__":
                     replacement = eval(section.description.strip(f"REPLACE {keyword} "))
                     for key, value in replacement.items():
                         description = description.replace(key, value)
+                description = description.replace("``", "`").replace("''", "`")
                 hover[section.keyword][section.block][description].append(dfn.path.stem)
 
     # Sort hover before exporting

--- a/utils/gen_from_dfn.py
+++ b/utils/gen_from_dfn.py
@@ -23,6 +23,7 @@ Usage:
     'syntaxes/mf6.tmLanguage.json' and 'src/providers/hover.json' files.
 """
 
+import ast
 import json
 from collections import defaultdict
 from dataclasses import dataclass
@@ -192,7 +193,9 @@ if __name__ == "__main__":
                     keyword = keyword_alias.get(section.keyword, section.keyword)
                     description = common[keyword]
                     # Create replacement dictionary from the description
-                    replacement = eval(section.description.strip(f"REPLACE {keyword} "))
+                    replacement = ast.literal_eval(
+                        section.description.strip(f"REPLACE {keyword} ")
+                    )
                     for key, value in replacement.items():
                         description = description.replace(key, value)
                 description = description.replace("``", "`").replace("''", "`")

--- a/utils/gen_from_dfn.py
+++ b/utils/gen_from_dfn.py
@@ -196,7 +196,15 @@ if __name__ == "__main__":
                         description = description.replace(key, value)
                 hover[section.keyword][section.block][dfn.extension] = description
 
+    # Sort hover before exporting
+    sorted_hover = {
+        key: {
+            subkey: dict(sorted(subval.items()))
+            for subkey, subval in sorted(val.items())
+        }
+        for key, val in sorted(hover.items())
+    }
     with open("src/providers/hover.json", "w") as f:
-        json.dump(hover, f, indent=2)
+        json.dump(sorted_hover, f, indent=2)
         f.write("\n")
     print("src/providers/hover.json has been generated")

--- a/utils/gen_from_dfn.py
+++ b/utils/gen_from_dfn.py
@@ -194,7 +194,7 @@ if __name__ == "__main__":
                     replacement = eval(section.description.strip(f"REPLACE {keyword} "))
                     for key, value in replacement.items():
                         description = description.replace(key, value)
-                hover[section.keyword][section.block][dfn.extension] = description
+                hover[section.keyword][section.block][dfn.path.stem] = description
 
     # Sort hover before exporting
     sorted_hover = {

--- a/utils/gen_from_dfn.py
+++ b/utils/gen_from_dfn.py
@@ -9,7 +9,8 @@
 This script parses MODFLOW 6 definition (dfn) files and extracts metadata for each block
 and keyword. It defines classes to represent lines, groups of lines, and the entire dfn
 file, and provides methods to parse and access this data in order to generate
-configuration files for the syntax highlighting feature.
+configuration files for the syntax highlighting feature. Moreover, it extracts hover
+data from the dfn files and exports it to a JSON file.
 
 Classes:
     Line: Represents a single line in a dfn file.
@@ -18,8 +19,8 @@ Classes:
 
 Usage:
     The script can be run to parse dfn files in the 'data/dfn' (downloaded from mf6
-    github repo) directory and preprocess the data to generate 'package.json' and
-    'syntaxes/mf6.tmLanguage.json' files.
+    github repo) directory and preprocess the data to generate 'package.json',
+    'syntaxes/mf6.tmLanguage.json' and 'src/providers/hover.json' files.
 """
 
 import json


### PR DESCRIPTION
This PR adds hover feature which shows description of keywords based on MF6 DFN files.

If a keyword is available in different blocks (which may have different descriptions), the corresponding block where the description is taken from is inferred based on the enclosing block. 

If a keyword-block pair is available in different DFN's (which may have different descriptions), the corresponding DFN where the description is taken from is inferred based on the filename extension.

If no single description can be inferred (0 or more than 1), a list of different descriptions are provided with the corresponding DFNs.