### PR TITLE
chore(ruff): update ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
         args: ["--branch", "main"]
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.6
+    rev: v0.15.0
     hooks:
       - id: ruff
         name: ruff check

--- a/utils/gen_from_dfn.py
+++ b/utils/gen_from_dfn.py
@@ -435,8 +435,10 @@ class Dfn:
             }
             # Exclude dev_options and sections that are handled in the inner loop
             for section in dfn.get_sections(
-                lambda s: not s.is_dev_option
-                and (not s.in_record or s.block_variable or s.is_rec)
+                lambda s: (
+                    not s.is_dev_option
+                    and (not s.in_record or s.block_variable or s.is_rec)
+                )
             ):
                 if not hover[section.block][dfn.name]:
                     hover[section.block][dfn.name] = section.get_block_begin()


### PR DESCRIPTION
CI from https://github.com/martclanor/vscode-mf6-syntax/pull/193 revealed that the ruff in the pre-commit tool is outdated.