### PR TITLE
chore(ci): commit on mf6-versions.txt before draft PR

### DIFF
--- a/.github/workflows/update-on-mf6-release.yml
+++ b/.github/workflows/update-on-mf6-release.yml
@@ -57,16 +57,24 @@ jobs:
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Add new version to mf6-versions.txt
+        if: steps.check_version.outputs.exists == 'false' && steps.check_branch.outputs.exists == 'false'
+        run: |
+          echo "${{ steps.get_latest_release.outputs.latest_tag }}" >> mf6-versions.txt
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b $BRANCH_NAME
+          git add .
+          git commit -m "Add support for MODFLOW 6 version ${{ steps.get_latest_release.outputs.latest_tag }}"
+          git push
+          git push --set-upstream origin $BRANCH_NAME
+
       - name: Create Draft Pull Request
         if: steps.check_version.outputs.exists == 'false' && steps.check_branch.outputs.exists == 'false'
         id: create_pr
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          BRANCH_NAME="update-modflow6-${{ steps.get_latest_release.outputs.latest_tag }}"
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git checkout -b $BRANCH_NAME
           git push --set-upstream origin $BRANCH_NAME
           PR_URL=$(gh pr create \
             --title "chore(mf6): add support for MODFLOW ${{ steps.get_latest_release.outputs.latest_tag }}" \
@@ -86,8 +94,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git checkout ${{ steps.create_pr.outputs.branch_name }}
-          echo "${{ steps.get_latest_release.outputs.latest_tag }}" >> mf6-versions.txt
           ./utils/download-dfn.sh
           if uv run python utils/gen_from_dfn.py; then
             echo "gen_from_dfn=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This ensures that there is a commit in the PR even if the `update_files` step would fail.