### PR TITLE
Increase default file size limit in go-to-def

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,4 +33,5 @@ This VS Code extension provides syntax highlighting support and rich language fe
 ## Usage
 
 - The extension activates based on the file's extension. If not detected, use `MF6 Syntax: Set language to MF6`. Alternatively, use the `Change Language Mode` command to set the language manually.
+- To avoid performance issues when opening huge files, a maximum file size that can be opened through the go-to-definition feature is set with the setting: `mf6Syntax.maxFileSizeMB` (default 50MB).
 - VS Code's minimap can display enlarged section headers (MF6 block names), which may appear cluttered. To simplify the view, disable this feature by setting `editor.minimap.showRegionSectionHeaders` to `false`.

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
       "properties": {
         "mf6Syntax.maxFileSizeMB": {
           "type": "number",
-          "default": 4,
+          "default": 50,
           "description": "The maximum file size (in MB) that can be opened through the extension."
         }
       }

--- a/src/providers/go-to-definition.ts
+++ b/src/providers/go-to-definition.ts
@@ -26,7 +26,7 @@ export class MF6DefinitionProvider implements vscode.DefinitionProvider {
     const fileStats = await fs.stat(fileUri.fsPath);
     if (fileStats.size > maxFileSizeBytes) {
       vscode.window.showWarningMessage(
-        `File ${word} is too large to open through the extension (over ${maxFileSizeMB}MB).`,
+        `File ${word} exceeds size limit (${maxFileSizeMB}MB).\nSee setting 'mf6Syntax.maxFileSizeMB' to adjust.`,
       );
       return null;
     }

--- a/src/providers/go-to-definition.ts
+++ b/src/providers/go-to-definition.ts
@@ -20,7 +20,7 @@ export class MF6DefinitionProvider implements vscode.DefinitionProvider {
     }
 
     const config = vscode.workspace.getConfiguration("mf6Syntax");
-    const maxFileSizeMB = config.get<number>("maxFileSizeMB", 4); // Default to 4MB
+    const maxFileSizeMB = config.get<number>("maxFileSizeMB", 50); // Default to 50MB
     const maxFileSizeBytes = maxFileSizeMB * 1024 * 1024;
 
     const fileStats = await fs.stat(fileUri.fsPath);

--- a/templates/package.json.j2
+++ b/templates/package.json.j2
@@ -46,7 +46,7 @@
       "properties": {
         "mf6Syntax.maxFileSizeMB": {
           "type": "number",
-          "default": 4,
+          "default": 50,
           "description": "The maximum file size (in MB) that can be opened through the extension."
         }
       }


### PR DESCRIPTION
This PR increases the maximum file size that can be opened with the go-to-definition feature from 4MB to 50MB.

Previously, in https://github.com/martclanor/vscode-mf6-syntax/pull/64, a conservative 4MB default limit was set to avoid performance issues observed when opening larger files. Further testing revealed that these performance issues were primarily related to interactions with the `todo-tree` extension (see issue 882 of todo-tree extension repo).