### PR TITLE
Add go-to-parent command

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,11 @@
         "command": "mf6-syntax.mf6-ify",
         "title": "Set language to MF6",
         "category": "MF6 Syntax"
+      },
+      {
+        "command": "mf6-syntax.goToParent",
+        "title": "Go to Parent File",
+        "category": "MF6 Syntax"
       }
     ],
     "configuration": {

--- a/src/commands/go-to-parent.ts
+++ b/src/commands/go-to-parent.ts
@@ -1,0 +1,36 @@
+import * as vscode from "vscode";
+import * as path from "path";
+
+export async function goToParent() {
+  if (vscode.window.activeTextEditor) {
+    const fileUri = vscode.window.activeTextEditor.document.uri;
+    const fileName = path.basename(fileUri.fsPath);
+    if (fileName === "mfsim.nam") {
+      vscode.window.showInformationMessage(
+        "mfsim.nam is already the top-level file.",
+      );
+      return null;
+    }
+    const dirUri = vscode.Uri.joinPath(fileUri, "..");
+    const filesInDir = await vscode.workspace.fs.readDirectory(dirUri);
+
+    for (const [name, type] of filesInDir) {
+      if (type === vscode.FileType.File && name !== fileName) {
+        const otherFileUri = vscode.Uri.joinPath(dirUri, name);
+        const contentBytes = await vscode.workspace.fs.readFile(otherFileUri);
+        const content = Buffer.from(contentBytes).toString("utf-8");
+
+        if (content.includes(fileName)) {
+          const parentDocument =
+            await vscode.workspace.openTextDocument(otherFileUri);
+          await vscode.window.showTextDocument(parentDocument);
+          return null;
+        }
+      }
+    }
+
+    vscode.window.showInformationMessage(
+      `No parent file found for ${fileName}`,
+    );
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 import { MF6DefinitionProvider } from "./providers/go-to-definition";
 import { MF6HoverKeywordProvider } from "./providers/hover";
 import { MF6HoverBlockProvider } from "./providers/hover";
+import { goToParent } from "./commands/go-to-parent";
 import { mf6ify } from "./commands/mf6-ify";
 
 const MF6 = { language: "mf6", scheme: "file" };
@@ -11,6 +12,13 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand("mf6-syntax.mf6-ify", async () => {
       await mf6ify();
+    }),
+  );
+
+  // go-to-parent command
+  context.subscriptions.push(
+    vscode.commands.registerCommand("mf6-syntax.goToParent", async () => {
+      await goToParent();
     }),
   );
 

--- a/templates/package.json.j2
+++ b/templates/package.json.j2
@@ -41,6 +41,11 @@
         "command": "mf6-syntax.mf6-ify",
         "title": "Set language to MF6",
         "category": "MF6 Syntax"
+      },
+      {
+        "command": "mf6-syntax.goToParent",
+        "title": "Go to Parent File",
+        "category": "MF6 Syntax"
       }
     ],
     "configuration": {


### PR DESCRIPTION
This PR adds the command `mf6-syntax.goToParent` which opens the parent file of the current (child) file. The logic is based on the reference of the child's filename within the parent file. 

- if `freyberg.dis` file is active, then open `freyberg.nam` file
- if `freyberg.nam` file is active, then open `mfsim.nam` file
- if `mfsim.nam` file is active, no-op since it is the top-level file

TODO's:

- [ ] find solution for (or ignore) the case when parent and child files are in separate directories
- [ ] optimize by reading files from smallest file size to largest
- [ ] optional: ignore binary files
- [ ] optoinal: considering checking file extension to filter potential parent files
- [ ] add tests