### PR TITLE
Downgrade @types/vscode to match engine.vscode

### DIFF
--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
   "devDependencies": {
     "@eslint/js": "^9.25.0",
     "@types/node": "^22.13.5",
-    "@types/vscode": "^1.99.1",
+    "@types/vscode": "^1.96.0",
     "@vscode/test-cli": "^0.0.10",
     "@vscode/test-electron": "^2.5.2",
     "@vscode/vsce": "^3.3.2",

--- a/templates/package.json.j2
+++ b/templates/package.json.j2
@@ -87,7 +87,7 @@
   "devDependencies": {
     "@eslint/js": "^9.25.0",
     "@types/node": "^22.13.5",
-    "@types/vscode": "^1.99.1",
+    "@types/vscode": "^1.96.0",
     "@vscode/test-cli": "^0.0.10",
     "@vscode/test-electron": "^2.5.2",
     "@vscode/vsce": "^3.3.2",


### PR DESCRIPTION
For the meantime, this is preferred over upgrading engine.vscode in package.json for wider extension compatibility.